### PR TITLE
主催者の承認不要（requiredApproval.false）の場合にも、申込完了画面で主催者からの承認必要な旨を表示している

### DIFF
--- a/src/app/reservation/complete/components/CompletionHeader.tsx
+++ b/src/app/reservation/complete/components/CompletionHeader.tsx
@@ -6,15 +6,38 @@ import { CheckCircle } from "lucide-react";
 /**
  * Header component for the reservation completion page
  */
-const CompletionHeader: React.FC = () => {
+interface CompletionHeaderProps {
+  requireApproval: boolean | undefined;
+}
+
+const getApprovalText = (requireApproval: boolean | undefined) => {
+  if (requireApproval === true) {
+    return {
+      title: "申し込み完了",
+      description: "案内人が承認すると、予約が確定します｡ 予約確定時にはLINEにてお知らせします｡"
+    };
+  }
+  if (requireApproval === false) {
+    return {
+      title: "予約完了",
+      description: "承認なしで参加できる募集のため、予約が確定しました。\nキャンセルをご希望の際は、マイページよりお手続きいただけます。"
+    };
+  }
+  return {
+    title: "案内人による承認が必要です",
+    description: "案内人が承認すると、予約が確定します｡ 予約確定時にはLINEにてお知らせします｡"
+  };
+};
+
+const CompletionHeader: React.FC<CompletionHeaderProps> = ({ requireApproval }) => {
   return (
     <div className="flex flex-col items-center pt-10 pb-6 max-w-mobile-l mx-auto w-full gap-y-2 px-6">
       <div className="flex items-center justify-center">
         <CheckCircle className="w-16 h-16 md:w-24 md:h-24 text-primary" strokeWidth={1.5} />
       </div>
-      <h2 className="text-display-md">申し込み完了</h2>
-      <p className="text-body-md text-caption">
-        案内人が承認すると、予約が確定します｡ 予約確定時にはLINEにてお知らせします｡
+      <h2 className="text-display-md">{ getApprovalText(requireApproval).title }</h2>
+      <p className="text-body-md text-caption whitespace-pre-line">
+        { getApprovalText(requireApproval).description }
       </p>
     </div>
   );

--- a/src/app/reservation/complete/components/CompletionHeader.tsx
+++ b/src/app/reservation/complete/components/CompletionHeader.tsx
@@ -30,14 +30,15 @@ const getApprovalText = (requireApproval: boolean | undefined) => {
 };
 
 const CompletionHeader: React.FC<CompletionHeaderProps> = ({ requireApproval }) => {
+  const approvalText = getApprovalText(requireApproval);
   return (
     <div className="flex flex-col items-center pt-10 pb-6 max-w-mobile-l mx-auto w-full gap-y-2 px-6">
       <div className="flex items-center justify-center">
         <CheckCircle className="w-16 h-16 md:w-24 md:h-24 text-primary" strokeWidth={1.5} />
       </div>
-      <h2 className="text-display-md">{ getApprovalText(requireApproval).title }</h2>
+      <h2 className="text-display-md">{ approvalText.title }</h2>
       <p className="text-body-md text-caption whitespace-pre-line">
-        { getApprovalText(requireApproval).description }
+        { approvalText.description }
       </p>
     </div>
   );

--- a/src/app/reservation/complete/page.tsx
+++ b/src/app/reservation/complete/page.tsx
@@ -76,7 +76,7 @@ export default function CompletePage() {
 
   return (
     <main className="flex flex-col items-center">
-      <CompletionHeader />
+      <CompletionHeader requireApproval={ oppotunityDetail?.requireApproval } />
       { oppotunityDetail && <OpportunityInfo opportunity={ oppotunityDetail } /> }
       { dateTimeInfo && opportunity && (
         <div className="px-6 w-full">


### PR DESCRIPTION
- CompletionHeaderコンポーネントに承認要否のプロパティを追加し、表示内容を動的に変更。
- 予約完了時のメッセージを条件に応じて更新するロジックを実装。

<img width="380" alt="スクリーンショット 2025-07-09 0 39 31" src="https://github.com/user-attachments/assets/0e5363bf-40f0-4190-8d61-df7f3f19b752" />

<img width="378" alt="スクリーンショット 2025-07-09 0 40 16" src="https://github.com/user-attachments/assets/39830ec1-c18c-46c5-b910-b63d6532f2dc" />
