### PR TITLE
Update logging imports and remove problematic CSS setting

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -40,8 +40,6 @@ const nextConfig = {
     webpackBuildWorker: true,
     parallelServerBuildTraces: true,
     parallelServerCompiles: true,
-    optimizeCss: true,
-    gzipSize: true,
   },
   compress: true,
   webpack(config) {

--- a/src/lib/logging/client/utils.ts
+++ b/src/lib/logging/client/utils.ts
@@ -11,7 +11,7 @@ let serverUtils: any = null;
 
 if (typeof window === "undefined") {
   try {
-    serverUtils = require("./logging-utils-server");
+    serverUtils = require("../server/utils");
   } catch (e) {
     console.warn("Failed to load server logging utilities:", e);
   }


### PR DESCRIPTION
### Summary

- Refactored the server logging utilities' import path to match the correct file structure and ensure proper module resolution.
- Removed the `optimizeCss` setting from the configuration, which previously caused an error with the `critters` module.