### PR TITLE
[0523] 細かな修正たち

### DIFF
--- a/src/app/activities/[id]/components/ActivityDetailsContent.tsx
+++ b/src/app/activities/[id]/components/ActivityDetailsContent.tsx
@@ -103,14 +103,28 @@ const HostInfoSection = ({ host }: { host: OpportunityHost }) => {
       <h2 className="text-display-md text-foreground mb-4">案内人</h2>
       <div className="rounded-xl flex flex-col gap-4">
         <div className="flex items-center gap-4">
-          <div className="relative w-16 h-16 rounded-full overflow-hidden flex-shrink-0">
-            <Image
-              src={host.image || PLACEHOLDER_IMAGE}
-              alt={host.name || "案内者"}
-              fill
-              className="object-cover"
-            />
-          </div>
+          {host.id ? (
+            <Link
+              href={`/users/${host.id}`}
+              className="relative w-16 h-16 rounded-full overflow-hidden flex-shrink-0"
+            >
+              <Image
+                src={host.image || PLACEHOLDER_IMAGE}
+                alt={host.name || "案内者"}
+                fill
+                className="object-cover"
+              />
+            </Link>
+          ) : (
+            <div className="relative w-16 h-16 rounded-full overflow-hidden flex-shrink-0">
+              <Image
+                src={host.image || PLACEHOLDER_IMAGE}
+                alt={host.name || "案内者"}
+                fill
+                className="object-cover"
+              />
+            </div>
+          )}
           <div>
             <h3 className="text-title-sm font-bold mb-1 text-caption">
               <span className="text-display-sm mr-1 text-foreground">{host.name}</span>さん

--- a/src/app/activities/[id]/components/ActivityDetailsFooter.tsx
+++ b/src/app/activities/[id]/components/ActivityDetailsFooter.tsx
@@ -8,12 +8,14 @@ interface ActivityDetailsFooterProps {
   opportunityId: string;
   price: number;
   communityId: string | undefined;
+  disableButton?: boolean;
 }
 
 const ActivityDetailsFooter: React.FC<ActivityDetailsFooterProps> = ({
   opportunityId,
   price,
   communityId,
+  disableButton = false,
 }) => {
   const query = new URLSearchParams({
     id: opportunityId,
@@ -27,11 +29,17 @@ const ActivityDetailsFooter: React.FC<ActivityDetailsFooterProps> = ({
           <p className="text-body-sm text-muted-foreground">1人あたり</p>
           <p className="text-bodylg font-bold">{price.toLocaleString()}円〜</p>
         </div>
-        <Link href={`/reservation/select-date?${query.toString()}`}>
-          <Button variant="primary" size="lg" className="px-8">
+        {disableButton ? (
+          <Button variant="primary" size="lg" className="px-8" disabled>
             日付を選択
           </Button>
-        </Link>
+        ) : (
+          <Link href={`/reservation/select-date?${query.toString()}`}>
+            <Button variant="primary" size="lg" className="px-8">
+              日付を選択
+            </Button>
+          </Link>
+        )}
       </div>
     </footer>
   );

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -76,6 +76,7 @@ export default function ActivityPage() {
         opportunityId={opportunity.id}
         price={opportunity.feeRequired || 0}
         communityId={communityId}
+        disableButton={!sortedSlots || sortedSlots.length === 0}
       />
     </>
   );

--- a/src/app/activities/data/presenter.ts
+++ b/src/app/activities/data/presenter.ts
@@ -140,6 +140,21 @@ export const sliceActivitiesBySection = (
 
   const N = activityCards.length;
 
+  // Filter activities with images
+  const hasImages = (card: ActivityCard) => card.images && card.images.length > 0;
+
+  // Sort function to put cards with images first
+  const sortByImages = (cards: ActivityCard[]) => {
+    return [...cards].sort((a, b) => {
+      const aHasImages = hasImages(a);
+      const bHasImages = hasImages(b);
+
+      if (aHasImages && !bHasImages) return -1;
+      if (!aHasImages && bHasImages) return 1;
+      return 0;
+    });
+  };
+
   const featuredHead = activityCards[0];
 
   if (N < 10) {
@@ -148,7 +163,8 @@ export const sliceActivitiesBySection = (
     const usedIndices = new Set<number>();
     if (featuredHead) usedIndices.add(0);
 
-    const featuredCards = safe([featuredHead]);
+    // Only include activities with images in featuredCards
+    const featuredCards = safe([featuredHead]).filter(hasImages);
 
     const upcomingCards = safe(
       activityCards.slice(1, 1 + maxUpcoming).map((card, i) => {
@@ -157,21 +173,22 @@ export const sliceActivitiesBySection = (
       }),
     );
 
-    const listCards = safe(activityCards.filter((_, idx) => !usedIndices.has(idx)));
+    // Get remaining cards and sort them - activities with images first
+    const listCards = sortByImages(safe(activityCards.filter((_, idx) => !usedIndices.has(idx))));
 
     return { upcomingCards, featuredCards, listCards };
   }
 
   const featuredTail = activityCards.slice(6, 10);
-  const featuredCards = safe([featuredHead, ...featuredTail]);
+  // Only include activities with images in featuredCards
+  const featuredCards = safe([featuredHead, ...featuredTail]).filter(hasImages);
 
   const upcomingCards = safe(activityCards.slice(1, 6));
 
-  const listCards = safe([
-    ...activityCards.slice(3, 6),
-    ...activityCards.slice(6, 10),
-    ...activityCards.slice(10),
-  ]);
+  // Get all list cards and sort them - activities with images first
+  const listCards = sortByImages(
+    safe([...activityCards.slice(3, 6), ...activityCards.slice(6, 10), ...activityCards.slice(10)]),
+  );
 
   return { upcomingCards, featuredCards, listCards };
 };

--- a/src/app/articles/components/Card.tsx
+++ b/src/app/articles/components/Card.tsx
@@ -18,7 +18,6 @@ interface ArticleCardProps {
 }
 
 const ArticleCard: React.FC<ArticleCardProps> = ({ article, showCategory, showUser }) => {
-  console.debug({ article });
   return (
     <Link href={`/articles/${article.id}`} className="block">
       <Card className="bg-white">

--- a/src/app/articles/data/presenter.ts
+++ b/src/app/articles/data/presenter.ts
@@ -8,7 +8,6 @@ import {
   TArticleWithAuthor,
 } from "@/app/articles/data/type";
 import { presenterActivityCard } from "@/app/activities/data/presenter";
-import markdownToTxt from 'markdown-to-txt';
 
 export const presenterArticleCards = (
   edges?: (GqlArticleEdge | null | undefined)[],
@@ -23,8 +22,7 @@ export const presenterArticleCard = (node?: GqlArticle): TArticleCard => ({
   id: node?.id || "",
   category: node?.category || GqlArticleCategory.Interview,
   title: node?.title || "",
-  // TODO FEでintroが入ったら修正
-  introduction: node?.body ? markdownToTxt(node.body) : "",
+  introduction: node?.introduction || "",
   thumbnail: node?.thumbnail || null,
   publishedAt: node?.publishedAt ? new Date(node.publishedAt).toISOString() : "",
 });
@@ -51,10 +49,8 @@ export const presenterArticleDetail = (article: GqlArticle): TArticleDetail => {
     id: article.id,
     title: article.title,
     category: article.category,
-    // TODO FEでintroが入ったら修正
-    introduction: article.body || "",
+    introduction: article.introduction || "",
     body: article.body || "",
-
     thumbnail: typeof article.thumbnail === "string" ? article.thumbnail : "",
     publishedAt: article.publishedAt ? new Date(article.publishedAt).toISOString() : "",
 

--- a/src/app/places/components/Card.tsx
+++ b/src/app/places/components/Card.tsx
@@ -35,38 +35,40 @@ const PlaceCard: React.FC<PlaceCardProps> = ({ place, selected, buttonVariant = 
           }}
         />
       </div>
-      <CardContent className="flex flex-col px-4 py-3">
+      <CardContent className="flex flex-col px-4 py-3 w-full">
         {/*//TODO 適切に1行に収めるか、name, addressで2行にした方が良い？ユーザーがどの地域なのか分からない問題を解消したい*/}
-        <div className="flex items-center justify-between mb-2">
-          <div className="mt-1 flex items-start text-foreground text-body-xs max-w-[75%]">
+        <div className="flex items-center justify-between mb-2 w-full">
+          <div className="mt-1 flex items-start text-foreground text-body-xs max-w-[75%] overflow-hidden">
             <MapPin className="mr-1 h-4 w-4 flex-shrink-0 mt-0.5" />
-            <div className="flex-1 flex flex-wrap overflow-hidden">
-              <span className="font-bold text-body-xs truncate min-w-0 max-w-[calc(100%-1rem)] mr-2">
+            <div className="flex-1 flex flex-wrap overflow-hidden min-w-0">
+              <span className="font-bold text-body-xs truncate min-w-0 max-w-full mr-2">
                 {place.name}
               </span>
-              <span className="truncate text-caption text-body-xs min-w-0 max-w-[calc(100%-1rem)]">
+              <span className="truncate text-caption text-body-xs min-w-0 max-w-full">
                 {place.address}
               </span>
             </div>
           </div>
-          <div className="mt-1 flex items-center text-caption text-label-xs">
+          <div className="mt-1 flex items-center text-caption text-label-xs flex-shrink-0">
             <Users className="mr-1 h-4 w-4 flex-shrink-0" />
             <span className="line-clamp-1 break-words">{place.participantCount}人</span>
           </div>
         </div>
 
         {place.headline && (
-          <CardTitle className="text-title-sm line-clamp-1 mb-1">{place.headline}</CardTitle>
+          <CardTitle className="text-title-sm line-clamp-1 mb-1 overflow-hidden">
+            {place.headline}
+          </CardTitle>
         )}
         {place.bio && (
-          <CardDescription className="line-clamp-2 mb-2 text-body-xs text-caption">
+          <CardDescription className="line-clamp-2 mb-2 text-body-xs text-caption overflow-hidden">
             {place.bio}
           </CardDescription>
         )}
 
-        <CardFooter className="flex justify-between mt-2 p-0 mb-1">
+        <CardFooter className="flex justify-between mt-2 p-0 mb-1 w-full">
           {place.publicOpportunityCount > 0 ? (
-            <span className="text-body-xs text-caption">
+            <span className="text-body-xs text-caption truncate mr-2">
               <strong className="text-foreground mr-0.5">{place.publicOpportunityCount}件</strong>
               の関わり方を募集中
             </span>
@@ -74,7 +76,7 @@ const PlaceCard: React.FC<PlaceCardProps> = ({ place, selected, buttonVariant = 
             // レイアウト保持のために render
             <span className="text-body-xs text-caption"></span>
           )}
-          <Button variant={buttonVariant} size={"sm"}>
+          <Button variant={buttonVariant} size={"sm"} className="flex-shrink-0">
             もっと見る
           </Button>
         </CardFooter>

--- a/src/app/places/data/presenter.ts
+++ b/src/app/places/data/presenter.ts
@@ -19,7 +19,12 @@ export const presenterPlacePins = (edges: GqlPlaceEdge[]): IPlacePin[] => {
     .filter((node): node is GqlPlace => !!node && node.latitude != null && node.longitude != null)
     .map((node) => ({
       id: node.id,
-      image: node.opportunities?.length && node.opportunities?.[0].images && node.opportunities?.[0].images?.[0] ? node.opportunities?.[0].images?.[0] : PLACEHOLDER_IMAGE,
+      image:
+        node.opportunities?.length &&
+        node.opportunities?.[0].images &&
+        node.opportunities?.[0].images?.[0]
+          ? node.opportunities?.[0].images?.[0]
+          : PLACEHOLDER_IMAGE,
       host: extractFirstHostFromPlace(node.opportunities?.[0]?.createdByUser),
       latitude: Number(node.latitude),
       longitude: Number(node.longitude),
@@ -30,7 +35,12 @@ export const presenterPlacePins = (edges: GqlPlaceEdge[]): IPlacePin[] => {
 export const presenterPlacePin = (node: GqlPlace): IPlacePin => {
   return {
     id: node.id,
-    image: node.opportunities?.length && node.opportunities?.[0].images && node.opportunities?.[0].images?.[0] ? node.opportunities?.[0].images?.[0] : PLACEHOLDER_IMAGE,
+    image:
+      node.opportunities?.length &&
+      node.opportunities?.[0].images &&
+      node.opportunities?.[0].images?.[0]
+        ? node.opportunities?.[0].images?.[0]
+        : PLACEHOLDER_IMAGE,
     host: extractFirstHostFromPlace(node.opportunities?.[0]?.createdByUser),
     latitude: Number(node.latitude),
     longitude: Number(node.longitude),

--- a/src/app/sign-up/components/SignUpForm.tsx
+++ b/src/app/sign-up/components/SignUpForm.tsx
@@ -9,6 +9,7 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
+  FormDescription,
 } from "@/components/ui/form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Input } from "@/components/ui/input";
@@ -76,10 +77,14 @@ export function SignUpForm() {
             name="name"
             render={({ field }) => (
               <FormItem className="space-y-3">
-                <FormLabel className="text-base">表示名</FormLabel>
+                {/* #NOTE: 運営メンバーが本名でないと、誰かが誰かを区別できなくなる可能性があるため本名としているが、NEO88における特殊対応 */}
+                <FormLabel className="text-base">本名</FormLabel>
                 <FormControl>
-                  <Input placeholder="名前を入力" {...field} className="h-12" />
+                  <Input placeholder="山田太郎" {...field} className="h-12" />
                 </FormControl>
+                <FormDescription className="text-xs text-muted-foreground">
+                  ※ どなたか分からなくなるため、必ず本名をご入力ください
+                </FormDescription>
                 <FormMessage />
               </FormItem>
             )}

--- a/src/app/users/components/UserProfileEdit.tsx
+++ b/src/app/users/components/UserProfileEdit.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import React, { useState } from 'react';
-import Image from 'next/image';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { Facebook, Instagram, Twitter } from 'lucide-react';
-import { GqlCurrentPrefecture } from '@/types/graphql';
+import React, { useState } from "react";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Facebook, Instagram, Twitter } from "lucide-react";
+import { GqlCurrentPrefecture } from "@/types/graphql";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { PLACEHOLDER_IMAGE } from "@/utils";
 
@@ -94,8 +94,9 @@ const UserProfileEdit: React.FC<UserProfileEditProps> = ({
       </div>
 
       <div>
+        {/* #NOTE: 運営メンバーが本名でないと、誰かが誰かを区別できなくなる可能性があるため本名としているが、NEO88における特殊対応 */}
         <Label className="mb-2 flex items-center gap-x-2">
-          表示名
+          本名
           <span className="text-primary text-label-xs font-bold bg-primary-foreground px-1 py-1 rounded-md">
             必須
           </span>
@@ -106,6 +107,9 @@ const UserProfileEdit: React.FC<UserProfileEditProps> = ({
           placeholder="山田太郎"
           required
         />
+        <span className="text-xs text-muted-foreground">
+          ※ どなたか分からなくなるため、必ず本名をご入力ください
+        </span>
       </div>
 
       <div>

--- a/src/app/users/components/UserProfileHeader.tsx
+++ b/src/app/users/components/UserProfileHeader.tsx
@@ -70,7 +70,7 @@ const UserProfileHeader: React.FC<UserProfileHeaderProps> = ({
             <h1 className="text-title-lg mb-2">{name}</h1>
 
             {currentPrefecture && (
-              <div className="flex items-center justify-center text-label-md text-caption mb-3">
+              <div className="flex items-center text-label-md text-caption mb-3">
                 <Home className="w-4 h-4 mr-1" />
                 <span>{prefectureLabels[currentPrefecture] || "不明"}</span>
               </div>

--- a/src/app/users/components/UserProfileHeader.tsx
+++ b/src/app/users/components/UserProfileHeader.tsx
@@ -120,7 +120,7 @@ const BioSection = ({ bio }: { bio: string }) => {
     <div className="mb-4 relative">
       <div
         ref={textRef}
-        className="text-body-md text-foreground whitespace-pre-line transition-all duration-300"
+        className="text-body-md text-foreground whitespace-pre-line transition-all duration-300 text-left"
         style={getTextStyle()}
       >
         {bio}


### PR DESCRIPTION
## 以下、修正している
- 日程がない時にボトムバーのボタンを非活性化されない

- 案内人のユーザーを推したらユーザー詳細に遷移

- place cardでarticleのintroductionをカードに表示させる、今表示されていない

- ユーザーのbioが中央寄せになっているので、左寄せに

- トップページで画像登録されていなかったりあんま見栄え良くないやつが目立ってる

- 拠点一覧のリストで横幅崩れてる

- ユーザー名の登録は「本名でする」と認識しやすくする（スプシで照合できないらしく）