### PR TITLE
fix: reversable place item order

### DIFF
--- a/src/app/places/[id]/components/PlaceFeaturedArticle.tsx
+++ b/src/app/places/[id]/components/PlaceFeaturedArticle.tsx
@@ -8,17 +8,21 @@ import { TArticleWithAuthor } from "@/app/articles/data/type";
 import ArticleCard from "@/app/articles/components/Card";
 
 interface PlaceFeaturedArticleProps {
-  article: TArticleWithAuthor | null;
+  articles: TArticleWithAuthor[] | null;
 }
 
 //TODO 複数記事が並ぶはず、Figma参照
-const PlaceFeaturedArticle: React.FC<PlaceFeaturedArticleProps> = ({ article }) => {
-  if (!article) return null;
+const PlaceFeaturedArticle: React.FC<PlaceFeaturedArticleProps> = ({ articles }) => {
+  if (!articles) return null;
 
   return (
     <div className="px-4 pt-6 pb-8 max-w-mobile-l mx-auto space-y-4">
       <h2 className="text-display-sm mb-4">関連記事</h2>
-      <ArticleCard article={article} showUser />
+      <div className="grid grid-cols-1 gap-6">
+        {articles.map((article) => (
+          <ArticleCard key={article.id} article={article} showUser />
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/app/places/[id]/page.tsx
+++ b/src/app/places/[id]/page.tsx
@@ -38,7 +38,7 @@ const PlaceDetail: FC = () => {
         <PlaceOverview detail={place} />
         <PlaceAddress detail={place} />
         <PlaceOpportunities opportunities={place.currentlyHiringOpportunities} />
-        <PlaceFeaturedArticle article={place.relatedArticles?.[0]} />
+        <PlaceFeaturedArticle articles={place.relatedArticles} />
       </div>
     </>
   );


### PR DESCRIPTION
拠点に複数人の案内人の体験が掲載されている場合、意図しない順序で表示されていることがある

簡易的に順序を逆にすることで解決する

例）https://www.neo88.app/places/cmahru0gg001vs60nnkqrgugc
- オーナーの方のインタビューや体験が最初に表示されていない
- マップの画像で見た時もパッと分からない

根本対応ではないが、今後同じようなケースがあれば `REVERSE_ORDER_PLACE_IDS` に ID を追加すれば対応可能