### PR TITLE
Refactor and standardize author-related fields and mappings

### DIFF
--- a/src/app/articles/data/presenter.ts
+++ b/src/app/articles/data/presenter.ts
@@ -38,9 +38,10 @@ export const presenterArticleWithAuthorList = (
 
 export const presenterArticleWithAuthor = (node?: GqlArticle): TArticleWithAuthor => ({
   ...presenterArticleCard(node),
+  //TODO 型そのものを直した方が良いが応急処置、authorは執筆者なので間違い。阪田の英語間違い。
   author: {
-    name: node?.authors?.[0]?.name || "",
-    image: node?.authors?.[0]?.image || "",
+    name: node?.relatedUsers?.[0]?.name || "",
+    image: node?.relatedUsers?.[0]?.image || "",
   },
 });
 

--- a/src/app/articles/data/presenter.ts
+++ b/src/app/articles/data/presenter.ts
@@ -59,7 +59,7 @@ export const presenterArticleDetail = (article: GqlArticle): TArticleDetail => {
     relatedUsers: article.relatedUsers?.map(presenterUser) || [],
 
     hostedOpportunitiesByAuthors:
-      article.authors?.flatMap(
+      article.relatedUsers?.flatMap(
         (author) => author.opportunitiesCreatedByMe?.map(presenterActivityCard) ?? [],
       ) ?? [],
     relatedArticles: [],

--- a/src/app/articles/hooks/useArticles.ts
+++ b/src/app/articles/hooks/useArticles.ts
@@ -1,11 +1,11 @@
-'use client';
+"use client";
 
 import React, { useEffect, useMemo } from "react";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { useLoading } from "@/hooks/useLoading";
 import { GqlSortDirection as SortDirection, useGetArticlesQuery } from "@/types/graphql";
-import { presenterArticleWithAuthorList, } from "@/app/articles/data/presenter";
-import {  TArticleWithAuthor } from "@/app/articles/data/type";
+import { presenterArticleWithAuthorList } from "@/app/articles/data/presenter";
+import { TArticleWithAuthor } from "@/app/articles/data/type";
 
 export const ARTICLES_PER_PAGE = 10;
 
@@ -35,6 +35,8 @@ export const useArticles = (): UseArticlesResult => {
     return data?.articles?.edges ? presenterArticleWithAuthorList(data.articles.edges) : [];
   }, [data]);
 
+  console.log(articles);
+
   const hasMore = data?.articles.pageInfo.hasNextPage || false;
 
   const handleLoadMore = async () => {
@@ -53,10 +55,7 @@ export const useArticles = (): UseArticlesResult => {
           ...prev,
           articles: {
             ...prev.articles,
-            edges: [
-              ...(prev.articles.edges ?? []),
-              ...(fetchMoreResult.articles.edges ?? [])
-            ],
+            edges: [...(prev.articles.edges ?? []), ...(fetchMoreResult.articles.edges ?? [])],
             pageInfo: fetchMoreResult.articles.pageInfo,
           },
         };

--- a/src/graphql/content/article/query.ts
+++ b/src/graphql/content/article/query.ts
@@ -21,7 +21,7 @@ export const GET_ARTICLES = gql`
         cursor
         node {
           ...ArticleFields
-          authors {
+          relatedUsers {
             ...UserFields
           }
         }
@@ -36,7 +36,7 @@ export const GET_ARTICLE = gql`
   query GetArticle($id: ID!, $permission: CheckCommunityPermissionInput!) {
     article(id: $id, permission: $permission) {
       ...ArticleFields
-      authors {
+      relatedUsers {
         ...UserFields
         opportunitiesCreatedByMe {
           ...OpportunityFields
@@ -45,7 +45,7 @@ export const GET_ARTICLE = gql`
           }
         }
       }
-      relatedUsers {
+      authors {
         ...UserFields
       }
     }
@@ -62,7 +62,7 @@ export const GET_ARTICLE = gql`
         cursor
         node {
           ...ArticleFields
-          authors {
+          relatedUsers {
             ...UserFields
           }
         }

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -3170,7 +3170,7 @@ export type GqlGetArticlesQuery = {
         category: GqlArticleCategory;
         publishStatus: GqlPublishStatus;
         publishedAt?: Date | null;
-        authors?: Array<{
+        relatedUsers?: Array<{
           __typename?: "User";
           id: string;
           name: string;
@@ -3204,7 +3204,7 @@ export type GqlGetArticleQuery = {
     category: GqlArticleCategory;
     publishStatus: GqlPublishStatus;
     publishedAt?: Date | null;
-    authors?: Array<{
+    relatedUsers?: Array<{
       __typename?: "User";
       id: string;
       name: string;
@@ -3250,7 +3250,7 @@ export type GqlGetArticleQuery = {
         } | null;
       }> | null;
     }> | null;
-    relatedUsers?: Array<{
+    authors?: Array<{
       __typename?: "User";
       id: string;
       name: string;
@@ -3286,7 +3286,7 @@ export type GqlGetArticleQuery = {
         category: GqlArticleCategory;
         publishStatus: GqlPublishStatus;
         publishedAt?: Date | null;
-        authors?: Array<{
+        relatedUsers?: Array<{
           __typename?: "User";
           id: string;
           name: string;
@@ -6179,7 +6179,7 @@ export const GetArticlesDocument = gql`
         cursor
         node {
           ...ArticleFields
-          authors {
+          relatedUsers {
             ...UserFields
           }
         }
@@ -6250,7 +6250,7 @@ export const GetArticleDocument = gql`
   query GetArticle($id: ID!, $permission: CheckCommunityPermissionInput!) {
     article(id: $id, permission: $permission) {
       ...ArticleFields
-      authors {
+      relatedUsers {
         ...UserFields
         opportunitiesCreatedByMe {
           ...OpportunityFields
@@ -6259,7 +6259,7 @@ export const GetArticleDocument = gql`
           }
         }
       }
-      relatedUsers {
+      authors {
         ...UserFields
       }
     }
@@ -6275,7 +6275,7 @@ export const GetArticleDocument = gql`
         cursor
         node {
           ...ArticleFields
-          authors {
+          relatedUsers {
             ...UserFields
           }
         }


### PR DESCRIPTION
### Description

This pull request refactors the handling of author-related data by introducing consistent terminology and making structural changes to improve clarity and maintainability.

### Changes
- Updated `hostedOpportunitiesByAuthors` logic to rely on `relatedUsers` for consistency.
- Renamed `authors` to `relatedUsers`, and vice versa, in GraphQL queries and types to align terminology across the codebase.
- Refactored author mapping to use the `relatedUsers` field as a temporary workaround, with notes on potential long-term solutions.

### Checklist
- [ ] Tests are passing for all changes introduced.
- [ ] The change has been reviewed and approved by another developer.
- [ ] Relevant documentation has been updated, if necessary.
- [ ] Code changes meet the team's coding standards and best practices.