### PR TITLE
Update filter key from cityCodes to stateCodes

### DIFF
--- a/src/app/search/result/hooks/useSearchResults.ts
+++ b/src/app/search/result/hooks/useSearchResults.ts
@@ -101,7 +101,7 @@ function buildFilter(searchParams: SearchParams): OpportunityFilterInput {
 
   const location = searchParams.location as GqlCurrentPrefecture;
   if (location && IPrefectureCodeMap[location]) {
-    filter.cityCodes = [IPrefectureCodeMap[location]];
+    filter.stateCodes = [IPrefectureCodeMap[location]];
   }
 
   if (searchParams.from || searchParams.to) {


### PR DESCRIPTION
Replaced the `cityCodes` filter key with `stateCodes` to match the updated naming conventions for location-based filtering. This ensures better consistency and avoids misinterpretations in functionality.