### PR TITLE
fix: マーカーのフォーカス挙動と一覧に表示されない拠点があるのを修正

### DIFF
--- a/src/app/places/hooks/usePlaceCards.ts
+++ b/src/app/places/hooks/usePlaceCards.ts
@@ -8,7 +8,7 @@ export default function usePlaceCards() {
   const { data, loading, error, refetch } = useGetPlacesQuery({
     variables: {
       filter: {},
-      first: 50,
+      first: 100,
       IsCard: true,
     },
     fetchPolicy: "cache-and-network",


### PR DESCRIPTION
## 解決した事象
1. マーカーをクリックしたら、意図しないカードが表示される
2. 拠点一覧に表示されない拠点がある

## アプローチ 
- 1. ユーザーの操作によらないカルーセルの選択を判別し、処理を出し分けるようにした
  - 理由：PlaceCardsSheet.tsxのuseEffect内で、カルーセルの選択が変わるたびにonPlaceSelectが呼び出されていた。これにより、マーカーをクリックした後にカルーセルが更新され、その後カルーセルのselectイベントが発火して別のマーカーが選択されていた。
- 2. 50件までしか取得していなかったので、100件まで取得するようにした。