### PR TITLE
Set fetch limit to 500 for wallet data queries

### DIFF
--- a/src/app/admin/wallet/grant/page.tsx
+++ b/src/app/admin/wallet/grant/page.tsx
@@ -32,6 +32,7 @@ export default function GrantPointStepperPage() {
       await fetchMore({
         variables: {
           filter: { communityId: COMMUNITY_ID },
+          first: 500,
           after: endCursor,
         },
       });

--- a/src/app/wallets/donate/page.tsx
+++ b/src/app/wallets/donate/page.tsx
@@ -104,6 +104,7 @@ export default function DonatePointPage() {
       await fetchMore({
         variables: {
           filter: { communityId: COMMUNITY_ID },
+          first: 500,
           after: endCursor,
         },
       });


### PR DESCRIPTION
Added `first: 500` to the `fetchMore` function in both donation and grant wallet components to ensure that a maximum of 500 records are retrieved per query. This improves data handling consistency across components.