### PR TITLE
Update phoneNumber prop to use opportunity creator info

### DIFF
--- a/src/app/reservation/complete/page.tsx
+++ b/src/app/reservation/complete/page.tsx
@@ -87,7 +87,7 @@ export default function CompletePage() {
             totalPrice={dateTimeInfo.totalPrice}
             pricePerPerson={opportunity.feeRequired ?? 0}
             location={oppotunityDetail?.place}
-            phoneNumber={reservation.createdByUser?.phoneNumber}
+            phoneNumber={reservation.opportunitySlot?.opportunity?.createdByUser?.phoneNumber}
             isReserved={true}
           />
         </div>


### PR DESCRIPTION
This pull request updates the `phoneNumber` prop logic to utilize the phone number of the opportunity's creator instead of the reservation's creator. This ensures the displayed contact information is accurate and relevant.