### PR TITLE
fix: include articles on GqlGetOpportunityQuery

### DIFF
--- a/src/graphql/experience/opportunity/fragment.ts
+++ b/src/graphql/experience/opportunity/fragment.ts
@@ -15,7 +15,7 @@ export const OPPORTUNITY_FRAGMENT = gql`
 
     feeRequired
     pointsToEarn
-    
+
     earliestReservableAt
   }
 `;

--- a/src/graphql/experience/opportunity/query.ts
+++ b/src/graphql/experience/opportunity/query.ts
@@ -72,6 +72,9 @@ export const GET_OPPORTUNITY = gql`
           }
         }
       }
+      articles {
+        ...ArticleFields
+      }
       createdByUser {
         ...UserFields
         articlesAboutMe {

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -3491,6 +3491,17 @@ export type GqlGetOpportunityQuery = {
         }> | null;
       }> | null;
     }> | null;
+    articles?: Array<{
+      __typename?: "Article";
+      id: string;
+      title: string;
+      body?: string | null;
+      introduction: string;
+      thumbnail?: any | null;
+      category: GqlArticleCategory;
+      publishStatus: GqlPublishStatus;
+      publishedAt?: Date | null;
+    }> | null;
     createdByUser?: {
       __typename?: "User";
       id: string;
@@ -6254,6 +6265,9 @@ export const GetOpportunityDocument = gql`
             }
           }
         }
+      }
+      articles {
+        ...ArticleFields
       }
       createdByUser {
         ...UserFields


### PR DESCRIPTION
## 変更内容

https://github.com/Hopin-inc/civicship-portal/pull/157
で Oppotunity に紐づく articles を参照しているが、articles をクエリで記述していなかったため取れていなったので修正

API の方ではすでに参照できるようになっている
https://github.com/Hopin-inc/civicship-api/blob/1ab599e0564cb31c6e781e4c152a9f625d7bd56d/src/application/domain/experience/opportunity/controller/resolver.ts#L122-L124

before
![image](https://github.com/user-attachments/assets/57196c41-6a08-4cb1-afd2-8446c109d094)

after
![image](https://github.com/user-attachments/assets/8312b5b1-6d14-4e00-bd42-c2d580e388a2)
