### PR TITLE
予約・キャンセル期限を「開催前日23:59 JST」に変更

### DIFF
--- a/src/app/admin/reservations/components/CancelReservationSheet.tsx
+++ b/src/app/admin/reservations/components/CancelReservationSheet.tsx
@@ -48,7 +48,7 @@ const CancelReservationSheet: React.FC<CancelReservationSheetProps> = ({
                 {cancelLoading ? "処理中..." : "開催中止"}
               </Button>
               <p className="text-sm text-muted-foreground text-center">
-                開催の24時間前まで、アプリから中止操作が可能です。
+                開催前日の23:59まで、アプリから中止操作が可能です。
               </p>
             </div>
           </SheetTrigger>

--- a/src/app/reservation/data/presenter/opportunitySlot.ts
+++ b/src/app/reservation/data/presenter/opportunitySlot.ts
@@ -4,16 +4,15 @@ import { ActivitySlot, ActivitySlotGroup } from "@/app/reservation/data/type/opp
 import { addDays, isAfter } from "date-fns";
 
 /**
- * 予約可能日数（現在時刻から何日後まで予約可能か）
- */
-export const RESERVATION_THRESHOLD_DAYS = 1;
-
-/**
- * 予約可能判定のための閾値（現在時刻から何日後まで予約可能か）を返す
+ * 予約可能判定のための閾値（前日23:59 JSTまで予約可能）を返す
  * @returns 予約可能判定のための閾値
  */
 export const getReservationThreshold = (): Date => {
-  return addDays(new Date(), RESERVATION_THRESHOLD_DAYS);
+  const now = new Date();
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(0, 0, 0, 0); // 翌日の00:00:00に設定（JSTで前日の23:59まで予約可能）
+  return tomorrow;
 };
 
 /**

--- a/src/app/reservation/data/presenter/reservation.ts
+++ b/src/app/reservation/data/presenter/reservation.ts
@@ -24,8 +24,9 @@ export const getTicketIds = (
   ticketCount: number,
 ) => {
   return (
-    wallets?.find(w => w.community?.id === getCommunityIdFromEnv())?.tickets
-      ?.filter((edge: GqlTicket) => {
+    wallets
+      ?.find((w) => w.community?.id === getCommunityIdFromEnv())
+      ?.tickets?.filter((edge: GqlTicket) => {
         if (!requiredUtilities?.length) return true;
         const utilityId = edge?.utility?.id;
         return utilityId && requiredUtilities.some((u) => u.id === utilityId);
@@ -101,14 +102,22 @@ const getIsCancelable = (startsAt?: Date | null): boolean => {
   if (!startsAt) return false;
 
   const now = new Date();
-  const diff = startsAt.getTime() - now.getTime();
-  return diff >= 24 * 60 * 60 * 1000; // 24時間以上あるか
+
+  // 開催日の0時0分0秒を取得（前日23:59:59までキャンセル可能）
+  const cancelDeadline = new Date(startsAt);
+  cancelDeadline.setHours(0, 0, 0, 0);
+
+  return now < cancelDeadline;
 };
 
 const getCancelDue = (startsAt?: Date | null): string | undefined => {
   if (!startsAt) return undefined;
 
-  const cancelDate = new Date(startsAt.getTime() - 24 * 60 * 60 * 1000);
+  // 開催日の前日23:59:59を計算
+  const cancelDate = new Date(startsAt);
+  cancelDate.setHours(0, 0, 0, 0); // 開催日の0時0分0秒
+  cancelDate.setMilliseconds(-1); // 1ミリ秒前 = 前日の23:59:59.999
+
   return cancelDate.toISOString();
 };
 


### PR DESCRIPTION
## 変更内容

予約およびキャンセルの期限を「開催の24時間前まで」から「開催前日23:59 JST」に変更しました。

### 技術的な変更点

1. **予約締め切りの変更**
   - getReservationThreshold 関数を修正し、開催日の前日23:59 JSTまで予約可能に変更
   - 関連するコメントを更新

2. **キャンセルポリシーの変更**
   - getIsCancelable 関数と getCancelDue 関数を修正し、開催日の前日23:59 JSTまでキャンセル可能に変更
   - 関連するコメントを更新

3. **UI表示の更新**
   - 管理画面のキャンセル説明文を「開催前日の23:59まで、アプリから中止操作が可能です」に更新

## 変更理由
- 「24時間前」という時間指定よりも「前日23:59まで」という日付指定の方がユーザーにとって直感的でわかりやすい
- 日付が変わるタイミング（23:59）で区切ることで、予約・キャンセル期限がより明確になる
- 運営側とユーザー側の両方にとって、予約状況の把握がしやすくなる

## 影響範囲
- 予約可能判定のロジック
- キャンセル可能判定のロジック
- 管理画面の説明文

## テスト項目
- [ ] 開催日の前日23:59までに予約が可能であることを確認
- [ ] 開催日当日0:00以降は予約ができないことを確認
- [ ] 開催日の前日23:59までにキャンセルが可能であることを確認
- [ ] 開催日当日0:00以降はキャンセルができないことを確認