### PR TITLE
fix: label for external booking on activity detail

### DIFF
--- a/src/app/activities/[id]/components/ActivityDetailsContent.tsx
+++ b/src/app/activities/[id]/components/ActivityDetailsContent.tsx
@@ -208,8 +208,8 @@ const ScheduleSection = ({
     <>
       <p className="text-muted-foreground font-bold mb-4 px-1">※予約は各日程の7日前まで受付中 </p>
       <div className="flex overflow-x-auto gap-4 pb-4 scrollbar-hide px-4 -mx-4">
-        {slots.map((slot, index) => (
-          <div key={index} className="flex-shrink-0 first:ml-0">
+        {slots.map((slot) => (
+          <div key={slot.id} className="flex-shrink-0 first:ml-0">
             <ActivityScheduleCard
               slot={slot}
               opportunityId={opportunityId}

--- a/src/app/activities/[id]/components/ActivityDetailsContent.tsx
+++ b/src/app/activities/[id]/components/ActivityDetailsContent.tsx
@@ -30,6 +30,11 @@ interface ActivityDetailsContentProps {
   isExternalBooking: boolean;
 }
 
+// NOTE: キャンセルの注意事項を表示しない例外的な体験のID
+const HIDE_CANCEL_NOTICE_OPPORTUNITY_IDS = [
+  "cmap6xqwn001os60nllhcq65s", // 【直接予約】手島で摘む、夏だけのブラックベリー https://www.neo88.app/activities/cmap6xqwn001os60nllhcq65s?community_id=neo88
+];
+
 const ActivityDetailsContent = ({
   opportunity,
   availableTickets,
@@ -49,7 +54,10 @@ const ActivityDetailsContent = ({
         communityId={communityId}
         isExternalBooking={isExternalBooking}
       />
-      <NoticeSection isExternalBooking={isExternalBooking} />
+      <NoticeSection
+        hideCancelNotice={HIDE_CANCEL_NOTICE_OPPORTUNITY_IDS.includes(opportunity.id)}
+        isExternalBooking={isExternalBooking}
+      />
       <SameStateActivities
         header={"近くでおすすめの体験"}
         opportunities={sameStateActivities}
@@ -250,7 +258,10 @@ const ScheduleSection = ({
   );
 };
 
-const NoticeSection: React.FC<{ isExternalBooking: boolean }> = ({ isExternalBooking }) => {
+const NoticeSection: React.FC<{ isExternalBooking: boolean; hideCancelNotice: boolean }> = ({
+  isExternalBooking,
+  hideCancelNotice,
+}) => {
   const commonNotices = [
     {
       text: "ホストによる確認後に、予約が確定します。",
@@ -287,7 +298,7 @@ const NoticeSection: React.FC<{ isExternalBooking: boolean }> = ({ isExternalBoo
   const noticesToShow = [
     ...commonNotices.slice(0, 1),
     ...(isExternalBooking ? externalBookingNotices : normalBookingNotices),
-    ...commonNotices.slice(1),
+    ...(hideCancelNotice ? [] : commonNotices.slice(1)),
   ];
 
   return (

--- a/src/app/activities/[id]/components/ActivityDetailsContent.tsx
+++ b/src/app/activities/[id]/components/ActivityDetailsContent.tsx
@@ -27,6 +27,7 @@ interface ActivityDetailsContentProps {
   availableDates: ActivitySlot[];
   sameStateActivities: ActivityCard[];
   communityId?: string;
+  isExternalBooking: boolean;
 }
 
 const ActivityDetailsContent = ({
@@ -35,6 +36,7 @@ const ActivityDetailsContent = ({
   availableDates,
   sameStateActivities,
   communityId = "",
+  isExternalBooking,
 }: ActivityDetailsContentProps) => {
   return (
     <>
@@ -45,8 +47,9 @@ const ActivityDetailsContent = ({
         slots={availableDates}
         opportunityId={opportunity.id}
         communityId={communityId}
+        isExternalBooking={isExternalBooking}
       />
-      <NoticeSection />
+      <NoticeSection isExternalBooking={isExternalBooking} />
       <SameStateActivities
         header={"近くでおすすめの体験"}
         opportunities={sameStateActivities}
@@ -179,10 +182,12 @@ const ScheduleSection = ({
   slots,
   opportunityId,
   communityId,
+  isExternalBooking,
 }: {
   slots: ActivitySlot[];
   opportunityId: string;
   communityId: string;
+  isExternalBooking: boolean;
 }) => {
   const query = new URLSearchParams({
     id: opportunityId,
@@ -191,79 +196,114 @@ const ScheduleSection = ({
 
   const hasSchedule = slots.length > 0;
 
+  const renderScheduleContent = () => (
+    <>
+      <p className="text-muted-foreground font-bold mb-4 px-1">※予約は各日程の7日前まで受付中 </p>
+      <div className="flex overflow-x-auto gap-4 pb-4 scrollbar-hide px-4 -mx-4">
+        {slots.map((slot, index) => (
+          <div key={index} className="flex-shrink-0 first:ml-0">
+            <ActivityScheduleCard
+              slot={slot}
+              opportunityId={opportunityId}
+              communityId={communityId}
+            />
+          </div>
+        ))}
+      </div>
+      <Link href={`/reservation/select-date?${query.toString()}`}>
+        <Button variant="secondary" size="md" className="w-full">
+          参加できる日程を探す
+        </Button>
+      </Link>
+    </>
+  );
+
+  const renderEmptyScheduleMessage = () => {
+    const messageContent = isExternalBooking
+      ? {
+          title: "日程は別途ご確認ください",
+          description:
+            "ページ上部の「体験できること」にある電話番号または外部リンクよりご確認ください",
+        }
+      : {
+          title: "現在予定されている日程はありません",
+          description:
+            "日程はまだ登録されていません。後日再度確認するか、主催者にお問い合わせください。",
+        };
+
+    return (
+      <div className="text-center py-8 px-4 bg-card rounded-lg border border-muted/20 flex flex-col items-center">
+        <CalendarX className="h-12 w-12 text-muted-foreground/50 mb-3" />
+        <p className="text-body-lg font-medium text-foreground">{messageContent.title}</p>
+        <p className="text-body-sm text-caption mt-2 max-w-xs">{messageContent.description}</p>
+      </div>
+    );
+  };
+
   return (
     <section className="pt-6 pb-8 mt-0">
       <h2 className="text-display-md text-foreground mb-4">開催日</h2>
       <div className="relative">
-        {hasSchedule ? (
-          <>
-            <p className="text-muted-foreground font-bold mb-4 px-1">
-              ※予約は各日程の7日前まで受付中{" "}
-            </p>
-            <div className="flex overflow-x-auto gap-4 pb-4 scrollbar-hide px-4 -mx-4">
-              {slots.map((slot, index) => (
-                <div key={index} className="flex-shrink-0 first:ml-0">
-                  <ActivityScheduleCard
-                    slot={slot}
-                    opportunityId={opportunityId}
-                    communityId={communityId}
-                  />
-                </div>
-              ))}
-            </div>
-            <Link href={`/reservation/select-date?${query.toString()}`}>
-              <Button variant="secondary" size="md" className="w-full">
-                参加できる日程を探す
-              </Button>
-            </Link>
-          </>
-        ) : (
-          <div className="text-center py-8 px-4 bg-card rounded-lg border border-muted/20 flex flex-col items-center">
-            <CalendarX className="h-12 w-12 text-muted-foreground/50 mb-3" />
-            <p className="text-body-lg font-medium text-foreground">
-              現在予定されている日程はありません
-            </p>
-            <p className="text-body-sm text-caption mt-2 max-w-xs">
-              日程はまだ登録されていません。後日再度確認するか、主催者にお問い合わせください。
-            </p>
-          </div>
-        )}
+        {hasSchedule ? renderScheduleContent() : renderEmptyScheduleMessage()}
       </div>
     </section>
   );
 };
 
-const NoticeSection: React.FC = () => {
+const NoticeSection: React.FC<{ isExternalBooking: boolean }> = ({ isExternalBooking }) => {
+  const commonNotices = [
+    {
+      text: "ホストによる確認後に、予約が確定します。",
+      isBold: true,
+    },
+    {
+      text: "キャンセルは開催日の7日前まで可能です。",
+      isBold: false,
+    },
+  ];
+
+  const externalBookingNotices = [
+    {
+      text: "日程の確定、もしくは中止の連絡方法は、事前にご確認ください。",
+      isBold: false,
+    },
+    {
+      text: "支払い方法は、事前にご確認ください。",
+      isBold: false,
+    },
+  ];
+
+  const normalBookingNotices = [
+    {
+      text: "実施確定または中止のどちらの場合でも、公式LINEからご連絡します。",
+      isBold: false,
+    },
+    {
+      text: "当日は現金をご用意下さい。",
+      isBold: false,
+    },
+  ];
+
+  const noticesToShow = [
+    ...commonNotices.slice(0, 1),
+    ...(isExternalBooking ? externalBookingNotices : normalBookingNotices),
+    ...commonNotices.slice(1),
+  ];
+
   return (
     <section className="pt-6 pb-8 mt-0 bg-background-hover -mx-4 px-4">
       <h2 className="text-display-md text-foreground mb-4">注意事項</h2>
       <div className="space-y-4">
-        <div className="flex items-center gap-3">
-          <IconWrapper color="warning">
-            <AlertCircle size={20} strokeWidth={2.5} />
-          </IconWrapper>
-          <p className="text-body-md flex-1 font-bold">ホストによる確認後に、予約が確定します。</p>
-        </div>
-        <div className="flex items-center gap-3">
-          <IconWrapper color="warning">
-            <AlertCircle size={20} strokeWidth={2.5} />
-          </IconWrapper>
-          <p className="text-body-md flex-1">
-            実施確定または中止のどちらの場合でも、公式LINEからご連絡します。
-          </p>
-        </div>
-        <div className="flex items-center gap-3">
-          <IconWrapper color="warning">
-            <AlertCircle size={20} strokeWidth={2.5} />
-          </IconWrapper>
-          <p className="text-body-md flex-1">当日は現金をご用意下さい。</p>
-        </div>
-        <div className="flex items-center gap-3">
-          <IconWrapper color="warning">
-            <AlertCircle size={20} strokeWidth={2.5} />
-          </IconWrapper>
-          <p className="text-body-md flex-1">キャンセルは開催日の7日前まで可能です。</p>
-        </div>
+        {noticesToShow.map((notice, index) => (
+          <div key={index} className="flex items-center gap-3">
+            <IconWrapper color="warning">
+              <AlertCircle size={20} strokeWidth={2.5} />
+            </IconWrapper>
+            <p className={`text-body-md flex-1 ${notice.isBold ? "font-bold" : ""}`}>
+              {notice.text}
+            </p>
+          </div>
+        ))}
       </div>
     </section>
   );

--- a/src/app/activities/[id]/components/ActivityDetailsFooter.tsx
+++ b/src/app/activities/[id]/components/ActivityDetailsFooter.tsx
@@ -5,12 +5,20 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { COMMUNITY_ID } from "@/utils";
 
+export type DisableReasonType = "noSlots" | "reservationClosed" | "externalBooking";
+
 interface ActivityDetailsFooterProps {
   opportunityId: string;
   price: number | null;
   communityId: string | undefined;
-  disableReason?: "noSlots" | "reservationClosed";
+  disableReason?: DisableReasonType;
 }
+
+const DISABLE_MESSAGES = {
+  noSlots: "開催日未定",
+  reservationClosed: "受付終了",
+  externalBooking: "直接お問い合わせ",
+} as const;
 
 const ActivityDetailsFooter: React.FC<ActivityDetailsFooterProps> = ({
   opportunityId,
@@ -23,6 +31,24 @@ const ActivityDetailsFooter: React.FC<ActivityDetailsFooterProps> = ({
     community_id: communityId ?? COMMUNITY_ID,
   });
 
+  const renderActionElement = () => {
+    if (disableReason && disableReason in DISABLE_MESSAGES) {
+      return (
+        <p className="text-muted-foreground text-body-md">
+          {DISABLE_MESSAGES[disableReason as keyof typeof DISABLE_MESSAGES]}
+        </p>
+      );
+    }
+
+    return (
+      <Link href={`/reservation/select-date?${query.toString()}`}>
+        <Button variant="primary" size="lg" className="px-8">
+          日付を選択
+        </Button>
+      </Link>
+    );
+  };
+
   return (
     <footer className="fixed bottom-0 left-0 right-0 bg-background border-t z-50">
       <div className="max-w-mobile-l mx-auto px-4 h-20 flex items-center justify-between w-full">
@@ -34,17 +60,7 @@ const ActivityDetailsFooter: React.FC<ActivityDetailsFooterProps> = ({
             {price != null ? `${price.toLocaleString()}円〜` : "料金未定"}
           </p>
         </div>
-        {disableReason === "noSlots" ? (
-          <p className="text-muted-foreground text-body-md">開催日未定</p>
-        ) : disableReason === "reservationClosed" ? (
-          <p className="text-muted-foreground text-body-md">受付終了</p>
-        ) : (
-          <Link href={`/reservation/select-date?${query.toString()}`}>
-            <Button variant="primary" size="lg" className="px-8">
-              日付を選択
-            </Button>
-          </Link>
-        )}
+        {renderActionElement()}
       </div>
     </footer>
   );


### PR DESCRIPTION
- LINE を使わず予約をする場合の表記変更（予約できないと勘違いされないように）

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/5acf2a99-02c5-459e-8750-a2db6c7e4d4c) | ![image](https://github.com/user-attachments/assets/bb77bbb9-81d9-4703-9998-df22dc8d1ce2) |

- キャンセルについての注意書きを非表示にできるように（特定のケースで要望があり）

![image](https://github.com/user-attachments/assets/a0416dac-eb7d-4ae5-bd47-98fb48a9a2ec)
