### PR TITLE
OpportunityCardコンポーネントのスタイルを調整し、DID発行リクエストのステータスチェックを改善。

### DIFF
--- a/src/app/admin/credentials/components/opportunity/OpportunityCard.tsx
+++ b/src/app/admin/credentials/components/opportunity/OpportunityCard.tsx
@@ -82,7 +82,7 @@ export function OpportunityCard({
     title ? (
     <div className="flex justify-center">
       <Card
-        className={`w-full max-w-80 transition-colors p-4 flex flex-col rounded-xl border border-gray-200 ${
+        className={`w-full transition-colors p-4 flex flex-col rounded-xl border border-gray-200 min-w-0 truncate ${
           onClick ? "cursor-pointer hover:bg-muted" : "opacity-50 pointer-events-none"
         } ${isSelected ? "border-primary" : ""}`}
         onClick={handleSelect}
@@ -97,7 +97,7 @@ export function OpportunityCard({
             tabIndex={-1}
           />
           <div className="flex-1 min-w-0">
-            <p className="text-base font-bold truncate w-full">{title}</p>
+            <p className="text-base font-bold truncate max-w-[200px]">{title}</p>
             <p className="text-gray-500 text-sm mt-1">参加者数: {data?.participations.totalCount ?? 0}</p>
           </div>
         </div>

--- a/src/app/admin/credentials/components/opportunity/OpportunityCard.tsx
+++ b/src/app/admin/credentials/components/opportunity/OpportunityCard.tsx
@@ -78,29 +78,31 @@ export function OpportunityCard({
     onClick?.();
   }, [participatedUsers, setParticipatedUsers, onClick]);
 
-    return (
-      title ? (
-        <Card
-          className={`transition-colors p-4 flex flex-col rounded-xl border border-gray-200 ${
-            onClick ? "cursor-pointer hover:bg-muted" : "opacity-50 pointer-events-none"
-          } ${isSelected ? "border-primary" : ""}`}
-          onClick={handleSelect}
-        >
-          <div className="flex items-center gap-3">
-            <input
-              type="radio"
-              checked={isSelected}
-              readOnly
-              name={name}
-              className="mr-2 w-5 h-5"
-              tabIndex={-1}
-            />
-            <div className="flex-1 min-w-0">
-              <p className="text-base font-bold truncate max-w-xs">{title}</p>
-              <p className="text-gray-500 text-sm mt-1">参加者数: {data?.participations.totalCount ?? 0}</p>
-            </div>
+  return (
+    title ? (
+    <div className="flex justify-center">
+      <Card
+        className={`w-full max-w-80 transition-colors p-4 flex flex-col rounded-xl border border-gray-200 ${
+          onClick ? "cursor-pointer hover:bg-muted" : "opacity-50 pointer-events-none"
+        } ${isSelected ? "border-primary" : ""}`}
+        onClick={handleSelect}
+      >
+        <div className="flex items-center gap-3">
+          <input
+            type="radio"
+            checked={isSelected}
+            readOnly
+            name={name}
+            className="mr-2 w-5 h-5"
+            tabIndex={-1}
+          />
+          <div className="flex-1 min-w-0">
+            <p className="text-base font-bold truncate w-full">{title}</p>
+            <p className="text-gray-500 text-sm mt-1">参加者数: {data?.participations.totalCount ?? 0}</p>
           </div>
-        </Card>
-      ) : null
+        </div>
+      </Card>
+    </div>
+    ) : null
   );
 }

--- a/src/app/admin/credentials/components/opportunity/OpportunityList.tsx
+++ b/src/app/admin/credentials/components/opportunity/OpportunityList.tsx
@@ -93,7 +93,7 @@ export default function OpportunityList({ setStep }: { setStep: (step: number) =
             キャンセル
           </Button>
           <Button
-            className={`rounded-full px-8 py-2 font-bold text-white ${selectedSlot?.opportunityId ? "bg-primary" : "bg-gray-200 text-gray-400 cursor-not-allowed"}`}
+            className={`rounded-full font-bold text-white ${selectedSlot?.opportunityId ? "bg-primary" : "bg-gray-200 text-gray-400 cursor-not-allowed"}`}
             disabled={!selectedSlot?.opportunityId}
             size="lg"
             onClick={() => {

--- a/src/app/admin/credentials/components/opportunity/OpportunityList.tsx
+++ b/src/app/admin/credentials/components/opportunity/OpportunityList.tsx
@@ -95,6 +95,7 @@ export default function OpportunityList({ setStep }: { setStep: (step: number) =
           <Button
             className={`rounded-full px-8 py-2 font-bold text-white ${selectedSlot?.opportunityId ? "bg-primary" : "bg-gray-200 text-gray-400 cursor-not-allowed"}`}
             disabled={!selectedSlot?.opportunityId}
+            size="lg"
             onClick={() => {
               if (selectedSlot?.opportunityId) {
                 setStep(2); // ステップを進める

--- a/src/app/admin/credentials/components/selectDate/TimeSlotList.tsx
+++ b/src/app/admin/credentials/components/selectDate/TimeSlotList.tsx
@@ -73,7 +73,7 @@ return (
             キャンセル
           </Button>
           <Button
-            className={`rounded-full px-8 py-2 font-bold text-white ${selectedDate ? "bg-primary" : "bg-gray-200 text-gray-400 cursor-not-allowed"}`}
+            className={`rounded-full font-bold text-white ${selectedDate ? "bg-primary" : "bg-gray-200 text-gray-400 cursor-not-allowed"}`}
             disabled={!selectedDate}
             size="lg"
             onClick={() => {

--- a/src/app/admin/credentials/components/selectDate/TimeSlotList.tsx
+++ b/src/app/admin/credentials/components/selectDate/TimeSlotList.tsx
@@ -75,6 +75,7 @@ return (
           <Button
             className={`rounded-full px-8 py-2 font-bold text-white ${selectedDate ? "bg-primary" : "bg-gray-200 text-gray-400 cursor-not-allowed"}`}
             disabled={!selectedDate}
+            size="lg"
             onClick={() => {
               if (selectedDate) {
                 onNext?.();

--- a/src/app/admin/credentials/components/selectUser/CredentialRecipientSelector.tsx
+++ b/src/app/admin/credentials/components/selectUser/CredentialRecipientSelector.tsx
@@ -183,10 +183,10 @@ export default function CredentialRecipientSelector({ setStep }: { setStep: (ste
           <span className={`${STEP_COLORS.GRAY} text-base`}>)</span>
         </span>
       </div>
-      <div className="px-4 mb-4 pt-4">
+      <div className="mb-4 pt-4">
         <SearchForm value={input} onInputChange={setInput} onSearch={setSearchQuery} />
       </div>
-      <div className="flex flex-col gap-4 px-4">
+      <div className="flex flex-col gap-4">
         <SearchResultList
           searchQuery={searchQuery}
           searchMembershipData={formattedMembers}

--- a/src/app/admin/credentials/components/selectUser/CredentialRecipientSelector.tsx
+++ b/src/app/admin/credentials/components/selectUser/CredentialRecipientSelector.tsx
@@ -44,16 +44,23 @@ const sortMembersByParticipation = (
       (u) => u.userId === b.user.id && u.slotId === selectedSlotId
     );
 
-    // isCreatedByUserがtrueのユーザーを最優先で上に
+    // 1. isCreatedByUserがtrueのユーザーを最優先
     if (aParticipated?.isCreatedByUser && !bParticipated?.isCreatedByUser) return -1;
     if (!aParticipated?.isCreatedByUser && bParticipated?.isCreatedByUser) return 1;
 
-    // 参加済みユーザーを上に
+    // 2. 参加済みユーザーを上に
     const aIsParticipated = !!aParticipated;
     const bIsParticipated = !!bParticipated;
     if (aIsParticipated && !bIsParticipated) return -1;
     if (!aIsParticipated && bIsParticipated) return 1;
 
+    // 3. didデータがある人を上に
+    const aHasDid = !!a.user.didInfo?.didValue;
+    const bHasDid = !!b.user.didInfo?.didValue;
+    if (aHasDid && !bHasDid) return -1;
+    if (!aHasDid && bHasDid) return 1;
+
+    // 4. それ以外は順不同
     return 0;
   });
 };
@@ -201,6 +208,7 @@ export default function CredentialRecipientSelector({ setStep }: { setStep: (ste
             </Button>
             <Button
               className={`rounded-full px-8 py-2 font-bold text-white ${selectedUserIds.length > 0 ? "bg-primary" : "bg-gray-200 text-gray-400 cursor-not-allowed"}`}
+              size="lg"
               disabled={selectedUserIds.length === 0}
               onClick={() => {
                 if (selectedUserIds.length > 0) {

--- a/src/app/admin/credentials/components/selectUser/Member.tsx
+++ b/src/app/admin/credentials/components/selectUser/Member.tsx
@@ -33,7 +33,7 @@ export const MemberRow = ({ user, checked, onCheck, isDisabled, reason, didInfo,
   const did = didInfo?.didValue;
   const hasCompletedVcIssuanceRequest =
     !!vcIssuanceRequestsData?.vcIssuanceRequests.edges.find(
-      (edge: any) =>
+      (edge) =>
         edge.node?.evaluation?.participation?.opportunitySlot?.id === selectedSlot?.slotId &&
         edge.node?.status === GqlVcIssuanceStatus.Completed &&
         edge.node?.user?.id === user.id
@@ -41,7 +41,7 @@ export const MemberRow = ({ user, checked, onCheck, isDisabled, reason, didInfo,
 
   const hasProcessingVcIssuanceRequest =
     !!vcIssuanceRequestsData?.vcIssuanceRequests.edges.find(
-      (edge: any) =>
+      (edge) =>
         edge.node?.evaluation?.participation?.opportunitySlot?.id === selectedSlot?.slotId &&
         (edge.node?.status === GqlVcIssuanceStatus.Processing || edge.node?.status === GqlVcIssuanceStatus.Pending) &&
         edge.node?.user?.id === user.id

--- a/src/app/admin/credentials/components/selectUser/Member.tsx
+++ b/src/app/admin/credentials/components/selectUser/Member.tsx
@@ -91,7 +91,7 @@ export const MemberRow = ({ user, checked, onCheck, isDisabled, reason, didInfo,
               指定された募集で証明書発行中
             </span>
           )}
-        <span className={`${did ? "font-bold text-base text-black" : "text-gray-400 text-base"}`}>
+        <span className={`${did ? "font-bold text-base text-black" : "text-gray-400 text-base"} truncate max-w-[160px]`}>
           {user.name}
         </span>
         <span className="text-gray-400 text-sm max-w-[160px]">

--- a/src/app/admin/credentials/components/selectUser/Member.tsx
+++ b/src/app/admin/credentials/components/selectUser/Member.tsx
@@ -43,7 +43,7 @@ export const MemberRow = ({ user, checked, onCheck, isDisabled, reason, didInfo,
     !!vcIssuanceRequestsData?.vcIssuanceRequests.edges.find(
       (edge: any) =>
         edge.node?.evaluation?.participation?.opportunitySlot?.id === selectedSlot?.slotId &&
-        edge.node?.status === GqlVcIssuanceStatus.Processing &&
+        (edge.node?.status === GqlVcIssuanceStatus.Processing || edge.node?.status === GqlVcIssuanceStatus.Pending) &&
         edge.node?.user?.id === user.id
     );
 

--- a/src/app/admin/credentials/components/selectUser/Member.tsx
+++ b/src/app/admin/credentials/components/selectUser/Member.tsx
@@ -9,6 +9,7 @@ import { PLACEHOLDER_IMAGE } from "@/utils";
 import { Input } from "@/components/ui/input";
 import { useSelection } from "../../context/SelectionContext";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Card } from "@/components/ui/card";
 
 interface Props {
   user: GqlUser & { didInfo?: GqlDidIssuanceRequest };
@@ -50,8 +51,8 @@ export const MemberRow = ({ user, checked, onCheck, isDisabled, reason, didInfo,
   const cardBgClass = !did || isDisabled ? "bg-zinc-200" : "bg-white";
 
   return (
-    <div
-      className={`flex items-center border border-gray-200 rounded-xl px-4 py-3 w-full max-w-lg ${cardBgClass}`}
+    <Card
+      className={`flex items-center gap-3 rounded-xl border transition-colors px-4 py-3 cursor-pointer ${cardBgClass}`}
     >
       {/* チェックボックス */}
       <Input
@@ -71,7 +72,7 @@ export const MemberRow = ({ user, checked, onCheck, isDisabled, reason, didInfo,
       </Avatar>
       {/* ユーザー情報 */}
       {/* isDisabledはタップ不可になる可能性のフラグ*/}
-      <div className="flex flex-col ml-4 min-w-0">
+      <div className="flex flex-col ml-4">
         {isDisabled && reason === GqlParticipationStatusReason.ReservationAccepted && (
           <span className="text-green-500 text-xs font-semibold mb-1">
             指定された募集に申込済み
@@ -94,10 +95,10 @@ export const MemberRow = ({ user, checked, onCheck, isDisabled, reason, didInfo,
         <span className={`${did ? "font-bold text-base text-black" : "text-gray-400 text-base"} truncate max-w-[160px]`}>
           {user.name}
         </span>
-        <span className="text-gray-400 text-sm max-w-[160px]">
+        <span className="text-gray-400 text-sm max-w-[200px]">
           {did ? truncateDid(did, 20) : "did発行中"}
         </span>
       </div>
-    </div>
+    </Card>
   );
 };


### PR DESCRIPTION
------------------------------------------------------------
- 発行先を選ぶ画面
  - 右下の発行ボタンサイズが小さい、たぶんleargeが正：完了
  - didがはみ出ている：完了
  - 自分のdidが表示されている（適切）が、理由表示されないまま選択不可になっている：一部完了
    - vcでProcessingは条件に入っていたがPendingが入っていなかったため発行した際に一番最初に選択されたユーザーにしかvcが発行されていないため1人しか理由がつかない、だがparticipationはあるため選択不可の状態になってる：vcが1人しか発行されない問題解決後に解消
   - did発行されてるやつから上から優先表示できると良い：完了
- 募集を選ぶ画面
  - 募集の横幅が見切れている：完了
 ------------------------------------------------------------

![スクリーンショット 2025-07-06 6 40 12](https://github.com/user-attachments/assets/1a848d83-92ae-48b4-aa81-c49ea988c04e)

![スクリーンショット 2025-07-06 6 40 43](https://github.com/user-attachments/assets/d9d694ce-bfa7-4691-862d-c2d6178e4e4e)
