### PR TITLE
Refactor LIFF initialization to handle initial redirects

### DIFF
--- a/src/contexts/LiffContext.tsx
+++ b/src/contexts/LiffContext.tsx
@@ -3,7 +3,7 @@
 import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from "react";
 import liff from "@line/liff";
 import { setIsInLiffBrowser } from "@/utils/liff";
-import { useInitialLiffRedirect } from "@/hooks/useInitialLiffRedirect";
+import { useRouter } from "next/navigation";
 
 type LiffProfile = {
   userId: string;
@@ -33,7 +33,7 @@ type LiffProviderProps = {
 
 export const LiffProvider = ({ children }: LiffProviderProps) => {
   const liffId = process.env.NEXT_PUBLIC_LIFF_ID || "";
-  useInitialLiffRedirect();
+  const router = useRouter();
 
   const [isLiffInitialized, setIsLiffInitialized] = useState<boolean>(false);
   const [isInLiff, setIsInLiff] = useState<boolean>(false);
@@ -81,12 +81,19 @@ export const LiffProvider = ({ children }: LiffProviderProps) => {
         await updateLiffProfile();
         updateLiffTokens();
       }
+
+      const searchParams = new URLSearchParams(window.location.search);
+      const initial = searchParams.get("initial");
+      if (initial && initial.startsWith("/") && initial !== window.location.pathname) {
+        console.log("🚀 Redirecting to initial path:", initial);
+        router.replace(initial);
+      }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       setLiffError(errorMessage);
       console.error("LIFF initialization failed:", error);
     }
-  }, [liffId, updateLiffProfile, updateLiffTokens]);
+  }, [liffId, updateLiffProfile, updateLiffTokens, router]);
 
   const liffLogin = useCallback(() => {
     if (!isLiffInitialized) {


### PR DESCRIPTION
Replaced `useInitialLiffRedirect` with `useRouter` and added logic to handle initial path redirection based on URL search parameters. This ensures smoother user navigation when a specific starting path is provided.