### PR TITLE
Firebase初期化処理の改善: 予約完了ページのエラーを修正

### DIFF
--- a/src/lib/auth/firebase-config.ts
+++ b/src/lib/auth/firebase-config.ts
@@ -37,7 +37,20 @@ export const getFirebaseAnalytics = async (): Promise<Analytics | undefined> => 
   return analyticsInstance;
 };
 
-export const analytics = await getFirebaseAnalytics();
+// Initialize analytics as null initially
+export let analytics: Analytics | null = null;
+
+// Initialize analytics asynchronously but don't block
+(async () => {
+  try {
+    analytics = (await getFirebaseAnalytics()) || null;
+  } catch (error) {
+    logger.error("Failed to initialize analytics", {
+      component: "FirebaseConfig",
+      error,
+    });
+  }
+})();
 
 /**
  * Firebase認証エラーを分類する


### PR DESCRIPTION
## 概要
予約完了ページで発生していた「Firebase: No Firebase App '[DEFAULT]' has been created - call initializeApp() first (app/no-app)」というエラーを修正しました。

## 変更内容
- Firebase analyticsの初期化方法を改善
  - トップレベルのawaitを使用する代わりに、非同期の自己実行関数を使用
  - 初期化中のエラーハンドリングを追加
  - analytics変数を最初にnullとして初期化し、非同期で値を設定するパターンに変更

## 技術的な詳細
- クライアントコンポーネントでのFirebase初期化タイミングの問題を解決
- useAnalytics フックは既にanalyticsがnullの場合のチェックを行っているため、互換性を維持
- 非ブロッキングな初期化により、アプリケーションのパフォーマンスへの影響を最小限に抑制

## テスト方法
- [x] 予約完了ページにアクセスし、エラーが発生しないことを確認
- [x] アナリティクスイベントが正常に送信されることを確認（開発者ツールのネットワークタブで確認可能）

## 関連する問題
予約完了ページでFirebaseエラーが発生する問題
