### PR TITLE
Refactor GraphQL schema for BigInt and portfolio support

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -25,7 +25,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "BigInt",
                 "ofType": null
               }
             },
@@ -1345,6 +1345,17 @@
       },
       {
         "kind": "SCALAR",
+        "name": "BigInt",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
         "name": "Boolean",
         "description": "The `Boolean` scalar type represents `true` or `false`.",
         "isOneOf": null,
@@ -2510,7 +2521,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "BigInt",
                 "ofType": null
               }
             },
@@ -2932,6 +2943,11 @@
           {
             "kind": "OBJECT",
             "name": "PlaceEdge",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "PortfolioEdge",
             "ofType": null
           },
           {
@@ -13226,6 +13242,132 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "PortfolioEdge",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Portfolio",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Edge",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PortfolioFilterInput",
+        "description": null,
+        "isOneOf": false,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "communityIds",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dateRange",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateTimeRangeFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "keyword",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PortfolioSortInput",
+        "description": null,
+        "isOneOf": false,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "date",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "PortfolioSource",
         "description": null,
@@ -13247,6 +13389,74 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PortfoliosConnection",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PortfolioEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -14349,6 +14559,63 @@
                 "kind": "OBJECT",
                 "name": "PlacesConnection",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "portfolios",
+            "description": null,
+            "args": [
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PortfolioFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PortfolioSortInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Portfolio",
+                  "ofType": null
+                }
               }
             },
             "isDeprecated": false,
@@ -19890,7 +20157,56 @@
           {
             "name": "portfolios",
             "description": null,
-            "args": [],
+            "args": [
+              {
+                "name": "cursor",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PortfolioFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PortfolioSortInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "LIST",
               "name": null,

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -19,6 +19,7 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean };
   Int: { input: number; output: number };
   Float: { input: number; output: number };
+  BigInt: { input: any; output: any };
   DateTime: { input: any; output: any };
   Datetime: { input: Date; output: Date };
   Decimal: { input: any; output: any };
@@ -28,7 +29,7 @@ export type Scalars = {
 
 export type GqlAccumulatedPointView = {
   __typename?: "AccumulatedPointView";
-  accumulatedPoint: Scalars["Int"]["output"];
+  accumulatedPoint: Scalars["BigInt"]["output"];
   walletId?: Maybe<Scalars["String"]["output"]>;
 };
 
@@ -292,7 +293,7 @@ export type GqlCommunityUpdateProfileSuccess = {
 
 export type GqlCurrentPointView = {
   __typename?: "CurrentPointView";
-  currentPoint: Scalars["Int"]["output"];
+  currentPoint: Scalars["BigInt"]["output"];
   walletId?: Maybe<Scalars["String"]["output"]>;
 };
 
@@ -1550,12 +1551,35 @@ export const GqlPortfolioCategory = {
 } as const;
 
 export type GqlPortfolioCategory = (typeof GqlPortfolioCategory)[keyof typeof GqlPortfolioCategory];
+export type GqlPortfolioEdge = GqlEdge & {
+  __typename?: "PortfolioEdge";
+  cursor: Scalars["String"]["output"];
+  node?: Maybe<GqlPortfolio>;
+};
+
+export type GqlPortfolioFilterInput = {
+  communityIds?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+  dateRange?: InputMaybe<GqlDateTimeRangeFilter>;
+  keyword?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type GqlPortfolioSortInput = {
+  date?: InputMaybe<GqlSortDirection>;
+};
+
 export const GqlPortfolioSource = {
   Article: "ARTICLE",
   Opportunity: "OPPORTUNITY",
 } as const;
 
 export type GqlPortfolioSource = (typeof GqlPortfolioSource)[keyof typeof GqlPortfolioSource];
+export type GqlPortfoliosConnection = {
+  __typename?: "PortfoliosConnection";
+  edges: Array<GqlPortfolioEdge>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars["Int"]["output"];
+};
+
 export const GqlPublishStatus = {
   CommunityInternal: "COMMUNITY_INTERNAL",
   Private: "PRIVATE",
@@ -1588,6 +1612,7 @@ export type GqlQuery = {
   participations: GqlParticipationsConnection;
   place?: Maybe<GqlPlace>;
   places: GqlPlacesConnection;
+  portfolios?: Maybe<Array<GqlPortfolio>>;
   reservation?: Maybe<GqlReservation>;
   reservationHistories: GqlReservationHistoriesConnection;
   reservationHistory?: Maybe<GqlReservationHistory>;
@@ -1730,6 +1755,12 @@ export type GqlQueryPlacesArgs = {
   filter?: InputMaybe<GqlPlaceFilterInput>;
   first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<GqlPlaceSortInput>;
+};
+
+export type GqlQueryPortfoliosArgs = {
+  filter?: InputMaybe<GqlPortfolioFilterInput>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  sort?: InputMaybe<GqlPortfolioSortInput>;
 };
 
 export type GqlQueryReservationArgs = {
@@ -2399,6 +2430,13 @@ export type GqlUser = {
   wallets?: Maybe<Array<GqlWallet>>;
 };
 
+export type GqlUserPortfoliosArgs = {
+  cursor?: InputMaybe<Scalars["String"]["input"]>;
+  filter?: InputMaybe<GqlPortfolioFilterInput>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  sort?: InputMaybe<GqlPortfolioSortInput>;
+};
+
 export type GqlUserDeletePayload = {
   __typename?: "UserDeletePayload";
   userId?: Maybe<Scalars["ID"]["output"]>;
@@ -2642,46 +2680,6 @@ export type GqlWalletsConnection = {
   edges?: Maybe<Array<Maybe<GqlWalletEdge>>>;
   pageInfo: GqlPageInfo;
   totalCount: Scalars["Int"]["output"];
-};
-
-export type GqlTicketClaimLinksQueryVariables = Exact<{
-  filter?: InputMaybe<GqlTicketClaimLinkFilterInput>;
-  sort?: InputMaybe<GqlTicketClaimLinkSortInput>;
-  cursor?: InputMaybe<Scalars["String"]["input"]>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
-}>;
-
-export type GqlTicketClaimLinksQuery = {
-  __typename?: "Query";
-  ticketClaimLinks: {
-    __typename?: "TicketClaimLinksConnection";
-    totalCount: number;
-    edges?: Array<{
-      __typename?: "TicketClaimLinkEdge";
-      cursor: string;
-      node?: {
-        __typename?: "TicketClaimLink";
-        id: string;
-        status: GqlClaimLinkStatus;
-        qty: number;
-        claimedAt?: Date | null;
-        createdAt?: Date | null;
-        issuer?: {
-          __typename?: "TicketIssuer";
-          id: string;
-          owner?: { __typename?: "User"; id: string; name: string; image?: string | null } | null;
-        } | null;
-        tickets?: Array<{ __typename?: "Ticket"; status: GqlTicketStatus }> | null;
-      } | null;
-    } | null> | null;
-    pageInfo: {
-      __typename?: "PageInfo";
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: string | null;
-      endCursor?: string | null;
-    };
-  };
 };
 
 export type GqlCommunityFieldsFragment = {
@@ -3146,7 +3144,7 @@ export type GqlGetUserFlexibleQuery = {
         reason: GqlTicketStatusReason;
         status: GqlTicketStatus;
       }> | null;
-      currentPointView?: { __typename?: "CurrentPointView"; currentPoint: number } | null;
+      currentPointView?: { __typename?: "CurrentPointView"; currentPoint: any } | null;
     }> | null;
     opportunitiesCreatedByMe?: Array<{
       __typename?: "Opportunity";
@@ -3244,7 +3242,7 @@ export type GqlGetUserWalletQuery = {
             name?: string | null;
             image?: string | null;
           } | null;
-          currentPointView?: { __typename?: "CurrentPointView"; currentPoint: number } | null;
+          currentPointView?: { __typename?: "CurrentPointView"; currentPoint: any } | null;
         } | null;
         toWallet?: {
           __typename?: "Wallet";
@@ -3269,7 +3267,7 @@ export type GqlGetUserWalletQuery = {
             name?: string | null;
             image?: string | null;
           } | null;
-          currentPointView?: { __typename?: "CurrentPointView"; currentPoint: number } | null;
+          currentPointView?: { __typename?: "CurrentPointView"; currentPoint: any } | null;
         } | null;
       }> | null;
       tickets?: Array<{
@@ -3287,7 +3285,7 @@ export type GqlGetUserWalletQuery = {
           pointsRequired: number;
         } | null;
       }> | null;
-      currentPointView?: { __typename?: "CurrentPointView"; currentPoint: number } | null;
+      currentPointView?: { __typename?: "CurrentPointView"; currentPoint: any } | null;
     }> | null;
     nftWallet?: { __typename?: "NftWallet"; id: string; walletAddress: string } | null;
   } | null;
@@ -3297,7 +3295,7 @@ export type GqlWalletFieldsFragment = {
   __typename?: "Wallet";
   id: string;
   type: GqlWalletType;
-  currentPointView?: { __typename?: "CurrentPointView"; currentPoint: number } | null;
+  currentPointView?: { __typename?: "CurrentPointView"; currentPoint: any } | null;
 };
 
 export type GqlGetWalletsWithTransactionQueryVariables = Exact<{
@@ -3349,7 +3347,7 @@ export type GqlGetWalletsWithTransactionQuery = {
               urlX?: string | null;
               nftWallet?: { __typename?: "NftWallet"; id: string; walletAddress: string } | null;
             } | null;
-            currentPointView?: { __typename?: "CurrentPointView"; currentPoint: number } | null;
+            currentPointView?: { __typename?: "CurrentPointView"; currentPoint: any } | null;
           } | null;
           toWallet?: {
             __typename?: "Wallet";
@@ -3368,10 +3366,10 @@ export type GqlGetWalletsWithTransactionQuery = {
               urlX?: string | null;
               nftWallet?: { __typename?: "NftWallet"; id: string; walletAddress: string } | null;
             } | null;
-            currentPointView?: { __typename?: "CurrentPointView"; currentPoint: number } | null;
+            currentPointView?: { __typename?: "CurrentPointView"; currentPoint: any } | null;
           } | null;
         }> | null;
-        currentPointView?: { __typename?: "CurrentPointView"; currentPoint: number } | null;
+        currentPointView?: { __typename?: "CurrentPointView"; currentPoint: any } | null;
       } | null;
     } | null> | null;
   };
@@ -3417,7 +3415,7 @@ export type GqlGetWalletsWithTicketQuery = {
             pointsRequired: number;
           } | null;
         }> | null;
-        currentPointView?: { __typename?: "CurrentPointView"; currentPoint: number } | null;
+        currentPointView?: { __typename?: "CurrentPointView"; currentPoint: any } | null;
       } | null;
     } | null> | null;
   };
@@ -3452,7 +3450,7 @@ export type GqlGetCommunityWalletQuery = {
           name?: string | null;
           image?: string | null;
         } | null;
-        currentPointView?: { __typename?: "CurrentPointView"; currentPoint: number } | null;
+        currentPointView?: { __typename?: "CurrentPointView"; currentPoint: any } | null;
       } | null;
     } | null> | null;
   };
@@ -3514,7 +3512,7 @@ export type GqlGetMemberWalletsQuery = {
           name?: string | null;
           image?: string | null;
         } | null;
-        currentPointView?: { __typename?: "CurrentPointView"; currentPoint: number } | null;
+        currentPointView?: { __typename?: "CurrentPointView"; currentPoint: any } | null;
       } | null;
     } | null> | null;
   };
@@ -5593,7 +5591,7 @@ export type GqlGetTransactionsQuery = {
             name?: string | null;
             image?: string | null;
           } | null;
-          currentPointView?: { __typename?: "CurrentPointView"; currentPoint: number } | null;
+          currentPointView?: { __typename?: "CurrentPointView"; currentPoint: any } | null;
         } | null;
         toWallet?: {
           __typename?: "Wallet";
@@ -5629,7 +5627,7 @@ export type GqlGetTransactionsQuery = {
             name?: string | null;
             image?: string | null;
           } | null;
-          currentPointView?: { __typename?: "CurrentPointView"; currentPoint: number } | null;
+          currentPointView?: { __typename?: "CurrentPointView"; currentPoint: any } | null;
         } | null;
       } | null;
     } | null> | null;
@@ -5858,110 +5856,6 @@ export const TransactionFieldsFragmentDoc = gql`
     createdAt
   }
 `;
-export const TicketClaimLinksDocument = gql`
-  query ticketClaimLinks(
-    $filter: TicketClaimLinkFilterInput
-    $sort: TicketClaimLinkSortInput
-    $cursor: String
-    $first: Int
-  ) {
-    ticketClaimLinks(filter: $filter, sort: $sort, cursor: $cursor, first: $first) {
-      edges {
-        node {
-          id
-          status
-          qty
-          claimedAt
-          createdAt
-          issuer {
-            id
-            owner {
-              id
-              name
-              image
-            }
-          }
-          tickets {
-            status
-          }
-        }
-        cursor
-      }
-      pageInfo {
-        hasNextPage
-        hasPreviousPage
-        startCursor
-        endCursor
-      }
-      totalCount
-    }
-  }
-`;
-
-/**
- * __useTicketClaimLinksQuery__
- *
- * To run a query within a React component, call `useTicketClaimLinksQuery` and pass it any options that fit your needs.
- * When your component renders, `useTicketClaimLinksQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useTicketClaimLinksQuery({
- *   variables: {
- *      filter: // value for 'filter'
- *      sort: // value for 'sort'
- *      cursor: // value for 'cursor'
- *      first: // value for 'first'
- *   },
- * });
- */
-export function useTicketClaimLinksQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GqlTicketClaimLinksQuery,
-    GqlTicketClaimLinksQueryVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<GqlTicketClaimLinksQuery, GqlTicketClaimLinksQueryVariables>(
-    TicketClaimLinksDocument,
-    options,
-  );
-}
-export function useTicketClaimLinksLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GqlTicketClaimLinksQuery,
-    GqlTicketClaimLinksQueryVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<GqlTicketClaimLinksQuery, GqlTicketClaimLinksQueryVariables>(
-    TicketClaimLinksDocument,
-    options,
-  );
-}
-export function useTicketClaimLinksSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<GqlTicketClaimLinksQuery, GqlTicketClaimLinksQueryVariables>,
-) {
-  const options =
-    baseOptions === Apollo.skipToken ? baseOptions : { ...defaultOptions, ...baseOptions };
-  return Apollo.useSuspenseQuery<GqlTicketClaimLinksQuery, GqlTicketClaimLinksQueryVariables>(
-    TicketClaimLinksDocument,
-    options,
-  );
-}
-export type TicketClaimLinksQueryHookResult = ReturnType<typeof useTicketClaimLinksQuery>;
-export type TicketClaimLinksLazyQueryHookResult = ReturnType<typeof useTicketClaimLinksLazyQuery>;
-export type TicketClaimLinksSuspenseQueryHookResult = ReturnType<
-  typeof useTicketClaimLinksSuspenseQuery
->;
-export type TicketClaimLinksQueryResult = Apollo.QueryResult<
-  GqlTicketClaimLinksQuery,
-  GqlTicketClaimLinksQueryVariables
->;
 export const GetCommunitiesDocument = gql`
   query GetCommunities {
     communities {


### PR DESCRIPTION
```markdown
### Description

This pull request includes the following updates:
- Updated GraphQL schema, replacing `Int` with `BigInt` to handle larger numerical values.
- Added new types and inputs to support portfolio operations, including filtering, sorting, and pagination.
- Removed the deprecated `ticketClaimLinks` query and its related hooks for codebase cleanup.

### Changes Made
- Switched numerical fields from `Int` to `BigInt`.
- Introduced schema definitions for portfolio filtering and pagination features.
- Removed legacy query and associated code (`ticketClaimLinks`).

### Checklists
#### Testing
- [ ] Tested locally
- [ ] Added test cases
- [ ] Ensured compatibility with the current API

#### Documentation
- [ ] Updated documentation for all new/modified API

```