### PR TITLE
style: Fine-tune activity carousel and navigation buttons on `/activities/[id]`

### DIFF
--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -9,8 +9,7 @@ import { useEffect, useMemo } from "react";
 import { useLoading } from "@/hooks/core/useLoading";
 import { useHeaderConfig } from "@/hooks/core/useHeaderConfig";
 import { useHierarchicalNavigation } from "@/hooks/core/useHierarchicalNavigation";
-import { ChevronLeft } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import ActivityNavigationButtons from "@/components/features/activity/ActivityNavigationButtons";
 
 interface ActivityPageProps {
   params: {
@@ -51,17 +50,10 @@ export default function ActivityPage({ params, searchParams }: ActivityPageProps
 
   return (
     <>
-      <div className="fixed top-4 left-4 z-50">
-        <Button
-          onClick={navigateBack}
-          variant="secondary"
-          size="icon"
-          className="rounded-full shadow-md"
-          aria-label="戻る"
-        >
-          <ChevronLeft className="h-5 w-5" />
-        </Button>
-      </div>
+      <ActivityNavigationButtons 
+        title={opportunity.title} 
+        onBack={navigateBack} 
+      />
 
       <main className="min-h-screen pb-24">
         <div className="max-w-7xl mx-auto px-4">

--- a/src/components/features/activity/ActivityDetailsHeader.tsx
+++ b/src/components/features/activity/ActivityDetailsHeader.tsx
@@ -69,7 +69,7 @@ const ActivityDetailsHeader: React.FC<ActivityDetailsHeaderProps> = ({
 
   return (
     <div className="relative w-full bg-background rounded-b-3xl shadow-md pb-6 max-w-mobile-l mx-auto">
-      <div className="relative w-full h-[480px] rounded-xl overflow-hidden mb-8">
+      <div className="relative h-[480px] overflow-hidden mb-8 mx-[-1rem] sm:mx-[-1.5rem] md:mx-[-2rem]">
         <div
           className="embla h-full relative"
           ref={emblaRef}
@@ -93,8 +93,8 @@ const ActivityDetailsHeader: React.FC<ActivityDetailsHeaderProps> = ({
           </div>
 
           {/* 左右のクリック領域 */}
-          <div className="absolute left-0 top-0 h-full w-[30%] cursor-w-resize z-[1] hover:bg-gradient-to-r hover:from-black/10 hover:to-transparent" />
-          <div className="absolute right-0 top-0 h-full w-[30%] cursor-e-resize z-[1] hover:bg-gradient-to-l hover:from-black/10 hover:to-transparent" />
+          <div className="absolute left-0 top-0 h-full w-[30%] cursor-pointer z-[1] hover:bg-gradient-to-r hover:from-black/10 hover:to-transparent" />
+          <div className="absolute right-0 top-0 h-full w-[30%] cursor-pointer z-[1] hover:bg-gradient-to-l hover:from-black/10 hover:to-transparent" />
         </div>
 
         <div className="absolute bottom-4 left-0 right-0 flex justify-center gap-1 z-10">

--- a/src/components/features/activity/ActivityNavigationButtons.tsx
+++ b/src/components/features/activity/ActivityNavigationButtons.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React from 'react';
+import { ArrowLeft, Share2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface ActivityNavigationButtonsProps {
+  title: string;
+  onBack: () => void;
+}
+
+const ActivityNavigationButtons: React.FC<ActivityNavigationButtonsProps> = ({
+  title,
+  onBack
+}) => {
+  const handleShare = () => {
+     if (navigator.share) {
+       navigator
+         .share({
+           title: title,
+           url: window.location.href,
+         })
+         .catch((err) => console.error("共有に失敗しました", err));
+     }
+  }
+
+  return (
+    <>
+      <div className="absolute top-4 left-4 z-50">
+        <Button
+          onClick={onBack}
+          variant="tertiary"
+          size="icon"
+          className="rounded-full bg-white/90 shadow-md h-14 w-14 border border-input"
+          aria-label="戻る"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+      </div>
+      <div className="absolute top-6 right-4 z-50">
+        <Button onClick={handleShare} variant="icon-only" size="icon" aria-label="シェア">
+          <Share2 className="h-5 w-5 text-white" />
+        </Button>
+      </div>
+    </>
+  );
+};
+
+export default ActivityNavigationButtons;


### PR DESCRIPTION
## Before
![image](https://github.com/user-attachments/assets/a228ede6-e569-4898-9c0c-c844bdbf4c0d)

## After
![image](https://github.com/user-attachments/assets/06906bd4-d43e-47f6-ac90-148ff9591cdc)


Please refer to the gemini-code-assist comments below for detailed changes.