### PR TITLE
Refactor search header logic into a custom hook

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -52,62 +52,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "AlreadyJoinedError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "AlreadyUsedClaimLinkError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "Article",
         "description": null,
         "isOneOf": null,
@@ -925,62 +869,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "AuthenticationError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "AuthorizationError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "SCALAR",
         "name": "Boolean",
         "description": "The `Boolean` scalar type represents `true` or `false`.",
@@ -1137,34 +1025,6 @@
               "kind": "OBJECT",
               "name": "State",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "ClaimLinkExpiredError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2135,34 +1995,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "DatabaseError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "SCALAR",
         "name": "DateTime",
         "description": null,
@@ -2378,6 +2210,212 @@
             "ofType": null
           }
         ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Error",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "code",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ErrorCode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ErrorCode",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ALREADY_EVALUATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ALREADY_JOINED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ALREADY_STARTED_RESERVATION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ALREADY_USED_CLAIM_LINK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CANNOT_EVALUATE_BEFORE_OPPORTUNITY_START",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CLAIM_LINK_EXPIRED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FORBIDDEN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INSUFFICIENT_BALANCE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INTERNAL_SERVER_ERROR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INVALID_TRANSFER_METHOD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MISSING_WALLET_INFORMATION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NOT_FOUND",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NO_AVAILABLE_PARTICIPATION_SLOTS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PERSONAL_RECORD_ONLY_DELETABLE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RATE_LIMIT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RESERVATION_ADVANCE_BOOKING_REQUIRED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RESERVATION_CANCELLATION_TIMEOUT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RESERVATION_FULL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RESERVATION_NOT_ACCEPTED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SLOT_NOT_SCHEDULED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TICKET_PARTICIPANT_MISMATCH",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNAUTHENTICATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNKNOWN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNSUPPORTED_TRANSACTION_REASON",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "VALIDATION_ERROR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
       },
       {
         "kind": "OBJECT",
@@ -4730,34 +4768,6 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "MissingTicketIdsError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
                 "ofType": null
               }
             },
@@ -7195,34 +7205,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "NoAvailableParticipationSlotsError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "OpportunitiesConnection",
         "description": null,
         "isOneOf": null,
@@ -8662,18 +8644,6 @@
         "isOneOf": false,
         "fields": null,
         "inputFields": [
-          {
-            "name": "dateRange",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "DateTimeRangeFilter",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
           {
             "name": "hostingStatus",
             "description": null,
@@ -13724,34 +13694,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "RateLimitError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "Reservation",
         "description": null,
         "isOneOf": null,
@@ -13883,34 +13825,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "ReservationAdvanceBookingRequiredError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "INPUT_OBJECT",
         "name": "ReservationCancelInput",
         "description": null,
@@ -13955,34 +13869,6 @@
           }
         ],
         "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "ReservationCancellationTimeoutError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -14098,37 +13984,7 @@
         "possibleTypes": [
           {
             "kind": "OBJECT",
-            "name": "MissingTicketIdsError",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "ReservationAdvanceBookingRequiredError",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
             "name": "ReservationCreateSuccess",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "ReservationFullError",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "ReservationNotAcceptedError",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "SlotNotScheduledError",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "TicketParticipantMismatchError",
             "ofType": null
           }
         ]
@@ -14239,6 +14095,18 @@
             "deprecationReason": null
           },
           {
+            "name": "opportunityOwnerId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "opportunitySlotId",
             "description": null,
             "type": {
@@ -14264,66 +14132,6 @@
           }
         ],
         "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "ReservationFullError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "capacity",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "requested",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -14598,34 +14406,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "ReservationNotAcceptedError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "ENUM",
         "name": "ReservationPaymentMethod",
         "description": null,
@@ -14659,21 +14439,6 @@
         "interfaces": null,
         "enumValues": null,
         "possibleTypes": [
-          {
-            "kind": "OBJECT",
-            "name": "AlreadyJoinedError",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "NoAvailableParticipationSlotsError",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "ReservationCancellationTimeoutError",
-            "ofType": null
-          },
           {
             "kind": "OBJECT",
             "name": "ReservationSetStatusSuccess",
@@ -14877,34 +14642,6 @@
             "deprecationReason": null
           }
         ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "SlotNotScheduledError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -15462,16 +15199,6 @@
         "possibleTypes": [
           {
             "kind": "OBJECT",
-            "name": "AlreadyUsedClaimLinkError",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "ClaimLinkExpiredError",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
             "name": "TicketClaimSuccess",
             "ofType": null
           }
@@ -15934,66 +15661,6 @@
           },
           {
             "name": "totalCount",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "TicketParticipantMismatchError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "participantCount",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ticketCount",
             "description": null,
             "args": [],
             "type": {
@@ -19320,34 +18987,6 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "Utility",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "ValidationError",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
                 "ofType": null
               }
             },

--- a/src/app/participations/[id]/page.tsx
+++ b/src/app/participations/[id]/page.tsx
@@ -8,11 +8,12 @@ import useHeaderConfig from "@/hooks/useHeaderConfig";
 import ParticipationStatusNotification from "@/app/participations/[id]/components/ParticipationStatusNotification";
 import ParticipationDetails from "@/app/participations/[id]/components/ParticipationDetails";
 import ParticipationActions from "@/app/participations/[id]/components/ParticipationActions";
-import { useCancelReservation } from "@/app/participations/[id]/hooks/useCancelReservation";
 import { toast } from "sonner";
 import { GqlReservationStatus } from "@/types/graphql";
 import OpportunityCardHorizontal from "@/app/activities/components/Card/CardHorizontal";
 import { useParams } from "next/navigation";
+import { errorMessages } from "@/utils/errorMessage";
+import useCancelReservation from "@/app/participations/[id]/hooks/useCancelReservation";
 
 export type ParticipationUIStatus = "pending" | "confirmed" | "cancelled";
 
@@ -72,12 +73,9 @@ export default function ParticipationPage() {
       if (refetchRef.current) {
         refetchRef.current();
       }
-    }else if (result.typename === "ReservationCancellationTimeoutError") {
-      toast.error("予約のキャンセルは24時間前まで可能です。");
-    }
-    else {
-      toast.error(`予約のキャンセルに失敗しました。`);
-      console.error("Cancel reservation failed:", result.error);
+    } else {
+      const message = errorMessages[result.code] ?? "予期しないエラーが発生しました。";
+      toast.error(message);
     }
   };
 

--- a/src/app/reservation/confirm/page.tsx
+++ b/src/app/reservation/confirm/page.tsx
@@ -16,10 +16,11 @@ import { useEffect, useMemo, useRef } from "react";
 import useHeaderConfig from "@/hooks/useHeaderConfig";
 import { toast } from "sonner";
 import { useReservationUIState } from "@/app/reservation/confirm/hooks/useReservationUIState";
-import { useReservationCommand } from "@/app/reservation/confirm/hooks/useReservationAction";
 import LoadingIndicator from "@/components/shared/LoadingIndicator";
 import ErrorState from "@/components/shared/ErrorState";
 import { ParticipationAge } from "./components/ParticipationAge";
+import { errorMessages } from "@/utils/errorMessage";
+import { useReservationCommand } from "@/app/reservation/confirm/hooks/useReservationAction";
 
 export default function ConfirmPage() {
   const headerConfig: HeaderConfig = useMemo(
@@ -77,29 +78,9 @@ export default function ConfirmPage() {
       if (!user) {
         ui.setIsLoginModalOpen(true);
       } else {
-        switch (result.typename) {
-          case "ReservationFullError":
-            toast.error("予約枠が満員です。別の日時をお試しください。");
-            break;
-          case "ReservationAdvanceBookingRequiredError":
-            toast.error("開始日から7日以上前に申し込みが必要です。");
-            break;
-          case "ReservationNotAcceptedError":
-            toast.error("予約が承認されていません。");
-            break;
-          case "SlotNotScheduledError":
-            toast.error("予約枠は開催を予定されていません。");
-            break;
-          case "TicketParticipantMismatchError":
-            toast.error(`チケット数と参加者数が一致しません。`);
-            break;
-          case "MissingTicketIdsError":
-            toast.error("チケットが指定されていません。");
-            break;
-          default:
-            toast.error(`申し込みに失敗しました。: ${result.error}`);
-        }
-        console.error("Reservation failed:", result.error);
+        const message = errorMessages[result.code] ?? "予期しないエラーが発生しました。";
+        toast.error(message);
+        console.error("Reservation failed:", result.code);
       }
       return;
     }

--- a/src/app/search/result/components/SearchResultHeader.tsx
+++ b/src/app/search/result/components/SearchResultHeader.tsx
@@ -1,30 +1,35 @@
-'use client';
+import { useEffect, useState } from "react";
+import { useHeader } from "@/components/providers/HeaderProvider";
+import { SearchParams } from "@/app/search/data/presenter";
 
-import React from 'react';
-import Link from 'next/link';
-import { ArrowLeft, Share, X } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+const useSearchResultHeader = (searchParams: SearchParams) => {
+  const { updateConfig } = useHeader();
 
-/**
- * Header component for the search results page
- */
-const SearchResultHeader: React.FC = () => {
-  return (
-    <header className="fixed top-0 left-0 right-0 z-50 bg-background border-b max-w-mobile-l mx-auto w-full h-14 flex items-center px-4">
-      <Link href="/search" className="absolute left-4">
-        <ArrowLeft className="h-6 w-6" />
-      </Link>
-      <h1 className="flex-1 text-center text-lg font-medium truncate">検索結果</h1>
-      <div className="absolute right-4 flex items-center space-x-4">
-        <Button variant="link">
-          <Share className="h-6 w-6" />
-        </Button>
-        <Link href="/public">
-          <X className="h-6 w-6" />
-        </Link>
-      </div>
-    </header>
-  );
+  const [previousSearchParams, setPreviousSearchParams] = useState<SearchParams | null>(null);
+
+  useEffect(() => {
+    if (
+      previousSearchParams === null ||
+      previousSearchParams.location !== searchParams.location ||
+      previousSearchParams.from !== searchParams.from ||
+      previousSearchParams.to !== searchParams.to ||
+      previousSearchParams.guests !== searchParams.guests
+    ) {
+      updateConfig({
+        showSearchForm: true,
+        searchParams: {
+          location: searchParams.location,
+          from: searchParams.from,
+          to: searchParams.to,
+          guests: searchParams.guests ? parseInt(searchParams.guests) : undefined,
+        },
+        showLogo: false,
+        showBackButton: true,
+      });
+
+      setPreviousSearchParams(searchParams);
+    }
+  }, [searchParams, updateConfig, previousSearchParams]);
 };
 
-export default SearchResultHeader;
+export default useSearchResultHeader;

--- a/src/app/search/result/components/SearchResultHeader.tsx
+++ b/src/app/search/result/components/SearchResultHeader.tsx
@@ -21,7 +21,7 @@ const useSearchResultHeader = (searchParams: SearchParams) => {
           location: searchParams.location,
           from: searchParams.from,
           to: searchParams.to,
-          guests: searchParams.guests ? parseInt(searchParams.guests) : undefined,
+          guests: searchParams.guests && !isNaN(parseInt(searchParams.guests, 10)) ? parseInt(searchParams.guests, 10) : undefined,
         },
         showLogo: false,
         showBackButton: true,

--- a/src/app/search/result/page.tsx
+++ b/src/app/search/result/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { useSearchResults } from "@/app/search/result/hooks/useSearchResults";
 import DateGroupedOpportunities from "@/app/search/result/components/DateGroupedOpportunities";
 import EmptySearchResults from "@/app/search/result/components/EmptySearchResults";
@@ -8,19 +8,24 @@ import LoadingIndicator from "@/components/shared/LoadingIndicator";
 import ActivitiesCarouselSection from "@/app/activities/components/CarouselSection/CarouselSection";
 import ErrorState from "@/components/shared/ErrorState";
 import { useSearchParams } from "next/navigation";
+import useSearchResultHeader from "@/app/search/result/components/SearchResultHeader";
 
 export default function SearchResultPage() {
   const searchParams = useSearchParams();
 
-  const queryParams = {
-    location: searchParams.get("location") ?? undefined,
-    from: searchParams.get("from") ?? undefined,
-    to: searchParams.get("to") ?? undefined,
-    guests: searchParams.get("guests") ?? undefined,
-    type: searchParams.get("type") as "activity" | "quest" | undefined,
-    ticket: searchParams.get("ticket") ?? undefined,
-    q: searchParams.get("q") ?? undefined,
-  };
+  const queryParams = useMemo(
+    () => ({
+      location: searchParams.get("location") ?? undefined,
+      from: searchParams.get("from") ?? undefined,
+      to: searchParams.get("to") ?? undefined,
+      guests: searchParams.get("guests") ?? undefined,
+      type: searchParams.get("type") as "activity" | "quest" | undefined,
+      ticket: searchParams.get("ticket") ?? undefined,
+      q: searchParams.get("q") ?? undefined,
+    }),
+    [searchParams],
+  );
+  useSearchResultHeader(queryParams);
 
   const { recommendedOpportunities, groupedOpportunities, loading, error, refetch } =
     useSearchResults(queryParams);

--- a/src/graphql/experience/reservation/mutation.ts
+++ b/src/graphql/experience/reservation/mutation.ts
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client';
+import { gql } from "@apollo/client";
 
 export const CREATE_RESERVATION = gql`
   mutation CreateReservation($input: ReservationCreateInput!) {
@@ -7,34 +7,6 @@ export const CREATE_RESERVATION = gql`
         reservation {
           ...ReservationFields
         }
-      }
-      ... on ReservationFullError {
-        __typename
-        message
-        capacity
-        requested
-      }
-      ... on ReservationAdvanceBookingRequiredError {
-        __typename
-        message
-      }
-      ... on ReservationNotAcceptedError {
-        __typename
-        message
-      }
-      ... on SlotNotScheduledError {
-        __typename
-        message
-      }
-      ... on MissingTicketIdsError {
-        __typename
-        message
-      }
-      ... on TicketParticipantMismatchError {
-        __typename
-        message
-        ticketCount
-        participantCount
       }
     }
   }
@@ -51,9 +23,6 @@ export const CANCEL_RESERVATION = gql`
         reservation {
           ...ReservationFields
         }
-      }
-      ... on ReservationCancellationTimeoutError {
-        message
       }
     }
   }

--- a/src/graphql/reward/ticket/mutation.ts
+++ b/src/graphql/reward/ticket/mutation.ts
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client';
+import { gql } from "@apollo/client";
 
 export const TICKET_CLAIM = gql`
   mutation ticketClaim($input: TicketClaimInput!) {
@@ -7,12 +7,6 @@ export const TICKET_CLAIM = gql`
         tickets {
           id
         }
-      }
-      ... on AlreadyUsedClaimLinkError {
-        message
-      }
-      ... on ClaimLinkExpiredError {
-        message
       }
     }
   }

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -32,16 +32,6 @@ export type GqlAccumulatedPointView = {
   walletId?: Maybe<Scalars["String"]["output"]>;
 };
 
-export type GqlAlreadyJoinedError = {
-  __typename?: "AlreadyJoinedError";
-  message: Scalars["String"]["output"];
-};
-
-export type GqlAlreadyUsedClaimLinkError = {
-  __typename?: "AlreadyUsedClaimLinkError";
-  message: Scalars["String"]["output"];
-};
-
 export type GqlArticle = {
   __typename?: "Article";
   authors?: Maybe<Array<GqlUser>>;
@@ -126,16 +116,6 @@ export const GqlAuthZRules = {
 } as const;
 
 export type GqlAuthZRules = (typeof GqlAuthZRules)[keyof typeof GqlAuthZRules];
-export type GqlAuthenticationError = {
-  __typename?: "AuthenticationError";
-  message: Scalars["String"]["output"];
-};
-
-export type GqlAuthorizationError = {
-  __typename?: "AuthorizationError";
-  message: Scalars["String"]["output"];
-};
-
 export type GqlCheckCommunityPermissionInput = {
   communityId: Scalars["ID"]["input"];
 };
@@ -154,11 +134,6 @@ export type GqlCity = {
   code: Scalars["ID"]["output"];
   name: Scalars["String"]["output"];
   state?: Maybe<GqlState>;
-};
-
-export type GqlClaimLinkExpiredError = {
-  __typename?: "ClaimLinkExpiredError";
-  message: Scalars["String"]["output"];
 };
 
 export const GqlClaimLinkStatus = {
@@ -273,11 +248,6 @@ export type GqlCurrentUserPayload = {
   user?: Maybe<GqlUser>;
 };
 
-export type GqlDatabaseError = {
-  __typename?: "DatabaseError";
-  message: Scalars["String"]["output"];
-};
-
 export type GqlDateTimeRangeFilter = {
   gt?: InputMaybe<Scalars["Datetime"]["input"]>;
   gte?: InputMaybe<Scalars["Datetime"]["input"]>;
@@ -289,6 +259,41 @@ export type GqlEdge = {
   cursor: Scalars["String"]["output"];
 };
 
+export type GqlError = {
+  __typename?: "Error";
+  code: GqlErrorCode;
+  message: Scalars["String"]["output"];
+};
+
+export const GqlErrorCode = {
+  AlreadyEvaluated: "ALREADY_EVALUATED",
+  AlreadyJoined: "ALREADY_JOINED",
+  AlreadyStartedReservation: "ALREADY_STARTED_RESERVATION",
+  AlreadyUsedClaimLink: "ALREADY_USED_CLAIM_LINK",
+  CannotEvaluateBeforeOpportunityStart: "CANNOT_EVALUATE_BEFORE_OPPORTUNITY_START",
+  ClaimLinkExpired: "CLAIM_LINK_EXPIRED",
+  Forbidden: "FORBIDDEN",
+  InsufficientBalance: "INSUFFICIENT_BALANCE",
+  InternalServerError: "INTERNAL_SERVER_ERROR",
+  InvalidTransferMethod: "INVALID_TRANSFER_METHOD",
+  MissingWalletInformation: "MISSING_WALLET_INFORMATION",
+  NotFound: "NOT_FOUND",
+  NoAvailableParticipationSlots: "NO_AVAILABLE_PARTICIPATION_SLOTS",
+  PersonalRecordOnlyDeletable: "PERSONAL_RECORD_ONLY_DELETABLE",
+  RateLimit: "RATE_LIMIT",
+  ReservationAdvanceBookingRequired: "RESERVATION_ADVANCE_BOOKING_REQUIRED",
+  ReservationCancellationTimeout: "RESERVATION_CANCELLATION_TIMEOUT",
+  ReservationFull: "RESERVATION_FULL",
+  ReservationNotAccepted: "RESERVATION_NOT_ACCEPTED",
+  SlotNotScheduled: "SLOT_NOT_SCHEDULED",
+  TicketParticipantMismatch: "TICKET_PARTICIPANT_MISMATCH",
+  Unauthenticated: "UNAUTHENTICATED",
+  Unknown: "UNKNOWN",
+  UnsupportedTransactionReason: "UNSUPPORTED_TRANSACTION_REASON",
+  ValidationError: "VALIDATION_ERROR",
+} as const;
+
+export type GqlErrorCode = (typeof GqlErrorCode)[keyof typeof GqlErrorCode];
 export type GqlEvaluation = {
   __typename?: "Evaluation";
   comment?: Maybe<Scalars["String"]["output"]>;
@@ -577,11 +582,6 @@ export type GqlMembershipsConnection = {
   edges?: Maybe<Array<Maybe<GqlMembershipEdge>>>;
   pageInfo: GqlPageInfo;
   totalCount: Scalars["Int"]["output"];
-};
-
-export type GqlMissingTicketIdsError = {
-  __typename?: "MissingTicketIdsError";
-  message: Scalars["String"]["output"];
 };
 
 export type GqlMutation = {
@@ -898,11 +898,6 @@ export type GqlNestedPlacesBulkUpdateInput = {
   disconnect?: InputMaybe<Array<Scalars["ID"]["input"]>>;
 };
 
-export type GqlNoAvailableParticipationSlotsError = {
-  __typename?: "NoAvailableParticipationSlotsError";
-  message: Scalars["String"]["output"];
-};
-
 export type GqlOpportunitiesConnection = {
   __typename?: "OpportunitiesConnection";
   edges: Array<GqlOpportunityEdge>;
@@ -1043,7 +1038,6 @@ export type GqlOpportunitySlotEdge = GqlEdge & {
 };
 
 export type GqlOpportunitySlotFilterInput = {
-  dateRange?: InputMaybe<GqlDateTimeRangeFilter>;
   hostingStatus?: InputMaybe<GqlOpportunitySlotHostingStatus>;
   opportunityId?: InputMaybe<Scalars["ID"]["input"]>;
 };
@@ -1670,11 +1664,6 @@ export type GqlQueryWalletsArgs = {
   sort?: InputMaybe<GqlWalletSortInput>;
 };
 
-export type GqlRateLimitError = {
-  __typename?: "RateLimitError";
-  message: Scalars["String"]["output"];
-};
-
 export type GqlReservation = {
   __typename?: "Reservation";
   createdAt?: Maybe<Scalars["Datetime"]["output"]>;
@@ -1687,19 +1676,9 @@ export type GqlReservation = {
   updatedAt?: Maybe<Scalars["Datetime"]["output"]>;
 };
 
-export type GqlReservationAdvanceBookingRequiredError = {
-  __typename?: "ReservationAdvanceBookingRequiredError";
-  message: Scalars["String"]["output"];
-};
-
 export type GqlReservationCancelInput = {
   paymentMethod: GqlReservationPaymentMethod;
   ticketIdsIfExists?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-};
-
-export type GqlReservationCancellationTimeoutError = {
-  __typename?: "ReservationCancellationTimeoutError";
-  message: Scalars["String"]["output"];
 };
 
 export type GqlReservationCreateInput = {
@@ -1710,14 +1689,7 @@ export type GqlReservationCreateInput = {
   totalParticipantCount: Scalars["Int"]["input"];
 };
 
-export type GqlReservationCreatePayload =
-  | GqlMissingTicketIdsError
-  | GqlReservationAdvanceBookingRequiredError
-  | GqlReservationCreateSuccess
-  | GqlReservationFullError
-  | GqlReservationNotAcceptedError
-  | GqlSlotNotScheduledError
-  | GqlTicketParticipantMismatchError;
+export type GqlReservationCreatePayload = GqlReservationCreateSuccess;
 
 export type GqlReservationCreateSuccess = {
   __typename?: "ReservationCreateSuccess";
@@ -1733,15 +1705,9 @@ export type GqlReservationEdge = GqlEdge & {
 export type GqlReservationFilterInput = {
   createdByUserId?: InputMaybe<Scalars["ID"]["input"]>;
   opportunityId?: InputMaybe<Scalars["ID"]["input"]>;
+  opportunityOwnerId?: InputMaybe<Scalars["ID"]["input"]>;
   opportunitySlotId?: InputMaybe<Scalars["ID"]["input"]>;
   status?: InputMaybe<GqlReservationStatus>;
-};
-
-export type GqlReservationFullError = {
-  __typename?: "ReservationFullError";
-  capacity: Scalars["Int"]["output"];
-  message: Scalars["String"]["output"];
-  requested: Scalars["Int"]["output"];
 };
 
 export type GqlReservationHistoriesConnection = {
@@ -1776,11 +1742,6 @@ export type GqlReservationHistorySortInput = {
   createdAt?: InputMaybe<GqlSortDirection>;
 };
 
-export type GqlReservationNotAcceptedError = {
-  __typename?: "ReservationNotAcceptedError";
-  message: Scalars["String"]["output"];
-};
-
 export const GqlReservationPaymentMethod = {
   Fee: "FEE",
   Ticket: "TICKET",
@@ -1788,11 +1749,7 @@ export const GqlReservationPaymentMethod = {
 
 export type GqlReservationPaymentMethod =
   (typeof GqlReservationPaymentMethod)[keyof typeof GqlReservationPaymentMethod];
-export type GqlReservationSetStatusPayload =
-  | GqlAlreadyJoinedError
-  | GqlNoAvailableParticipationSlotsError
-  | GqlReservationCancellationTimeoutError
-  | GqlReservationSetStatusSuccess;
+export type GqlReservationSetStatusPayload = GqlReservationSetStatusSuccess;
 
 export type GqlReservationSetStatusSuccess = {
   __typename?: "ReservationSetStatusSuccess";
@@ -1826,11 +1783,6 @@ export const GqlRole = {
 } as const;
 
 export type GqlRole = (typeof GqlRole)[keyof typeof GqlRole];
-export type GqlSlotNotScheduledError = {
-  __typename?: "SlotNotScheduledError";
-  message: Scalars["String"]["output"];
-};
-
 export const GqlSortDirection = {
   Asc: "asc",
   Desc: "desc",
@@ -1898,10 +1850,7 @@ export type GqlTicketClaimLink = {
   tickets?: Maybe<Array<GqlTicket>>;
 };
 
-export type GqlTicketClaimPayload =
-  | GqlAlreadyUsedClaimLinkError
-  | GqlClaimLinkExpiredError
-  | GqlTicketClaimSuccess;
+export type GqlTicketClaimPayload = GqlTicketClaimSuccess;
 
 export type GqlTicketClaimSuccess = {
   __typename?: "TicketClaimSuccess";
@@ -1963,13 +1912,6 @@ export type GqlTicketIssuersConnection = {
   edges?: Maybe<Array<Maybe<GqlTicketIssuerEdge>>>;
   pageInfo: GqlPageInfo;
   totalCount: Scalars["Int"]["output"];
-};
-
-export type GqlTicketParticipantMismatchError = {
-  __typename?: "TicketParticipantMismatchError";
-  message: Scalars["String"]["output"];
-  participantCount: Scalars["Int"]["output"];
-  ticketCount: Scalars["Int"]["output"];
 };
 
 export type GqlTicketPurchaseInput = {
@@ -2342,11 +2284,6 @@ export type GqlUtilityUpdateInfoPayload = GqlUtilityUpdateInfoSuccess;
 export type GqlUtilityUpdateInfoSuccess = {
   __typename?: "UtilityUpdateInfoSuccess";
   utility: GqlUtility;
-};
-
-export type GqlValidationError = {
-  __typename?: "ValidationError";
-  message: Scalars["String"]["output"];
 };
 
 export const GqlValueType = {
@@ -3831,23 +3768,10 @@ export type GqlCreateReservationMutationVariables = Exact<{
 
 export type GqlCreateReservationMutation = {
   __typename?: "Mutation";
-  reservationCreate?:
-    | { __typename: "MissingTicketIdsError"; message: string }
-    | { __typename: "ReservationAdvanceBookingRequiredError"; message: string }
-    | {
-        __typename?: "ReservationCreateSuccess";
-        reservation: { __typename?: "Reservation"; id: string; status: GqlReservationStatus };
-      }
-    | { __typename: "ReservationFullError"; message: string; capacity: number; requested: number }
-    | { __typename: "ReservationNotAcceptedError"; message: string }
-    | { __typename: "SlotNotScheduledError"; message: string }
-    | {
-        __typename: "TicketParticipantMismatchError";
-        message: string;
-        ticketCount: number;
-        participantCount: number;
-      }
-    | null;
+  reservationCreate?: {
+    __typename?: "ReservationCreateSuccess";
+    reservation: { __typename?: "Reservation"; id: string; status: GqlReservationStatus };
+  } | null;
 };
 
 export type GqlCancelReservationMutationVariables = Exact<{
@@ -3858,15 +3782,10 @@ export type GqlCancelReservationMutationVariables = Exact<{
 
 export type GqlCancelReservationMutation = {
   __typename?: "Mutation";
-  reservationCancel?:
-    | { __typename?: "AlreadyJoinedError" }
-    | { __typename?: "NoAvailableParticipationSlotsError" }
-    | { __typename?: "ReservationCancellationTimeoutError"; message: string }
-    | {
-        __typename?: "ReservationSetStatusSuccess";
-        reservation: { __typename?: "Reservation"; id: string; status: GqlReservationStatus };
-      }
-    | null;
+  reservationCancel?: {
+    __typename?: "ReservationSetStatusSuccess";
+    reservation: { __typename?: "Reservation"; id: string; status: GqlReservationStatus };
+  } | null;
 };
 
 export type GqlGetReservationsQueryVariables = Exact<{ [key: string]: never }>;
@@ -4012,11 +3931,10 @@ export type GqlTicketClaimMutationVariables = Exact<{
 
 export type GqlTicketClaimMutation = {
   __typename?: "Mutation";
-  ticketClaim?:
-    | { __typename?: "AlreadyUsedClaimLinkError"; message: string }
-    | { __typename?: "ClaimLinkExpiredError"; message: string }
-    | { __typename?: "TicketClaimSuccess"; tickets: Array<{ __typename?: "Ticket"; id: string }> }
-    | null;
+  ticketClaim?: {
+    __typename?: "TicketClaimSuccess";
+    tickets: Array<{ __typename?: "Ticket"; id: string }>;
+  } | null;
 };
 
 export type GqlGetTicketsQueryVariables = Exact<{ [key: string]: never }>;
@@ -6413,34 +6331,6 @@ export const CreateReservationDocument = gql`
           ...ReservationFields
         }
       }
-      ... on ReservationFullError {
-        __typename
-        message
-        capacity
-        requested
-      }
-      ... on ReservationAdvanceBookingRequiredError {
-        __typename
-        message
-      }
-      ... on ReservationNotAcceptedError {
-        __typename
-        message
-      }
-      ... on SlotNotScheduledError {
-        __typename
-        message
-      }
-      ... on MissingTicketIdsError {
-        __typename
-        message
-      }
-      ... on TicketParticipantMismatchError {
-        __typename
-        message
-        ticketCount
-        participantCount
-      }
     }
   }
   ${ReservationFieldsFragmentDoc}
@@ -6496,9 +6386,6 @@ export const CancelReservationDocument = gql`
         reservation {
           ...ReservationFields
         }
-      }
-      ... on ReservationCancellationTimeoutError {
-        message
       }
     }
   }
@@ -6778,12 +6665,6 @@ export const TicketClaimDocument = gql`
         tickets {
           id
         }
-      }
-      ... on AlreadyUsedClaimLinkError {
-        message
-      }
-      ... on ClaimLinkExpiredError {
-        message
       }
     }
   }

--- a/src/utils/errorMessage.ts
+++ b/src/utils/errorMessage.ts
@@ -1,0 +1,35 @@
+import { GqlErrorCode } from "@/types/graphql";
+
+export const errorMessages: Record<GqlErrorCode, string> = {
+  [GqlErrorCode.ValidationError]: "入力内容に誤りがあります。",
+  [GqlErrorCode.Unauthenticated]: "ログインが必要です。",
+  [GqlErrorCode.Forbidden]: "権限がありません。",
+  [GqlErrorCode.NotFound]: "ページが見つかりません。",
+  [GqlErrorCode.InternalServerError]: "サーバーエラーが発生しました。",
+  [GqlErrorCode.RateLimit]: "リクエストが多すぎます。",
+
+  [GqlErrorCode.InsufficientBalance]: "ポイント残高が不足しています。",
+  [GqlErrorCode.InvalidTransferMethod]: "無効なポイント交換方法です。",
+  [GqlErrorCode.MissingWalletInformation]: "ウォレット情報が不足しています。",
+  [GqlErrorCode.UnsupportedTransactionReason]: "サポートされない取引理由です。",
+
+  [GqlErrorCode.ReservationFull]: "予約枠が満員です。",
+  [GqlErrorCode.AlreadyStartedReservation]: "イベントは終了しました。",
+  [GqlErrorCode.ReservationCancellationTimeout]: "キャンセル期限を過ぎています。",
+  [GqlErrorCode.ReservationAdvanceBookingRequired]: "開催より7日前までの予約が必要です。",
+  [GqlErrorCode.ReservationNotAccepted]: "申し込みがまだ承認されていません。",
+  [GqlErrorCode.SlotNotScheduled]: "予約枠は開催が予定されていません。",
+  [GqlErrorCode.TicketParticipantMismatch]: "チケットと人数が一致しません。",
+
+  [GqlErrorCode.AlreadyJoined]: "既に参加しています。",
+  [GqlErrorCode.NoAvailableParticipationSlots]: "参加可能な枠がありません。",
+  [GqlErrorCode.PersonalRecordOnlyDeletable]: "個人の記録のみ削除できます。",
+
+  [GqlErrorCode.AlreadyEvaluated]: "既に評価済みです。",
+  [GqlErrorCode.CannotEvaluateBeforeOpportunityStart]: "開始前は評価できません。",
+
+  [GqlErrorCode.AlreadyUsedClaimLink]: "リンクは使用済みです。",
+  [GqlErrorCode.ClaimLinkExpired]: "リンクの有効期限が切れています。",
+
+  [GqlErrorCode.Unknown]: "予期しないエラーが発生しました。",
+};


### PR DESCRIPTION
Moved search header configuration logic to a new `useSearchResultHeader` hook for improved modularity and separation of concerns. Adjusted `SearchResultPage` and `useSearchResults` to integrate the new hook, reducing redundancy and centralizing the header management logic.