### PR TITLE
LIFFログインを実装

### DIFF
--- a/src/app/components/elements/LoginModal.tsx
+++ b/src/app/components/elements/LoginModal.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/app/components/ui/dialog";
 import { Button } from "@/app/components/ui/button";
-import { signInWithLine } from "@/lib/firebase";
+import { useAuth } from "@/contexts/AuthContext";
 
 type LoginModalProps = {
   isOpen: boolean;
@@ -13,13 +13,20 @@ type LoginModalProps = {
 const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { loginWithLiff, isAuthenticating } = useAuth();
 
   const handleLogin = async () => {
     setIsLoading(true);
     setError(null);
-    await signInWithLine();
-    setIsLoading(false);
-    onClose();
+
+    try {
+      await loginWithLiff();
+      setIsLoading(false);
+      onClose();
+    } catch (err) {
+      setError("ログインに失敗しました");
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -29,8 +36,12 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
           <DialogTitle>ログイン</DialogTitle>
         </DialogHeader>
         <div className="flex flex-col items-center mt-4">
-          <Button onClick={handleLogin} disabled={isLoading}>
-            {isLoading ? "ログイン中..." : "LINEでログイン"}
+          <Button
+            onClick={handleLogin}
+            disabled={isLoading || isAuthenticating}
+            className="bg-[#06C755] hover:bg-[#05B74B] text-white"
+          >
+            {isLoading || isAuthenticating ? "ログイン中..." : "LINEでログイン"}
           </Button>
           {error && <div className="text-red-500 text-sm mt-2">{error}</div>}
         </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import ApolloProvider from "@/app/components/providers/ApolloProvider";
 import { Toaster } from "@/app/components/ui/sonner";
 import LoadingProvider from "@/app/components/providers/LoadingProvider";
 import Header from "@/app/components/layout/Header";
+import { LiffProvider } from "@/contexts/LiffContext";
 import { AuthProvider } from "@/contexts/AuthContext";
 
 const font = Inter({ subsets: ["latin"] });
@@ -25,13 +26,15 @@ const RootLayout = ({
       <body className={font.className}>
         <CookiesProvider>
           <ApolloProvider>
-            <AuthProvider>
-              <LoadingProvider>
-                <Header />
-                <main className="flex-grow pt-16">{children}</main>
-                <Toaster richColors className="mx-8" />
-              </LoadingProvider>
-            </AuthProvider>
+            <LiffProvider>
+              <AuthProvider>
+                <LoadingProvider>
+                  <Header />
+                  <main className="flex-grow pt-16">{children}</main>
+                  <Toaster richColors className="mx-8" />
+                </LoadingProvider>
+              </AuthProvider>
+            </LiffProvider>
           </ApolloProvider>
         </CookiesProvider>
       </body>

--- a/src/contexts/LiffContext.tsx
+++ b/src/contexts/LiffContext.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import liff from '@line/liff';
+
+type LiffProfile = {
+  userId: string;
+  displayName: string;
+  pictureUrl?: string;
+};
+
+type LiffContextType = {
+  liff: typeof liff | null;
+  isInLiff: boolean;
+  isLiffLoggedIn: boolean;
+  liffError: string | null;
+  liffProfile: LiffProfile | null;
+  liffIdToken: string | null;
+  liffAccessToken: string | null;
+  liffInit: () => Promise<void>;
+  liffLogin: () => void;
+  liffLogout: () => void;
+};
+
+const LiffContext = createContext<LiffContextType | undefined>(undefined);
+
+type LiffProviderProps = {
+  children: ReactNode;
+};
+
+export const LiffProvider = ({ children }: LiffProviderProps) => {
+  const liffId = process.env.NEXT_PUBLIC_LIFF_ID || '';
+  const [isLiffInitialized, setIsLiffInitialized] = useState<boolean>(false);
+  const [isInLiff, setIsInLiff] = useState<boolean>(false);
+  const [isLiffLoggedIn, setIsLiffLoggedIn] = useState<boolean>(false);
+  const [liffError, setLiffError] = useState<string | null>(null);
+  const [liffProfile, setLiffProfile] = useState<LiffProfile | null>(null);
+  const [liffIdToken, setLiffIdToken] = useState<string | null>(null);
+  const [liffAccessToken, setLiffAccessToken] = useState<string | null>(null);
+
+  const liffInit = async () => {
+    try {
+      await liff.init({ liffId });
+      setIsLiffInitialized(true);
+      
+      setIsInLiff(liff.isInClient());
+      setIsLiffLoggedIn(liff.isLoggedIn());
+      
+      if (liff.isLoggedIn()) {
+        await updateLiffProfile();
+        updateLiffTokens();
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      setLiffError(errorMessage);
+      console.error('LIFF initialization failed:', error);
+    }
+  };
+
+  const updateLiffTokens = () => {
+    try {
+      const accessToken = liff.getAccessToken();
+      setLiffAccessToken(accessToken);
+      
+      const idToken = liff.getIDToken();
+      setLiffIdToken(idToken);
+      
+      console.log("🔥 accessToken", accessToken);
+    } catch (error) {
+      console.error('Failed to get LIFF tokens:', error);
+    }
+  };
+
+  const updateLiffProfile = async () => {
+    try {
+      const profile = await liff.getProfile();
+      setLiffProfile({
+        userId: profile.userId,
+        displayName: profile.displayName,
+        pictureUrl: profile.pictureUrl
+      });
+    } catch (error) {
+      console.error('Failed to get LIFF profile:', error);
+    }
+  };
+
+  const liffLogin = () => {
+    if (!isLiffInitialized) {
+      liffInit().then(() => {
+        liff.login({ redirectUri: window.location.href });
+      });
+      return;
+    }
+    
+    liff.login({ redirectUri: window.location.href });
+  };
+
+  const liffLogout = () => {
+    if (liff.isLoggedIn()) {
+      liff.logout();
+      setIsLiffLoggedIn(false);
+      setLiffProfile(null);
+      setLiffIdToken(null);
+      setLiffAccessToken(null);
+    }
+  };
+
+  useEffect(() => {
+    liffInit().catch(console.error);
+  }, [liffId]);
+
+  useEffect(() => {
+    if (isLiffInitialized && liff.isLoggedIn() && !liffProfile) {
+      updateLiffProfile();
+      updateLiffTokens();
+      setIsLiffLoggedIn(true);
+    }
+  }, [isLiffInitialized, liffProfile]);
+
+  return (
+    <LiffContext.Provider
+      value={{
+        liff: isLiffInitialized ? liff : null,
+        isInLiff,
+        isLiffLoggedIn,
+        liffError,
+        liffProfile,
+        liffIdToken,
+        liffAccessToken,
+        liffInit,
+        liffLogin,
+        liffLogout
+      }}
+    >
+      {children}
+    </LiffContext.Provider>
+  );
+};
+
+export const useLiff = () => {
+  const context = useContext(LiffContext);
+  if (context === undefined) {
+    throw new Error("useLiff must be used within a LiffProvider");
+  }
+  return context;
+};

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -4,6 +4,7 @@ import {
   getAuth,
   OAuthProvider,
   signInWithPopup,
+  signInWithCustomToken,
 } from "@firebase/auth";
 
 export const app = initializeApp({
@@ -33,4 +34,28 @@ export const signInWithLine = async () => {
 
 export const signInWithFacebook = async () => {
   return signIn("facebook");
+};
+
+export const signInWithLiffToken = async (accessToken: string): Promise<boolean> => {
+  try {
+    const response = await fetch("https://localhost:3000/line/liff-login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ accessToken }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`LIFF authentication failed: ${response.status}`);
+    }
+
+    const { customToken } = await response.json();
+    
+    console.log("👏 customToken", customToken);
+    
+    await signInWithCustomToken(auth, customToken);
+    return true;
+  } catch (error) {
+    console.error("Authentication with LIFF token failed:", error);
+    return false;
+  }
 };

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -38,7 +38,7 @@ export const signInWithFacebook = async () => {
 
 export const signInWithLiffToken = async (accessToken: string): Promise<boolean> => {
   try {
-    const response = await fetch("https://localhost:3000/line/liff-login", {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT}/line/liff-login`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ accessToken }),


### PR DESCRIPTION
対応issue: #14 

### 実装内容
- LINEでログイン ボタンからLIFFフレームワークを使ったログインを実装

### 処理の流れ
1. liffログイン
2. LIFFからリダイレクトされ、取得できるようになる accessToken をAPI側に送付
3. Firebase AuthのcustomTokenを受け取り、auth.signInWithCustomToken

### 追記
.envに以下を追加

```NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT =https://localhost:3000```