### PR TITLE
トップページに「もうすぐ開催予定」の関わりと「すべての体験」を表示する

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -8751,6 +8751,18 @@
             "deprecationReason": null
           },
           {
+            "name": "pointsToRequired",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "publishStatus",
             "description": null,
             "args": [],
@@ -10542,18 +10554,6 @@
             "deprecationReason": null
           },
           {
-            "name": "capacity",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "category",
             "description": null,
             "type": {
@@ -10580,18 +10580,6 @@
                 "name": "String",
                 "ofType": null
               }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "endsAt",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Datetime",
-              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -10630,11 +10618,11 @@
             "deprecationReason": null
           },
           {
-            "name": "place",
+            "name": "placeId",
             "description": null,
             "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "NestedPlaceConnectOrCreateInput",
+              "kind": "SCALAR",
+              "name": "ID",
               "ofType": null
             },
             "defaultValue": null,
@@ -10663,6 +10651,26 @@
                 "kind": "ENUM",
                 "name": "PublishStatus",
                 "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "relatedArticleIds",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               }
             },
             "defaultValue": null,
@@ -10700,18 +10708,6 @@
                   "ofType": null
                 }
               }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "startsAt",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Datetime",
-              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -9487,6 +9487,18 @@
             "deprecationReason": null
           },
           {
+            "name": "pointsToRequired",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "publishStatus",
             "description": null,
             "type": {

--- a/public/icons/arrow.svg
+++ b/public/icons/arrow.svg
@@ -1,0 +1,4 @@
+<svg width="34" height="22" viewBox="0 0 34 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line y1="11" x2="32" y2="11" stroke="#2563EB" stroke-width="2"/>
+<line x1="26.7071" y1="5.29289" x2="32.7071" y2="11.2929" stroke="#2563EB" stroke-width="2"/>
+</svg>

--- a/src/app/activities/[id]/layout.tsx
+++ b/src/app/activities/[id]/layout.tsx
@@ -14,11 +14,11 @@ import { apolloClient } from "@/lib/apollo";
 import React from "react";
 
 type Props = {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const id = params.id;
+  const { id } = await params;
   const communityId = COMMUNITY_ID;
   const res = await fetchOpportunity(id, communityId);
   const communityMetadata = currentCommunityMetadata;

--- a/src/app/activities/components/ActivitiesList.tsx
+++ b/src/app/activities/components/ActivitiesList.tsx
@@ -1,0 +1,53 @@
+"use client";
+import DateGroupedOpportunities from "@/app/search/result/components/DateGroupedOpportunities";
+import useSearchResultHeader from "@/app/search/result/components/SearchResultHeader";
+import useSearchResults from "@/app/search/result/hooks/useSearchResults";
+import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+import { CarouselSection } from "@/app/components/CarouselSection";
+import EmptySearchResults from "@/app/search/result/components/EmptySearchResults";
+
+export default function ActivitiesList() {
+    const searchParams = useSearchParams();
+    
+    const queryParams = useMemo(
+      () => ({
+        location: searchParams.get("location") ?? undefined,
+        from: searchParams.get("from") ?? undefined,
+        to: searchParams.get("to") ?? undefined,
+        guests: searchParams.get("guests") ?? undefined,
+        type: "activity" as "activity" | undefined,
+        ticket: searchParams.get("ticket") ?? undefined,
+        q: searchParams.get("q") ?? undefined,
+        redirectTo: "/activities",
+      }),
+      [searchParams],
+    );
+  
+    useSearchResultHeader(queryParams);
+  
+    const { recommendedOpportunities, groupedOpportunities, loading, error, refetch } =
+    useSearchResults(queryParams);
+
+    const isEmpty =
+    recommendedOpportunities.length === 0 && Object.keys(groupedOpportunities).length === 0;
+
+  if (isEmpty) {
+    return <EmptySearchResults searchQuery={queryParams.q} />;
+  }
+  
+  return (
+    <>
+    <div className="min-h-screen">
+      <main>
+        <CarouselSection
+          title="おすすめの体験"
+          opportunities={recommendedOpportunities}
+          isVertical={false}
+        />
+        <DateGroupedOpportunities groupedOpportunities={groupedOpportunities} />
+      </main>
+    </div>
+    </>
+  );
+}

--- a/src/app/activities/components/ActivitiesPageClient.tsx
+++ b/src/app/activities/components/ActivitiesPageClient.tsx
@@ -71,11 +71,11 @@ export default function ActivitiesPageClient() {
             <Coins className="w-8 h-8 text-primary" />
           </div>
           <div className="ml-2">
-            <div className="flex justify-between pl-2">
+            <div className="flex justify-between">
               <p className="text-base font-bold text-left">ポイントを獲得すると、<br/>無料で体験に参加できます。</p>
               <Image src={"icons/arrow.svg"} alt="arrow" width={32} height={32} className="mt-6 ml-4"/>
             </div>
-            <span className="text-xs pl-2">ポイントがもらえるお手伝いを探してみましょう</span>
+            <span className="text-xs">ポイントがもらえるお手伝いを探してみましょう</span>
           </div>
         </button>
       </div>

--- a/src/app/activities/components/ActivitiesPageClient.tsx
+++ b/src/app/activities/components/ActivitiesPageClient.tsx
@@ -55,4 +55,4 @@ export default function ActivitiesPageClient() {
       <div ref={loadMoreRef} className="h-10" aria-hidden="true" />
     </div>
   );
- }
+}

--- a/src/app/activities/components/ActivitiesPageClient.tsx
+++ b/src/app/activities/components/ActivitiesPageClient.tsx
@@ -7,21 +7,16 @@ import { mapOpportunityCards } from "../data/presenter";
 import ErrorState from "@/components/shared/ErrorState";
 import EmptyState from "@/components/shared/EmptyState";
 import useHeaderConfig from "@/hooks/useHeaderConfig";
-import { Coins } from "lucide-react";
-import Image from "next/image";
-import { useRouter } from "next/navigation";
 
 export default function ActivitiesPageClient() {
   const { opportunities, loading, error, loadMoreRef, refetch } = useActivities();
-  const router = useRouter();
+
   const refetchRef = useRef<(() => void) | null>(null);
   useEffect(() => {
     refetchRef.current = refetch;
   }, [refetch]);
 
-  const allCards = mapOpportunityCards(opportunities.edges ?? []);
-  const firstFour = allCards.slice(0, 4);
-  const afterFour = allCards.slice(4);
+  const listCards = mapOpportunityCards(opportunities.edges ?? []);
   const isFirstLoaded = !loading && opportunities?.edges?.length > 0;
   const isEmpty = !loading && opportunities?.edges?.length === 0;
 
@@ -51,40 +46,11 @@ export default function ActivitiesPageClient() {
   }
 
   return (
-    <div className="min-h-screen ">
-      {/* 最初の4件 */}
+    <div className="min-h-screen">
       <ActivitiesListSection
-        opportunities={firstFour}
+        opportunities={listCards}
         isInitialLoading={false}
         isSectionLoading={loading}
-      />
-      {/* バナー */}
-      <div className="px-6">
-        <button
-          className="w-full flex bg-blue-50 rounded-lg p-4 appearance-none border-none focus:outline-none"
-          style={{ boxSizing: 'border-box' }}
-          onClick={() => {
-            router.push("/quests");
-          }}
-        >
-          <div>
-            <Coins className="w-8 h-8 text-primary" />
-          </div>
-          <div className="ml-2">
-            <div className="flex justify-between">
-              <p className="text-base font-bold text-left">ポイントを獲得すると、<br/>無料で体験に参加できます。</p>
-              <Image src={"icons/arrow.svg"} alt="arrow" width={32} height={32} className="mt-6 ml-4"/>
-            </div>
-            <span className="text-xs">ポイントがもらえるお手伝いを探してみましょう</span>
-          </div>
-        </button>
-      </div>
-      {/* 5件目以降 */}
-      <ActivitiesListSection
-        opportunities={afterFour}
-        isInitialLoading={false}
-        isSectionLoading={loading}
-        isTitle={false}
       />
       <div ref={loadMoreRef} className="h-10" aria-hidden="true" />
     </div>

--- a/src/app/activities/components/ActivitiesPageClient.tsx
+++ b/src/app/activities/components/ActivitiesPageClient.tsx
@@ -55,4 +55,4 @@ export default function ActivitiesPageClient() {
       <div ref={loadMoreRef} className="h-10" aria-hidden="true" />
     </div>
   );
-}
+ }

--- a/src/app/activities/components/ActivitiesPageClient.tsx
+++ b/src/app/activities/components/ActivitiesPageClient.tsx
@@ -7,16 +7,21 @@ import { mapOpportunityCards } from "../data/presenter";
 import ErrorState from "@/components/shared/ErrorState";
 import EmptyState from "@/components/shared/EmptyState";
 import useHeaderConfig from "@/hooks/useHeaderConfig";
+import { Coins } from "lucide-react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
 
 export default function ActivitiesPageClient() {
   const { opportunities, loading, error, loadMoreRef, refetch } = useActivities();
-
+  const router = useRouter();
   const refetchRef = useRef<(() => void) | null>(null);
   useEffect(() => {
     refetchRef.current = refetch;
   }, [refetch]);
 
-  const listCards = mapOpportunityCards(opportunities.edges ?? []);
+  const allCards = mapOpportunityCards(opportunities.edges ?? []);
+  const firstFour = allCards.slice(0, 4);
+  const afterFour = allCards.slice(4);
   const isFirstLoaded = !loading && opportunities?.edges?.length > 0;
   const isEmpty = !loading && opportunities?.edges?.length === 0;
 
@@ -46,11 +51,40 @@ export default function ActivitiesPageClient() {
   }
 
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen ">
+      {/* 最初の4件 */}
       <ActivitiesListSection
-        opportunities={listCards}
+        opportunities={firstFour}
         isInitialLoading={false}
         isSectionLoading={loading}
+      />
+      {/* バナー */}
+      <div className="px-6">
+        <button
+          className="w-full flex bg-blue-50 rounded-lg p-4 appearance-none border-none focus:outline-none"
+          style={{ boxSizing: 'border-box' }}
+          onClick={() => {
+            router.push("/quests");
+          }}
+        >
+          <div>
+            <Coins className="w-8 h-8 text-primary" />
+          </div>
+          <div className="ml-2">
+            <div className="flex justify-between pl-2">
+              <p className="text-base font-bold text-left">ポイントを獲得すると、<br/>無料で体験に参加できます。</p>
+              <Image src={"icons/arrow.svg"} alt="arrow" width={32} height={32} className="mt-6 ml-4"/>
+            </div>
+            <span className="text-xs pl-2">ポイントがもらえるお手伝いを探してみましょう</span>
+          </div>
+        </button>
+      </div>
+      {/* 5件目以降 */}
+      <ActivitiesListSection
+        opportunities={afterFour}
+        isInitialLoading={false}
+        isSectionLoading={loading}
+        isTitle={false}
       />
       <div ref={loadMoreRef} className="h-10" aria-hidden="true" />
     </div>

--- a/src/app/activities/components/Card/CardHorizontal.tsx
+++ b/src/app/activities/components/Card/CardHorizontal.tsx
@@ -1,15 +1,14 @@
 "use client";
 
-import { ActivityCard, QuestCard } from "@/app/activities/data/type";
+import { ActivityCard } from "@/app/activities/data/type";
 import Link from "next/link";
 import Image from "next/image";
 import { MapPin } from "lucide-react";
 import React from "react";
 import { PLACEHOLDER_IMAGE } from "@/utils";
-import { GqlOpportunityCategory } from "@/types/graphql";
 
 type Props = {
-  opportunity: ActivityCard | QuestCard;
+  opportunity: ActivityCard;
   withShadow?: boolean;
 };
 
@@ -42,13 +41,11 @@ function OpportunityCardHorizontal({ opportunity, withShadow = true }: Props) {
           </div>
           <div className="flex-1 px-4 py-3">
             <h2 className="text-title-sm text-foreground line-clamp-1">{opportunity.title}</h2>
-            {opportunity.category === GqlOpportunityCategory.Activity && 'feeRequired' in opportunity && (
-              <p className="mt-1 text-body-sm text-muted-foreground">
-                {opportunity.feeRequired
-                  ? `1人あたり${opportunity.feeRequired.toLocaleString()}円から`
-                  : "料金未定"}
-              </p>
-            )}
+            <p className="mt-1 text-body-sm text-muted-foreground">
+              {opportunity.feeRequired
+                ? `1人あたり${opportunity.feeRequired.toLocaleString()}円から`
+                : "料金未定"}
+            </p>
             <div className="mt-1 flex items-center text-muted-foreground text-body-sm">
               <MapPin className="mr-1 h-4 w-4 flex-shrink-0" />
               <span className="line-clamp-1 break-words">{opportunity.location}</span>

--- a/src/app/activities/components/Card/CardHorizontal.tsx
+++ b/src/app/activities/components/Card/CardHorizontal.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { ActivityCard } from "@/app/activities/data/type";
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
 import Link from "next/link";
 import Image from "next/image";
 import { MapPin } from "lucide-react";
 import React from "react";
 import { PLACEHOLDER_IMAGE } from "@/utils";
+import { GqlOpportunityCategory } from "@/types/graphql";
 
 type Props = {
-  opportunity: ActivityCard;
+  opportunity: ActivityCard | QuestCard;
   withShadow?: boolean;
 };
 
@@ -41,11 +42,13 @@ function OpportunityCardHorizontal({ opportunity, withShadow = true }: Props) {
           </div>
           <div className="flex-1 px-4 py-3">
             <h2 className="text-title-sm text-foreground line-clamp-1">{opportunity.title}</h2>
-            <p className="mt-1 text-body-sm text-muted-foreground">
-              {opportunity.feeRequired
-                ? `1人あたり${opportunity.feeRequired.toLocaleString()}円から`
-                : "料金未定"}
-            </p>
+            {opportunity.category === GqlOpportunityCategory.Activity && 'feeRequired' in opportunity && (
+              <p className="mt-1 text-body-sm text-muted-foreground">
+                {opportunity.feeRequired
+                  ? `1人あたり${opportunity.feeRequired.toLocaleString()}円から`
+                  : "料金未定"}
+              </p>
+            )}
             <div className="mt-1 flex items-center text-muted-foreground text-body-sm">
               <MapPin className="mr-1 h-4 w-4 flex-shrink-0" />
               <span className="line-clamp-1 break-words">{opportunity.location}</span>

--- a/src/app/activities/components/Card/CardVertical.tsx
+++ b/src/app/activities/components/Card/CardVertical.tsx
@@ -4,37 +4,20 @@ import Image from "next/image";
 import { MapPin } from "lucide-react";
 import Link from "next/link";
 import { Card } from "@/components/ui/card";
-import { ActivityCard, QuestCard } from "@/app/activities/data/type";
+import { ActivityCard } from "@/app/activities/data/type";
 import { PLACEHOLDER_IMAGE } from "@/utils";
-import { GqlOpportunityCategory } from "@/types/graphql";
 
 interface OpportunityCardVerticalProps {
-  opportunity: ActivityCard | QuestCard;
+  opportunity: ActivityCard;
   isCarousel?: boolean;
-}
-
-const selectBadge = (hasReservableTicket: boolean | null, pointsToRequired: boolean | null) => {
-  switch (true) {
-    case hasReservableTicket && pointsToRequired:
-      return "チケット利用可";
-    case hasReservableTicket:
-      return "チケット利用可";
-    case pointsToRequired:
-      return "ポイントが使える";
-    default:
-      return null;
-  }
 }
 
 export default function OpportunityCardVertical({
   opportunity,
   isCarousel = false,
 }: OpportunityCardVerticalProps) {
-  const { id, title, location, images, hasReservableTicket, communityId,category} = opportunity;
-  
-  const feeRequired = 'feeRequired' in opportunity ? opportunity.feeRequired : null;
-  const pointsToRequired = 'pointsToRequired' in opportunity ? opportunity.pointsToRequired : null;
-  const pointsToEarn = 'pointsToEarn' in opportunity ? opportunity.pointsToEarn : null;
+  const { id, title, feeRequired, location, images, hasReservableTicket, communityId } =
+    opportunity;
 
   return (
     <Link
@@ -42,9 +25,9 @@ export default function OpportunityCardVertical({
       className={`relative w-full flex-shrink-0 ${isCarousel ? "max-w-[150px] sm:max-w-[164px]" : ""}`}
     >
       <Card className="w-full h-[205px] overflow-hidden relative">
-        {(hasReservableTicket || pointsToRequired) && (
+        {hasReservableTicket && (
           <div className="absolute top-2 left-2 bg-primary-foreground text-primary px-2.5 py-1 rounded-xl text-label-xs font-bold z-10">
-            {selectBadge(hasReservableTicket, pointsToRequired)}
+            チケット利用可
           </div>
         )}
         <Image
@@ -73,14 +56,6 @@ export default function OpportunityCardVertical({
             <MapPin className="mr-1 h-4 w-4 flex-shrink-0" />
             <span className="line-clamp-1 break-words">{location}</span>
           </div>
-          {pointsToEarn != null && pointsToEarn > 0 && category === GqlOpportunityCategory.Quest && (
-            <div className="flex items-center gap-1 pt-1">
-              <p className="bg-primary text-[11px] p-1 rounded-full w-4 h-4 flex items-center justify-center pt-[6px] font-bold text-white">P</p>
-              <p className="text-sm font-bold">
-                  {pointsToEarn}ptもらえる
-              </p>
-            </div>
-          )}
         </div>
       </div>
     </Link>

--- a/src/app/activities/components/Card/CardVertical.tsx
+++ b/src/app/activities/components/Card/CardVertical.tsx
@@ -4,11 +4,11 @@ import Image from "next/image";
 import { MapPin } from "lucide-react";
 import Link from "next/link";
 import { Card } from "@/components/ui/card";
-import { ActivityCard } from "@/app/activities/data/type";
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
 import { PLACEHOLDER_IMAGE } from "@/utils";
 
 interface OpportunityCardVerticalProps {
-  opportunity: ActivityCard;
+  opportunity: ActivityCard | QuestCard;
   isCarousel?: boolean;
 }
 
@@ -16,8 +16,8 @@ export default function OpportunityCardVertical({
   opportunity,
   isCarousel = false,
 }: OpportunityCardVerticalProps) {
-  const { id, title, feeRequired, location, images, hasReservableTicket, communityId } =
-    opportunity;
+  const { id, title, location, images, hasReservableTicket, communityId } = opportunity;
+  const feeRequired = "feeRequired" in opportunity ? opportunity.feeRequired : null;
 
   return (
     <Link

--- a/src/app/activities/components/Card/CardVertical.tsx
+++ b/src/app/activities/components/Card/CardVertical.tsx
@@ -4,20 +4,37 @@ import Image from "next/image";
 import { MapPin } from "lucide-react";
 import Link from "next/link";
 import { Card } from "@/components/ui/card";
-import { ActivityCard } from "@/app/activities/data/type";
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
 import { PLACEHOLDER_IMAGE } from "@/utils";
+import { GqlOpportunityCategory } from "@/types/graphql";
 
 interface OpportunityCardVerticalProps {
-  opportunity: ActivityCard;
+  opportunity: ActivityCard | QuestCard;
   isCarousel?: boolean;
+}
+
+const selectBadge = (hasReservableTicket: boolean | null, pointsToRequired: boolean | null) => {
+  switch (true) {
+    case hasReservableTicket && pointsToRequired:
+      return "チケット利用可";
+    case hasReservableTicket:
+      return "チケット利用可";
+    case pointsToRequired:
+      return "ポイントが使える";
+    default:
+      return null;
+  }
 }
 
 export default function OpportunityCardVertical({
   opportunity,
   isCarousel = false,
 }: OpportunityCardVerticalProps) {
-  const { id, title, feeRequired, location, images, hasReservableTicket, communityId } =
-    opportunity;
+  const { id, title, location, images, hasReservableTicket, communityId,category} = opportunity;
+  
+  const feeRequired = 'feeRequired' in opportunity ? opportunity.feeRequired : null;
+  const pointsToRequired = 'pointsToRequired' in opportunity ? opportunity.pointsToRequired : null;
+  const pointsToEarn = 'pointsToEarn' in opportunity ? opportunity.pointsToEarn : null;
 
   return (
     <Link
@@ -25,9 +42,9 @@ export default function OpportunityCardVertical({
       className={`relative w-full flex-shrink-0 ${isCarousel ? "max-w-[150px] sm:max-w-[164px]" : ""}`}
     >
       <Card className="w-full h-[205px] overflow-hidden relative">
-        {hasReservableTicket && (
+        {(hasReservableTicket || pointsToRequired) && (
           <div className="absolute top-2 left-2 bg-primary-foreground text-primary px-2.5 py-1 rounded-xl text-label-xs font-bold z-10">
-            チケット利用可
+            {selectBadge(hasReservableTicket, pointsToRequired)}
           </div>
         )}
         <Image
@@ -56,6 +73,14 @@ export default function OpportunityCardVertical({
             <MapPin className="mr-1 h-4 w-4 flex-shrink-0" />
             <span className="line-clamp-1 break-words">{location}</span>
           </div>
+          {pointsToEarn != null && pointsToEarn > 0 && category === GqlOpportunityCategory.Quest && (
+            <div className="flex items-center gap-1 pt-1">
+              <p className="bg-primary text-[11px] p-1 rounded-full w-4 h-4 flex items-center justify-center pt-[6px] font-bold text-white">P</p>
+              <p className="text-sm font-bold">
+                  {pointsToEarn}ptもらえる
+              </p>
+            </div>
+          )}
         </div>
       </div>
     </Link>

--- a/src/app/activities/components/CarouselSection/CarouselSection.tsx
+++ b/src/app/activities/components/CarouselSection/CarouselSection.tsx
@@ -2,12 +2,12 @@
 
 import React from "react";
 import OpportunityCardVertical from "@/app/activities/components/Card/CardVertical";
-import { ActivityCard } from "@/app/activities/data/type";
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
 import CarouselSectionSkeleton from "@/app/activities/components/CarouselSection/CarouselSectionSkeleton";
 
 interface ActivitiesCarouselSectionProps {
   title: string;
-  opportunities: ActivityCard[];
+  opportunities: (ActivityCard | QuestCard)[];
   isInitialLoading?: boolean;
   isSearchResult?: boolean;
 }

--- a/src/app/activities/components/CarouselSection/CarouselSection.tsx
+++ b/src/app/activities/components/CarouselSection/CarouselSection.tsx
@@ -2,12 +2,12 @@
 
 import React from "react";
 import OpportunityCardVertical from "@/app/activities/components/Card/CardVertical";
-import { ActivityCard, QuestCard } from "@/app/activities/data/type";
+import { ActivityCard } from "@/app/activities/data/type";
 import CarouselSectionSkeleton from "@/app/activities/components/CarouselSection/CarouselSectionSkeleton";
 
 interface ActivitiesCarouselSectionProps {
   title: string;
-  opportunities: (ActivityCard | QuestCard)[];
+  opportunities: ActivityCard[];
   isInitialLoading?: boolean;
   isSearchResult?: boolean;
 }

--- a/src/app/activities/components/FeaturedSection/FeaturedSection.tsx
+++ b/src/app/activities/components/FeaturedSection/FeaturedSection.tsx
@@ -1,11 +1,11 @@
-import { ActivityCard, QuestCard } from "@/app/activities/data/type";
+import { ActivityCard } from "@/app/activities/data/type";
 import FeaturedSectionSkeleton from "@/app/activities/components/FeaturedSection/FeaturedSectionSkeleton";
 import HeroHeader from "@/app/activities/components/FeaturedSection/HeroHeader";
 import OpportunityImageSSR from "@/app/activities/components/FeaturedSection/ImageSSR";
 import ActivitiesFeaturedSliderWrapper from "@/app/activities/components/FeaturedSection/FeaturedSlideWrapper";
 
 interface Props {
-  opportunities: (ActivityCard | QuestCard)[];
+  opportunities: ActivityCard[];
   isInitialLoading?: boolean;
 }
 

--- a/src/app/activities/components/FeaturedSection/FeaturedSection.tsx
+++ b/src/app/activities/components/FeaturedSection/FeaturedSection.tsx
@@ -1,11 +1,11 @@
-import { ActivityCard } from "@/app/activities/data/type";
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
 import FeaturedSectionSkeleton from "@/app/activities/components/FeaturedSection/FeaturedSectionSkeleton";
 import HeroHeader from "@/app/activities/components/FeaturedSection/HeroHeader";
 import OpportunityImageSSR from "@/app/activities/components/FeaturedSection/ImageSSR";
 import ActivitiesFeaturedSliderWrapper from "@/app/activities/components/FeaturedSection/FeaturedSlideWrapper";
 
 interface Props {
-  opportunities: ActivityCard[];
+  opportunities: (ActivityCard | QuestCard)[];
   isInitialLoading?: boolean;
 }
 

--- a/src/app/activities/components/FeaturedSection/FeaturedSlideWrapper.tsx
+++ b/src/app/activities/components/FeaturedSection/FeaturedSlideWrapper.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { ActivityCard, QuestCard } from "@/app/activities/data/type";
+import { ActivityCard } from "@/app/activities/data/type";
 
 const ActivitiesFeaturedSlider = dynamic(() => import("./FeaturedSlider"), {
   ssr: false,
 });
 
 type Props = {
-  opportunities: (ActivityCard | QuestCard)[];
+  opportunities: ActivityCard[];
 };
 
 export default function ActivitiesFeaturedSliderWrapper({ opportunities }: Props) {

--- a/src/app/activities/components/FeaturedSection/FeaturedSlideWrapper.tsx
+++ b/src/app/activities/components/FeaturedSection/FeaturedSlideWrapper.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { ActivityCard } from "@/app/activities/data/type";
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
 
 const ActivitiesFeaturedSlider = dynamic(() => import("./FeaturedSlider"), {
   ssr: false,
 });
 
 type Props = {
-  opportunities: ActivityCard[];
+  opportunities: (ActivityCard | QuestCard)[];
 };
 
 export default function ActivitiesFeaturedSliderWrapper({ opportunities }: Props) {

--- a/src/app/activities/components/FeaturedSection/FeaturedSlider.tsx
+++ b/src/app/activities/components/FeaturedSection/FeaturedSlider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ActivityCard } from "@/app/activities/data/type";
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
 import { useCallback, useEffect, useState } from "react";
 import OpportunityCardHorizontal from "@/app/activities/components/Card/CardHorizontal";
 import useEmblaCarousel from "embla-carousel-react";
@@ -10,7 +10,7 @@ import OpportunityImageSlider from "@/app/activities/components/FeaturedSection/
 export default function ActivitiesFeaturedSlider({
   opportunities,
 }: {
-  opportunities: ActivityCard[];
+  opportunities: (ActivityCard | QuestCard)[];
 }) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true, align: "center" });

--- a/src/app/activities/components/FeaturedSection/FeaturedSlider.tsx
+++ b/src/app/activities/components/FeaturedSection/FeaturedSlider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ActivityCard, QuestCard } from "@/app/activities/data/type";
+import { ActivityCard } from "@/app/activities/data/type";
 import { useCallback, useEffect, useState } from "react";
 import OpportunityCardHorizontal from "@/app/activities/components/Card/CardHorizontal";
 import useEmblaCarousel from "embla-carousel-react";
@@ -10,7 +10,7 @@ import OpportunityImageSlider from "@/app/activities/components/FeaturedSection/
 export default function ActivitiesFeaturedSlider({
   opportunities,
 }: {
-  opportunities: (ActivityCard | QuestCard)[];
+  opportunities: ActivityCard[];
 }) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true, align: "center" });

--- a/src/app/activities/components/Header.tsx
+++ b/src/app/activities/components/Header.tsx
@@ -1,0 +1,26 @@
+"use client";
+import useSearchResultHeader from "@/app/search/result/components/SearchResultHeader";
+import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+
+export default function ActivitiesHeader() {
+    const searchParams = useSearchParams();
+
+    const queryParams = useMemo(
+      () => ({
+        location: searchParams.get("location") ?? undefined,
+        from: searchParams.get("from") ?? undefined,
+        to: searchParams.get("to") ?? undefined,
+        guests: searchParams.get("guests") ?? undefined,
+        type: searchParams.get("type") as "quest" | undefined,
+        ticket: searchParams.get("ticket") ?? undefined,
+        points: searchParams.get("points") ?? undefined,
+        q: searchParams.get("q") ?? undefined,
+        redirectTo: "/activities",
+      }),
+      [searchParams],
+    );
+    useSearchResultHeader(queryParams);
+
+    return null;
+}

--- a/src/app/activities/components/ListSection/ListSection.tsx
+++ b/src/app/activities/components/ListSection/ListSection.tsx
@@ -2,26 +2,28 @@
 
 import React from "react";
 import OpportunityCardVertical from "@/app/activities/components/Card/CardVertical";
-import { ActivityCard } from "@/app/activities/data/type";
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
 import OpportunitiesListSectionSkeleton from "@/app/activities/components/ListSection/ListSectionSkeleton";
 
 interface ActivitiesAllSectionProps {
-  opportunities: ActivityCard[];
+  opportunities: (ActivityCard | QuestCard)[];
   isSectionLoading: boolean;
   isInitialLoading?: boolean;
+  isTitle?: boolean;
 }
 
 const ActivitiesListSection: React.FC<ActivitiesAllSectionProps> = ({
   opportunities,
   isInitialLoading,
   isSectionLoading,
+  isTitle = true,
 }) => {
   if (isInitialLoading) return <OpportunitiesListSectionSkeleton />;
   if (opportunities.length === 0) return null;
 
   return (
     <section className="mt-6 px-6">
-      <h2 className="text-display-md">すべての体験</h2>
+      {isTitle && <h2 className="text-display-md">すべての体験</h2>}
       <div className="mt-6 grid grid-cols-2 gap-4">
         {opportunities.map((opportunity) => (
           <OpportunityCardVertical key={opportunity.id} opportunity={opportunity} />

--- a/src/app/activities/components/ListSection/ListSection.tsx
+++ b/src/app/activities/components/ListSection/ListSection.tsx
@@ -2,11 +2,11 @@
 
 import React from "react";
 import OpportunityCardVertical from "@/app/activities/components/Card/CardVertical";
-import { ActivityCard } from "@/app/activities/data/type";
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
 import OpportunitiesListSectionSkeleton from "@/app/activities/components/ListSection/ListSectionSkeleton";
 
 interface ActivitiesAllSectionProps {
-  opportunities: ActivityCard[];
+  opportunities: (ActivityCard|QuestCard)[];
   isSectionLoading: boolean;
   isInitialLoading?: boolean;
   isTitle?: boolean;
@@ -29,7 +29,7 @@ const ActivitiesListSection: React.FC<ActivitiesAllSectionProps> = ({
           <OpportunityCardVertical key={opportunity.id} opportunity={opportunity} />
         ))}
       </div>
-      <div className="h-20" aria-hidden="true"></div>
+      <div className="h-10" aria-hidden="true"></div>
       {/*<div ref={loadMoreRef} className="h-10" aria-hidden="true" />*/}
       {isSectionLoading && (
         <div className="py-6 flex items-center justify-center">

--- a/src/app/activities/components/ListSection/ListSection.tsx
+++ b/src/app/activities/components/ListSection/ListSection.tsx
@@ -2,28 +2,26 @@
 
 import React from "react";
 import OpportunityCardVertical from "@/app/activities/components/Card/CardVertical";
-import { ActivityCard, QuestCard } from "@/app/activities/data/type";
+import { ActivityCard } from "@/app/activities/data/type";
 import OpportunitiesListSectionSkeleton from "@/app/activities/components/ListSection/ListSectionSkeleton";
 
 interface ActivitiesAllSectionProps {
-  opportunities: (ActivityCard|QuestCard)[];
+  opportunities: ActivityCard[];
   isSectionLoading: boolean;
   isInitialLoading?: boolean;
-  isTitle?: boolean;
 }
 
 const ActivitiesListSection: React.FC<ActivitiesAllSectionProps> = ({
   opportunities,
   isInitialLoading,
   isSectionLoading,
-  isTitle = true,
 }) => {
   if (isInitialLoading) return <OpportunitiesListSectionSkeleton />;
   if (opportunities.length === 0) return null;
 
   return (
     <section className="mt-6 px-6">
-      {isTitle && <h2 className="text-display-md">すべての体験</h2>}
+      <h2 className="text-display-md">すべての体験</h2>
       <div className="mt-6 grid grid-cols-2 gap-4">
         {opportunities.map((opportunity) => (
           <OpportunityCardVertical key={opportunity.id} opportunity={opportunity} />

--- a/src/app/activities/components/ListSection/ListSection.tsx
+++ b/src/app/activities/components/ListSection/ListSection.tsx
@@ -9,19 +9,21 @@ interface ActivitiesAllSectionProps {
   opportunities: ActivityCard[];
   isSectionLoading: boolean;
   isInitialLoading?: boolean;
+  isTitle?: boolean;
 }
 
 const ActivitiesListSection: React.FC<ActivitiesAllSectionProps> = ({
   opportunities,
   isInitialLoading,
   isSectionLoading,
+  isTitle = true,
 }) => {
   if (isInitialLoading) return <OpportunitiesListSectionSkeleton />;
   if (opportunities.length === 0) return null;
 
   return (
     <section className="mt-6 px-6">
-      <h2 className="text-display-md">すべての体験</h2>
+      {isTitle && <h2 className="text-display-md">すべての体験</h2>}
       <div className="mt-6 grid grid-cols-2 gap-4">
         {opportunities.map((opportunity) => (
           <OpportunityCardVertical key={opportunity.id} opportunity={opportunity} />

--- a/src/app/activities/data/fetchActivities.ts
+++ b/src/app/activities/data/fetchActivities.ts
@@ -1,24 +1,25 @@
-import { apolloClient } from "@/lib/apollo";
 import {
-  GetOpportunitiesDocument,
-  GqlGetOpportunitiesQuery,
-  GqlGetOpportunitiesQueryVariables,
   GqlOpportunityCategory,
   GqlPublishStatus,
   GqlSortDirection,
+  useGetOpportunitiesQuery,
 } from "@/types/graphql";
 import { mapOpportunityCards, sliceActivitiesBySection } from "./presenter";
 
-export async function fetchFeaturedAndCarousel() {
-  const { data, loading } = await apolloClient.query<
-    GqlGetOpportunitiesQuery,
-    GqlGetOpportunitiesQueryVariables
-  >({
-    query: GetOpportunitiesDocument,
+export function fetchFeaturedAndCarousel() {
+  const { data, loading } = useGetOpportunitiesQuery({
     variables: {
       filter: {
-        category: GqlOpportunityCategory.Activity,
-        publishStatus: [GqlPublishStatus.Public],
+        or: [
+          {
+            category: GqlOpportunityCategory.Activity,
+            publishStatus: [GqlPublishStatus.Public],
+          },
+          {
+            category: GqlOpportunityCategory.Quest,
+            publishStatus: [GqlPublishStatus.Public],
+          },
+        ],
       },
       sort: {
         earliestSlotStartsAt: GqlSortDirection.Asc,
@@ -27,7 +28,7 @@ export async function fetchFeaturedAndCarousel() {
     },
     fetchPolicy: "cache-first",
   });
-  const activityCards = mapOpportunityCards(data.opportunities.edges ?? []);
+  const activityCards = mapOpportunityCards(data?.opportunities.edges ?? []);
   const { featuredCards, upcomingCards } = sliceActivitiesBySection(activityCards);
   return { featuredCards, upcomingCards, loading };
 }

--- a/src/app/activities/data/fetchActivities.ts
+++ b/src/app/activities/data/fetchActivities.ts
@@ -1,25 +1,24 @@
+import { apolloClient } from "@/lib/apollo";
 import {
+  GetOpportunitiesDocument,
+  GqlGetOpportunitiesQuery,
+  GqlGetOpportunitiesQueryVariables,
   GqlOpportunityCategory,
   GqlPublishStatus,
   GqlSortDirection,
-  useGetOpportunitiesQuery,
 } from "@/types/graphql";
 import { mapOpportunityCards, sliceActivitiesBySection } from "./presenter";
 
-export function fetchFeaturedAndCarousel() {
-  const { data, loading } = useGetOpportunitiesQuery({
+export async function fetchFeaturedAndCarousel() {
+  const { data, loading } = await apolloClient.query<
+    GqlGetOpportunitiesQuery,
+    GqlGetOpportunitiesQueryVariables
+  >({
+    query: GetOpportunitiesDocument,
     variables: {
       filter: {
-        or: [
-          {
-            category: GqlOpportunityCategory.Activity,
-            publishStatus: [GqlPublishStatus.Public],
-          },
-          {
-            category: GqlOpportunityCategory.Quest,
-            publishStatus: [GqlPublishStatus.Public],
-          },
-        ],
+        category: GqlOpportunityCategory.Activity,
+        publishStatus: [GqlPublishStatus.Public],
       },
       sort: {
         earliestSlotStartsAt: GqlSortDirection.Asc,
@@ -28,7 +27,7 @@ export function fetchFeaturedAndCarousel() {
     },
     fetchPolicy: "cache-first",
   });
-  const activityCards = mapOpportunityCards(data?.opportunities.edges ?? []);
+  const activityCards = mapOpportunityCards(data.opportunities.edges ?? []);
   const { featuredCards, upcomingCards } = sliceActivitiesBySection(activityCards);
   return { featuredCards, upcomingCards, loading };
 }

--- a/src/app/activities/data/presenter.ts
+++ b/src/app/activities/data/presenter.ts
@@ -81,6 +81,7 @@ export const presenterQuestCard = (node: Partial<GqlOpportunity>): QuestCard => 
     hasReservableTicket: node?.isReservableWithTicket || false,
     pointsToEarn: node?.pointsToEarn ?? 0,
     slots: node?.slots ?? [],
+    pointsToRequired: node?.pointsToRequired ?? null,
   };
 };
 

--- a/src/app/activities/data/presenter.ts
+++ b/src/app/activities/data/presenter.ts
@@ -41,11 +41,19 @@ export const presenterQuestCards = (
     .filter((node): node is GqlOpportunity => !!node)
     .map((node) => presenterQuestCard(node));
 };
-export const mapOpportunityCards = (edges: GqlOpportunityEdge[]): ActivityCard[] =>
+export const mapOpportunityCards = (edges: GqlOpportunityEdge[]): (ActivityCard | QuestCard)[] =>
   edges
     .map((edge) => edge.node)
     .filter((node): node is GqlOpportunity => !!node)
-    .map(presenterActivityCard);
+    .map((node) => {
+      if (node.category === GqlOpportunityCategory.Activity) {
+        return presenterActivityCard(node);
+      } else if (node.category === GqlOpportunityCategory.Quest) {
+        return presenterQuestCard(node);
+      }
+      return null;
+    })
+    .filter((v): v is ActivityCard | QuestCard => v !== null);
 
 export const presenterActivityCard = (node: Partial<GqlOpportunity>): ActivityCard => {
   return {
@@ -259,15 +267,15 @@ export const presenterReservationDateTimeInfo = (
 };
 
 export const sliceActivitiesBySection = (
-  activityCards: ActivityCard[],
+  cards: (ActivityCard | QuestCard)[],
 ): {
-  upcomingCards: ActivityCard[];
-  featuredCards: ActivityCard[];
+  upcomingCards: (ActivityCard | QuestCard)[];
+  featuredCards: (ActivityCard | QuestCard)[];
 } => {
   const safe = <T>(cards: (T | undefined)[]): T[] => cards.filter((c): c is T => !!c);
-  const hasImages = (card: ActivityCard) => card.images && card.images.length > 0;
+  const hasImages = (card: ActivityCard | QuestCard) => card.images && card.images.length > 0;
 
-  const validCards = safe(activityCards.filter(hasImages));
+  const validCards = safe(cards.filter(hasImages));
   const featuredCards = validCards.slice(0, 3);
   const upcomingCards = validCards.slice(3);
 

--- a/src/app/activities/data/type.ts
+++ b/src/app/activities/data/type.ts
@@ -16,7 +16,8 @@ export type ActivityCard = OpportunityBaseCard & {
 
 export type QuestCard = OpportunityBaseCard & {
   pointsToEarn: number | null;
-  slots:GqlOpportunitySlot[]
+  slots: GqlOpportunitySlot[];
+  pointsToRequired: boolean | null;
 };
 
 export type OpportunityBaseCard = CommunityId & {

--- a/src/app/activities/data/type.ts
+++ b/src/app/activities/data/type.ts
@@ -10,6 +10,7 @@ export type OpportunityCard = ActivityCard | QuestCard;
 
 export type ActivityCard = OpportunityBaseCard & {
   feeRequired: number | null;
+  pointsToRequired: boolean | null;
 };
 
 export type QuestCard = OpportunityBaseCard & {

--- a/src/app/activities/data/type.ts
+++ b/src/app/activities/data/type.ts
@@ -1,4 +1,4 @@
-import { GqlOpportunityCategory } from "@/types/graphql";
+import { GqlOpportunityCategory, GqlOpportunitySlot } from "@/types/graphql";
 import { CommunityId } from "@/types";
 import { TArticleCard } from "@/app/articles/data/type";
 import { ActivitySlot, QuestSlot } from "@/app/reservation/data/type/opportunitySlot";
@@ -11,10 +11,12 @@ export type OpportunityCard = ActivityCard | QuestCard;
 export type ActivityCard = OpportunityBaseCard & {
   feeRequired: number | null;
   pointsToRequired: boolean | null;
+  slots: GqlOpportunitySlot[];
 };
 
 export type QuestCard = OpportunityBaseCard & {
   pointsToEarn: number | null;
+  slots:GqlOpportunitySlot[]
 };
 
 export type OpportunityBaseCard = CommunityId & {
@@ -41,7 +43,9 @@ export type ActivityDetail = OpportunityDetail & {
 // ⚠️直近では使わない⚠️
 export type QuestDetail = OpportunityDetail & {
   slots: QuestSlot[];
+  category: GqlOpportunityCategory;
   relatedQuests: QuestCard[];
+  pointsToEarn: number;
 };
 
 export type OpportunityDetail = CommunityId & {
@@ -58,6 +62,7 @@ export type OpportunityDetail = CommunityId & {
   body: string;
   images: string[];
   totalImageCount: number;
+  category: GqlOpportunityCategory;
 
   host: OpportunityHost;
   recentOpportunities: OpportunityCard[];

--- a/src/app/activities/hooks/useActivities.ts
+++ b/src/app/activities/hooks/useActivities.ts
@@ -33,8 +33,16 @@ export const useActivities = (): UseActivitiesResult => {
   const { data, loading, error, fetchMore, refetch } = useGetOpportunitiesQuery({
     variables: {
       filter: {
-        category: GqlOpportunityCategory.Activity,
-        publishStatus: [GqlPublishStatus.Public],
+        or: [
+          {
+            category: GqlOpportunityCategory.Activity,
+            publishStatus: [GqlPublishStatus.Public],
+          },
+          {
+            category: GqlOpportunityCategory.Quest,
+            publishStatus: [GqlPublishStatus.Public],
+          },
+        ],
       },
       sort: {
         earliestSlotStartsAt: GqlSortDirection.Asc,
@@ -56,8 +64,16 @@ export const useActivities = (): UseActivitiesResult => {
     await fetchMore({
       variables: {
         filter: {
-          category: GqlOpportunityCategory.Activity,
-          publishStatus: [GqlPublishStatus.Public],
+          or: [
+            {
+              category: GqlOpportunityCategory.Activity,
+              publishStatus: [GqlPublishStatus.Public],
+            },
+            {
+              category: GqlOpportunityCategory.Quest,
+              publishStatus: [GqlPublishStatus.Public],
+            },
+          ],
         },
         sort: {
           earliestSlotStartsAt: GqlSortDirection.Asc,

--- a/src/app/activities/hooks/useActivities.ts
+++ b/src/app/activities/hooks/useActivities.ts
@@ -33,16 +33,8 @@ export const useActivities = (): UseActivitiesResult => {
   const { data, loading, error, fetchMore, refetch } = useGetOpportunitiesQuery({
     variables: {
       filter: {
-        or: [
-          {
-            category: GqlOpportunityCategory.Activity,
-            publishStatus: [GqlPublishStatus.Public],
-          },
-          {
-            category: GqlOpportunityCategory.Quest,
-            publishStatus: [GqlPublishStatus.Public],
-          },
-        ],
+        category: GqlOpportunityCategory.Activity,
+        publishStatus: [GqlPublishStatus.Public],
       },
       sort: {
         earliestSlotStartsAt: GqlSortDirection.Asc,
@@ -64,16 +56,8 @@ export const useActivities = (): UseActivitiesResult => {
     await fetchMore({
       variables: {
         filter: {
-          or: [
-            {
-              category: GqlOpportunityCategory.Activity,
-              publishStatus: [GqlPublishStatus.Public],
-            },
-            {
-              category: GqlOpportunityCategory.Quest,
-              publishStatus: [GqlPublishStatus.Public],
-            },
-          ],
+          category: GqlOpportunityCategory.Activity,
+          publishStatus: [GqlPublishStatus.Public],
         },
         sort: {
           earliestSlotStartsAt: GqlSortDirection.Asc,

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -1,21 +1,12 @@
-import { fetchFeaturedAndCarousel } from "./data/fetchActivities";
-import ActivitiesFeaturedSection from "@/app/activities/components/FeaturedSection/FeaturedSection";
-import ActivitiesCarouselSection from "@/app/activities/components/CarouselSection/CarouselSection";
-import ActivitiesPageClient from "@/app/activities/components/ActivitiesPageClient";
+import ActivitiesList from "./components/ActivitiesList";
+import ActivitiesHeader from "./components/Header";
 
 export default async function ActivitiesPage() {
-  const { featuredCards, upcomingCards, loading } = await fetchFeaturedAndCarousel();
-  return (
-    <>
-      <div className="min-h-screen">
-        <ActivitiesFeaturedSection opportunities={featuredCards} isInitialLoading={loading} />
-        <ActivitiesCarouselSection
-          title="もうすぐ開催予定"
-          opportunities={upcomingCards}
-          isInitialLoading={loading}
-        />
-        <ActivitiesPageClient />
-      </div>
-    </>
-  );
+
+return (
+  <>
+  <ActivitiesHeader />
+  <ActivitiesList />
+  </>
+);
 }

--- a/src/app/admin/wallet/grant/components/SearchSection.tsx
+++ b/src/app/admin/wallet/grant/components/SearchSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import SearchForm from "@/components/shared/SearchForm";
 import React, { useState } from "react";
-import SearchForm from "@/app/admin/credentials/components/selectUser/SearchForm";
 
 interface SearchSectionProps {
   onSearch: (query: string) => void;
@@ -15,6 +15,7 @@ export function SearchSection({ onSearch }: SearchSectionProps) {
       value={input} 
       onInputChange={setInput} 
       onSearch={onSearch} 
+      placeholder="名前・DIDを入力してください"
     />
   );
 } 

--- a/src/app/components/CardVertical.tsx
+++ b/src/app/components/CardVertical.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import Image from "next/image";
+import { JapaneseYenIcon, MapPin } from "lucide-react";
+import Link from "next/link";
+import { Card } from "@/components/ui/card";
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
+import { PLACEHOLDER_IMAGE } from "@/utils";
+import { GqlOpportunityCategory } from "@/types/graphql";
+
+interface OpportunityCardVerticalProps {
+  opportunity: ActivityCard | QuestCard;
+  isCarousel?: boolean;
+}
+
+const selectBadge = (hasReservableTicket: boolean | null, pointsToRequired: boolean | null) => {
+  switch (true) {
+    case hasReservableTicket && pointsToRequired:
+      return "チケット利用可";
+    case hasReservableTicket:
+      return "チケット利用可";
+    case pointsToRequired:
+      return "ポイントが使える";
+    default:
+      return null;
+  }
+}
+
+const getLink = (id: string, communityId: string, category: GqlOpportunityCategory) => {
+  if (category === GqlOpportunityCategory.Activity) {
+    return `/activities/${id}?community_id=${communityId}`;
+  } else if (category === GqlOpportunityCategory.Quest) {
+    return `/quests/${id}?community_id=${communityId}`;
+  }
+  return "";
+}
+
+export default function OpportunityCardVertical({
+  opportunity,
+  isCarousel = false,
+}: OpportunityCardVerticalProps) {
+  const { id, title, location, images, hasReservableTicket, communityId,category} = opportunity;
+  const feeRequired = 'feeRequired' in opportunity ? opportunity.feeRequired : null;
+  const pointsToRequired = 'pointsToRequired' in opportunity ? opportunity.pointsToRequired : null;
+  const pointsToEarn = 'pointsToEarn' in opportunity ? opportunity.pointsToEarn : null;
+  return (
+    <Link
+      href={getLink(id, communityId, category)}
+      className={`relative w-full flex-shrink-0 ${isCarousel ? "max-w-[150px] sm:max-w-[164px]" : ""}`}
+    >
+      <Card className="w-full h-[205px] overflow-hidden relative">
+        {(hasReservableTicket || pointsToRequired) && (
+          <div className="absolute top-2 left-2 bg-primary-foreground text-primary px-2.5 py-1 rounded-xl text-label-xs font-bold z-10">
+            {selectBadge(hasReservableTicket, pointsToRequired)}
+          </div>
+        )}
+        <Image
+          src={images?.[0] || PLACEHOLDER_IMAGE}
+          alt={title}
+          width={400}
+          height={400}
+          sizes="164px"
+          placeholder={`blur`}
+          blurDataURL={PLACEHOLDER_IMAGE}
+          loading="lazy"
+          className="h-full w-full object-cover"
+          onError={(e) => {
+            const img = e.target as HTMLImageElement;
+            img.src = PLACEHOLDER_IMAGE;
+          }}
+        />
+      </Card>
+      <div className="mt-3">
+        <h3 className="text-title-sm text-foreground line-clamp-2">{title}</h3>
+        <div className="mt-2 flex flex-col">
+          <div className="text-body-sm text-muted-foreground">
+            {category === GqlOpportunityCategory.Activity
+            ? <p className="text-body-sm text-muted-foreground flex items-center gap-1"><JapaneseYenIcon className="w-4 h-4" /> {feeRequired?.toLocaleString()}円/人~</p> 
+            :category === GqlOpportunityCategory.Quest
+            ? <p className="text-body-sm text-muted-foreground flex items-center gap-1"><JapaneseYenIcon className="w-4 h-4" /> 参加無料</p>
+            : "料金未定"
+            }
+          </div>
+          <div className="flex items-center text-body-sm text-muted-foreground mt-1">
+            <MapPin className="mr-1 h-4 w-4 flex-shrink-0" />
+            <span className="line-clamp-1 break-words">{location}</span>
+          </div>
+          {pointsToEarn != null && pointsToEarn > 0 && category === GqlOpportunityCategory.Quest && (
+            <div className="flex items-center gap-1 pt-1">
+              <p className="bg-primary text-[11px] p-1 rounded-full w-4 h-4 flex items-center justify-center pt-[6px] font-bold text-white">P</p>
+              <p className="text-sm font-bold">
+                  {pointsToEarn}ptもらえる
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/app/components/CardVertical.tsx
+++ b/src/app/components/CardVertical.tsx
@@ -87,7 +87,9 @@ export default function OpportunityCardVertical({
           </div>
           {pointsToEarn != null && pointsToEarn > 0 && category === GqlOpportunityCategory.Quest && (
             <div className="flex items-center gap-1 pt-1">
-              <p className="bg-primary text-[11px] p-1 rounded-full w-4 h-4 flex items-center justify-center pt-[6px] font-bold text-white">P</p>
+              <p className="bg-primary text-[11px] rounded-full w-4 h-4 flex items-center justify-center font-bold text-white leading-none">
+                P
+              </p>
               <p className="text-sm font-bold">
                   {pointsToEarn}ptもらえる
               </p>

--- a/src/app/components/CarouselSection.tsx
+++ b/src/app/components/CarouselSection.tsx
@@ -1,22 +1,24 @@
 "use client";
 
 import React from "react";
-import OpportunityCardVertical from "@/app/activities/components/Card/CardVertical";
-import { ActivityCard } from "@/app/activities/data/type";
 import CarouselSectionSkeleton from "@/app/activities/components/CarouselSection/CarouselSectionSkeleton";
+import OpportunityCardVertical from "./CardVertical";
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
 
 interface ActivitiesCarouselSectionProps {
   title: string;
-  opportunities: ActivityCard[];
+  opportunities: (ActivityCard | QuestCard)[];
   isInitialLoading?: boolean;
   isSearchResult?: boolean;
+  isVertical?: boolean;
 }
 
-const ActivitiesCarouselSection: React.FC<ActivitiesCarouselSectionProps> = ({
+export const CarouselSection: React.FC<ActivitiesCarouselSectionProps> = ({
   title,
   opportunities,
   isInitialLoading = false,
   isSearchResult = false,
+  isVertical = true,
 }) => {
   if (isInitialLoading) return <CarouselSectionSkeleton title={title} />;
   if (opportunities.length === 0) return null;
@@ -35,12 +37,12 @@ const ActivitiesCarouselSection: React.FC<ActivitiesCarouselSectionProps> = ({
       ) : (
         <h2 className="text-display-md">{title}</h2>
       )}
-      <div className="mt-4 grid grid-cols-2 gap-4">
+      <div className={`mt-4 ${isVertical ? "grid grid-cols-2 gap-4" : "flex gap-4 overflow-x-auto pb-4 scrollbar-hide"}`}>
         {opportunities.map((opportunity, index) => (
           <OpportunityCardVertical
             key={`${opportunity.id}_${index}`}
             opportunity={opportunity}
-            isCarousel={false}
+            isCarousel
           />
         ))}
       </div>
@@ -48,4 +50,3 @@ const ActivitiesCarouselSection: React.FC<ActivitiesCarouselSectionProps> = ({
   );
 };
 
-export default ActivitiesCarouselSection;

--- a/src/app/components/FeaturedSection.tsx
+++ b/src/app/components/FeaturedSection.tsx
@@ -1,0 +1,29 @@
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
+import FeaturedSectionSkeleton from "@/app/activities/components/FeaturedSection/FeaturedSectionSkeleton";
+import ActivitiesFeaturedSliderWrapper from "./FeaturedSlideWrapper";
+import OpportunityImageSSR from "../activities/components/FeaturedSection/ImageSSR";
+import HeroHeader from "../activities/components/FeaturedSection/HeroHeader";
+
+interface Props {
+  opportunities: (ActivityCard | QuestCard)[];
+  isInitialLoading?: boolean;
+}
+
+export default function FeaturedSection({
+  opportunities,
+  isInitialLoading = false,
+}: Props) {
+  if (isInitialLoading) return <FeaturedSectionSkeleton />;
+  if (opportunities.length === 0) return null;
+
+  const firstImage = opportunities[0]?.images?.[1] ?? "";
+  const firstTitle = opportunities[0]?.title ?? "";
+
+  return (
+    <section className="relative h-[70vh] w-full overflow-hidden mb-12 mt-0">
+      <HeroHeader />
+      <OpportunityImageSSR image={firstImage} title={firstTitle} />
+      <ActivitiesFeaturedSliderWrapper opportunities={opportunities} />
+    </section>
+  );
+}

--- a/src/app/components/FeaturedSlideWrapper.tsx
+++ b/src/app/components/FeaturedSlideWrapper.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
+
+const FeaturedSlider = dynamic(() => import("./FeaturedSlider"), {
+  ssr: false,
+});
+
+type Props = {
+  opportunities: (ActivityCard | QuestCard)[];
+};
+
+export default function FeaturedSlideWrapper({ opportunities }: Props) {
+  return <FeaturedSlider opportunities={opportunities} />;
+}

--- a/src/app/components/FeaturedSlider.tsx
+++ b/src/app/components/FeaturedSlider.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
+import { useCallback, useEffect, useState } from "react";
+import OpportunityCardHorizontal from "@/app/activities/components/Card/CardHorizontal";
+import useEmblaCarousel from "embla-carousel-react";
+import { PLACEHOLDER_IMAGE } from "@/utils";
+import OpportunityImageSlider from "@/app/activities/components/FeaturedSection/ImageSlider";
+
+export default function FeaturedSlider({
+  opportunities,
+}: {
+  opportunities: (ActivityCard | QuestCard)[];
+}) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true, align: "center" });
+  const [imageSliderApi, setImageSliderApi] = useState<any>(null);
+
+  useEffect(() => {
+    if (!emblaApi) return;
+
+    const id = requestIdleCallback(() => {
+      const onSelect = () => {
+        const index = emblaApi.selectedScrollSnap();
+        setSelectedIndex(index);
+        imageSliderApi?.scrollTo(index);
+      };
+      emblaApi.on("select", onSelect);
+      onSelect();
+
+      return () => emblaApi.off("select", onSelect);
+    });
+
+    return () => cancelIdleCallback(id);
+  }, [emblaApi, imageSliderApi]);
+
+  const handleImageSlideChange = useCallback(
+    (index: number) => emblaApi?.scrollTo(index % opportunities.length),
+    [emblaApi, opportunities.length],
+  );
+
+  const images = opportunities.map((op) => op.images?.[1] ?? PLACEHOLDER_IMAGE);
+
+  return (
+    <>
+      <OpportunityImageSlider
+        images={images}
+        title={opportunities[selectedIndex]?.title ?? ""}
+        isVisible
+        onSlideChange={handleImageSlideChange}
+        onApiChange={setImageSliderApi}
+      />
+      <div className="embla h-full" ref={emblaRef}>
+        <div className="embla__container h-full">
+          {opportunities.map((op) => (
+            <div key={op.id} className="embla__slide relative h-full w-full flex-[0_0_100%]">
+              <div className="absolute inset-x-0 bottom-0 z-10 bg-gradient-to-t from-black/60 via-black/40 to-transparent px-6 pb-8 pt-16">
+                <OpportunityCardHorizontal opportunity={op as ActivityCard} />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/components/HomeSection.tsx
+++ b/src/app/components/HomeSection.tsx
@@ -1,10 +1,10 @@
 "use client";
-import ActivitiesFeaturedSection from "../activities/components/FeaturedSection/FeaturedSection";
-import ActivitiesCarouselSection from "../activities/components/CarouselSection/CarouselSection";
-import ActivitiesPageClient from "../activities/components/ActivitiesPageClient";
 import { useAuth } from "@/contexts/AuthProvider";
 import LoadingIndicator from "@/components/shared/LoadingIndicator";
-import { fetchFeaturedAndCarousel } from "../activities/data/fetchActivities";
+import FeaturedSection from "./FeaturedSection";
+import { CarouselSection } from "./CarouselSection";
+import PageClient from "./PageClient";
+import { fetchFeaturedAndCarousel } from "../data/fetchActivities";
 
 export default function HomeSection() {
   const { isAuthenticating, loading: authLoading } = useAuth();
@@ -12,16 +12,16 @@ export default function HomeSection() {
   if (isAuthenticating || authLoading) {
     return <LoadingIndicator fullScreen={true} />;
   }
-
   return (
     <div className="min-h-screen">
-      <ActivitiesFeaturedSection opportunities={featuredCards} isInitialLoading={loading} />
-      <ActivitiesCarouselSection
+      <FeaturedSection opportunities={featuredCards} isInitialLoading={loading} />
+      <CarouselSection
         title="もうすぐ開催予定"
         opportunities={upcomingCards}
         isInitialLoading={loading}
+        isVertical={false}
       />
-      <ActivitiesPageClient />
+      <PageClient />
     </div>
   );
 }

--- a/src/app/components/HomeSection.tsx
+++ b/src/app/components/HomeSection.tsx
@@ -4,17 +4,11 @@ import ActivitiesCarouselSection from "../activities/components/CarouselSection/
 import ActivitiesPageClient from "../activities/components/ActivitiesPageClient";
 import { useAuth } from "@/contexts/AuthProvider";
 import LoadingIndicator from "@/components/shared/LoadingIndicator";
-import { ActivityCard } from "../activities/data/type";
+import { fetchFeaturedAndCarousel } from "../activities/data/fetchActivities";
 
-interface HomeSectionProps {
-  featuredCards: ActivityCard[];
-  upcomingCards: ActivityCard[];
-  loading: boolean;
-}
-
-export default function HomeSection({ featuredCards, upcomingCards, loading }: HomeSectionProps) {
+export default function HomeSection() {
   const { isAuthenticating, loading: authLoading } = useAuth();
-
+  const { featuredCards, upcomingCards, loading } = fetchFeaturedAndCarousel();
   if (isAuthenticating || authLoading) {
     return <LoadingIndicator fullScreen={true} />;
   }

--- a/src/app/components/HomeSection.tsx
+++ b/src/app/components/HomeSection.tsx
@@ -1,0 +1,33 @@
+"use client";
+import ActivitiesFeaturedSection from "../activities/components/FeaturedSection/FeaturedSection";
+import ActivitiesCarouselSection from "../activities/components/CarouselSection/CarouselSection";
+import ActivitiesPageClient from "../activities/components/ActivitiesPageClient";
+import { useAuth } from "@/contexts/AuthProvider";
+import LoadingIndicator from "@/components/shared/LoadingIndicator";
+import { ActivityCard } from "../activities/data/type";
+
+interface HomeSectionProps {
+  featuredCards: ActivityCard[];
+  upcomingCards: ActivityCard[];
+  loading: boolean;
+}
+
+export default function HomeSection({ featuredCards, upcomingCards, loading }: HomeSectionProps) {
+  const { isAuthenticating, loading: authLoading } = useAuth();
+
+  if (isAuthenticating || authLoading) {
+    return <LoadingIndicator fullScreen={true} />;
+  }
+
+  return (
+    <div className="min-h-screen">
+      <ActivitiesFeaturedSection opportunities={featuredCards} isInitialLoading={loading} />
+      <ActivitiesCarouselSection
+        title="もうすぐ開催予定"
+        opportunities={upcomingCards}
+        isInitialLoading={loading}
+      />
+      <ActivitiesPageClient />
+    </div>
+  );
+}

--- a/src/app/components/PageClient.tsx
+++ b/src/app/components/PageClient.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { useActivities } from "@/app/activities/hooks/useActivities";
+import ActivitiesListSection from "@/app/activities/components/ListSection/ListSection";
+import { mapOpportunityCards } from "@/app/activities/data/presenter";
+import ErrorState from "@/components/shared/ErrorState";
+import EmptyState from "@/components/shared/EmptyState";
+import useHeaderConfig from "@/hooks/useHeaderConfig";
+import { Coins } from "lucide-react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+
+export default function PageClient() {
+  const { opportunities, loading, error, loadMoreRef, refetch } = useActivities();
+  const router = useRouter();
+  const refetchRef = useRef<(() => void) | null>(null);
+  useEffect(() => {
+    refetchRef.current = refetch;
+  }, [refetch]);
+
+  const allCards = mapOpportunityCards(opportunities.edges ?? []);
+  const firstFour = allCards.slice(0, 4);
+  const afterFour = allCards.slice(4);
+  const isFirstLoaded = !loading && opportunities?.edges?.length > 0;
+  const isEmpty = !loading && opportunities?.edges?.length === 0;
+
+  // if (!isFirstLoaded && loading) {
+  //   return (
+  //     <div className="min-h-screen pb-16">
+  //       <ListSectionSkeleton />
+  //     </div>
+  //   );
+  // }
+
+  const headerConfig = useMemo(
+    () => ({
+      showLogo: true,
+      showSearchForm: true,
+    }),
+    [],
+  );
+  useHeaderConfig(headerConfig);
+
+  if (error) {
+    return <ErrorState title="募集一覧を読み込めませんでした" refetchRef={refetchRef} />;
+  }
+
+  if (isEmpty) {
+    return <EmptyState title="募集" />;
+  }
+
+  return (
+    <div className="min-h-screen ">
+      {/* 最初の4件 */}
+      <ActivitiesListSection
+        opportunities={firstFour}
+        isInitialLoading={false}
+        isSectionLoading={loading}
+      />
+      {/* バナー */}
+      <div className="px-6">
+        <button
+          className="w-full flex bg-blue-50 rounded-lg p-4 appearance-none border-none focus:outline-none"
+          style={{ boxSizing: 'border-box' }}
+          onClick={() => {
+            router.push("/quests");
+          }}
+        >
+          <div>
+            <Coins className="w-8 h-8 text-primary" />
+          </div>
+          <div className="ml-2">
+            <div className="flex justify-between">
+              <p className="text-base font-bold text-left">ポイントを獲得すると、<br/>無料で体験に参加できます。</p>
+              <Image src={"icons/arrow.svg"} alt="arrow" width={32} height={32} className="mt-6 ml-4"/>
+            </div>
+            <span className="text-xs">ポイントがもらえるお手伝いを探してみましょう</span>
+          </div>
+        </button>
+      </div>
+      {/* 5件目以降 */}
+      <ActivitiesListSection
+        opportunities={afterFour}
+        isInitialLoading={false}
+        isSectionLoading={loading}
+      />
+      <div ref={loadMoreRef} className="h-10" aria-hidden="true" />
+    </div>
+  );
+}

--- a/src/app/components/PageClient.tsx
+++ b/src/app/components/PageClient.tsx
@@ -84,6 +84,7 @@ export default function PageClient() {
         opportunities={afterFour}
         isInitialLoading={false}
         isSectionLoading={loading}
+        isTitle={false}
       />
       <div ref={loadMoreRef} className="h-10" aria-hidden="true" />
     </div>

--- a/src/app/data/fetchActivities.ts
+++ b/src/app/data/fetchActivities.ts
@@ -1,0 +1,34 @@
+import {
+  GqlOpportunityCategory,
+  GqlPublishStatus,
+  GqlSortDirection,
+  useGetOpportunitiesQuery,
+} from "@/types/graphql";
+import { mapOpportunityCards, sliceActivitiesBySection } from "../activities/data/presenter";
+
+export function fetchFeaturedAndCarousel() {
+  const { data, loading } = useGetOpportunitiesQuery({
+    variables: {
+      filter: {
+        or: [
+          {
+            category: GqlOpportunityCategory.Activity,
+            publishStatus: [GqlPublishStatus.Public],
+          },
+          {
+            category: GqlOpportunityCategory.Quest,
+            publishStatus: [GqlPublishStatus.Public],
+          },
+        ],
+      },
+      sort: {
+        earliestSlotStartsAt: GqlSortDirection.Asc,
+      },
+      first: 10,
+    },
+    fetchPolicy: "cache-first",
+  });
+  const activityCards = mapOpportunityCards(data?.opportunities.edges ?? []);
+  const { featuredCards, upcomingCards } = sliceActivitiesBySection(activityCards);
+  return { featuredCards, upcomingCards, loading };
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,5 @@
 import HomeSection from "./components/HomeSection";
-import { fetchFeaturedAndCarousel } from "./activities/data/fetchActivities";
 
 export default async function HomePage() {
-  const { featuredCards, upcomingCards, loading } = await fetchFeaturedAndCarousel();
-  return <HomeSection featuredCards={featuredCards} upcomingCards={upcomingCards} loading={loading} />;
+  return <HomeSection />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,24 +1,7 @@
-"use client";
+import HomeSection from "./components/HomeSection";
+import { fetchFeaturedAndCarousel } from "./activities/data/fetchActivities";
 
-import React, { useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { useAuth } from "@/contexts/AuthProvider";
-import LoadingIndicator from "@/components/shared/LoadingIndicator";
-import { currentCommunityConfig } from "@/lib/communities/metadata";
-
-export default function HomePage() {
-  const router = useRouter();
-  const { isAuthenticating, loading: authLoading } = useAuth();
-
-  useEffect(() => {
-    router.replace(currentCommunityConfig.rootPath ?? "/activities");
-  }, [router]);
-
-  useEffect(() => {
-    window.scrollTo({ top: 0, behavior: "smooth" });
-  }, []);
-
-  if (isAuthenticating || authLoading) {
-    return <LoadingIndicator fullScreen={true} />;
-  }
+export default async function HomePage() {
+  const { featuredCards, upcomingCards, loading } = await fetchFeaturedAndCarousel();
+  return <HomeSection featuredCards={featuredCards} upcomingCards={upcomingCards} loading={loading} />;
 }

--- a/src/app/quests/components/Header.tsx
+++ b/src/app/quests/components/Header.tsx
@@ -1,0 +1,26 @@
+"use client";
+import useSearchResultHeader from "@/app/search/result/components/SearchResultHeader";
+import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+
+export default function QuestHeader({ id }: { id?: string }) {
+    const searchParams = useSearchParams();
+
+    const queryParams = useMemo(
+      () => ({
+        location: searchParams.get("location") ?? undefined,
+        from: searchParams.get("from") ?? undefined,
+        to: searchParams.get("to") ?? undefined,
+        guests: searchParams.get("guests") ?? undefined,
+        type: searchParams.get("type") as "quest" | undefined,
+        ticket: searchParams.get("ticket") ?? undefined,
+        points: searchParams.get("points") ?? undefined,
+        q: searchParams.get("q") ?? undefined,
+        redirectTo: id ? `/quests/${id}` : "/quests",
+      }),
+      [searchParams],
+    );
+    useSearchResultHeader(queryParams);
+
+    return null;
+}

--- a/src/app/quests/components/QuestsList.tsx
+++ b/src/app/quests/components/QuestsList.tsx
@@ -33,7 +33,7 @@ export default function QuestsList() {
     const isEmpty =
     recommendedOpportunities.length === 0 && Object.keys(groupedOpportunities).length === 0;
 
-  if (isEmpty) {
+  if (!loading && isEmpty) {
     return <EmptySearchResults searchQuery={queryParams.q} />;
   }
 

--- a/src/app/quests/components/QuestsList.tsx
+++ b/src/app/quests/components/QuestsList.tsx
@@ -20,7 +20,6 @@ export default function QuestsList() {
         ticket: searchParams.get("ticket") ?? undefined,
         points: searchParams.get("points") ?? undefined,
         q: searchParams.get("q") ?? undefined,
-        redirectTo: "/quests",
       }),
       [searchParams],
     );

--- a/src/app/quests/components/QuestsList.tsx
+++ b/src/app/quests/components/QuestsList.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { CarouselSection } from "@/app/components/CarouselSection";
+import DateGroupedOpportunities from "@/app/search/result/components/DateGroupedOpportunities";
+import EmptySearchResults from "@/app/search/result/components/EmptySearchResults";
+import useSearchResultHeader from "@/app/search/result/components/SearchResultHeader";
+import useSearchResults from "@/app/search/result/hooks/useSearchResults";
+import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+
+export default function QuestsList() {
+    const searchParams = useSearchParams();
+    
+    const queryParams = useMemo(
+      () => ({
+        location: searchParams.get("location") ?? undefined,
+        from: searchParams.get("from") ?? undefined,
+        to: searchParams.get("to") ?? undefined,
+        guests: searchParams.get("guests") ?? undefined,
+        type: "quest" as "quest" | undefined,
+        ticket: searchParams.get("ticket") ?? undefined,
+        points: searchParams.get("points") ?? undefined,
+        q: searchParams.get("q") ?? undefined,
+        redirectTo: "/quests",
+      }),
+      [searchParams],
+    );
+
+    useSearchResultHeader(queryParams);
+
+    const { recommendedOpportunities, groupedOpportunities, loading, error, refetch } =
+    useSearchResults(queryParams);
+
+    const isEmpty =
+    recommendedOpportunities.length === 0 && Object.keys(groupedOpportunities).length === 0;
+
+  if (isEmpty) {
+    return <EmptySearchResults searchQuery={queryParams.q} />;
+  }
+
+  return (
+    <>
+    <div className="min-h-screen">
+      <main>
+        <CarouselSection
+          title="おすすめの体験"
+          opportunities={recommendedOpportunities}
+          isVertical={false}
+        />
+        <DateGroupedOpportunities groupedOpportunities={groupedOpportunities} />
+      </main>
+    </div>
+    </>
+  );
+}

--- a/src/app/quests/components/index.ts
+++ b/src/app/quests/components/index.ts
@@ -1,0 +1,2 @@
+export { default as QuestHeader } from "./Header";
+export { default as QuestsList } from "./QuestsList";

--- a/src/app/quests/page.tsx
+++ b/src/app/quests/page.tsx
@@ -1,0 +1,10 @@
+import { QuestHeader, QuestsList } from "./components";
+
+export default function QuestsPage() {
+  return (
+    <>
+      <QuestHeader />
+      <QuestsList />
+    </>
+  );
+}

--- a/src/app/search/components/Footer.tsx
+++ b/src/app/search/components/Footer.tsx
@@ -5,9 +5,10 @@ import { Search } from "lucide-react";
 interface SearchFooterProps {
   onClear: () => void;
   onSearch: () => void;
+  isNoCondition?: boolean;
 }
 
-const SearchFooter: React.FC<SearchFooterProps> = ({ onClear, onSearch }) => {
+const SearchFooter: React.FC<SearchFooterProps> = ({ onClear, onSearch, isNoCondition }) => {
   return (
     <footer className="fixed bottom-0 left-0 right-0 z-50 bg-background border-t border-border max-w-mobile-l w-full h-16 flex items-center px-4 justify-between mx-auto">
         <Button

--- a/src/app/search/components/SearchBox.tsx
+++ b/src/app/search/components/SearchBox.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { Search, Calendar, Users } from "lucide-react";
+import { Search, Calendar, Users, MapPin } from "lucide-react";
 import { format } from "date-fns";
 import { ja } from "date-fns/locale";
 import { Button } from "@/components/ui/button";
@@ -11,6 +11,11 @@ interface SearchFormProps {
   from?: string;
   to?: string;
   guests?: string;
+  q?: string;
+  type?: string;
+  ticket?: string;
+  points?: string;
+  redirectTo?: string;
 }
 
 const PREFECTURE_LABELS: Record<string, string> = {
@@ -21,12 +26,22 @@ const PREFECTURE_LABELS: Record<string, string> = {
 };
 const DEFAULT_LABEL = "四国";
 
-const SearchBox = ({ location, from, to, guests }: SearchFormProps) => {
+const SearchBox = ({ location, from, to, guests, q, type, ticket, points, redirectTo }: SearchFormProps) => {
   const router = useRouter();
 
-  const getLocationText = (location: string | undefined): string => {
+  const getLocationText = (location: string | undefined, isDefault: boolean = false): string => {
     const label = location ? PREFECTURE_LABELS[location] || DEFAULT_LABEL : DEFAULT_LABEL;
-    return `${label}の体験`;
+    return isDefault ? label : `${label}の体験`;
+  };
+
+  const getKeywordText = (keyword?: string, location?: string): string => {
+    if (keyword) {
+      return keyword;
+    }
+    if (location) {
+      return getLocationText(location, false); // 例: "香川県の体験"
+    }
+    return "すべての体験";
   };
 
   const formatDateRange = () => {
@@ -51,9 +66,16 @@ const SearchBox = ({ location, from, to, guests }: SearchFormProps) => {
     if (from) params.set("from", from);
     if (to) params.set("to", to);
     if (guests) params.set("guests", guests);
+    if (q) params.set("q", q);
+    if (type) params.set("type", type);
+    if (ticket) params.set("ticket", ticket);
+    if (points) params.set("points", points);
+    if (redirectTo) params.set("redirectTo", redirectTo);
 
     router.push(`/search${params.toString() ? `?${params.toString()}` : ""}`);
   };
+  
+  const badgeCount = [ticket, points].filter(Boolean).length;
 
   return (
     <Button
@@ -64,25 +86,38 @@ const SearchBox = ({ location, from, to, guests }: SearchFormProps) => {
       <div className="absolute left-4 top-1/2 -translate-y-1/2">
         <Search className="h-6 w-6 text-muted-foreground" />
       </div>
-      {!location && !from && !to && !guests ? (
+      {!location && !from && !to && !guests && !q && !points && !ticket ? (
         <div className="flex items-center justify-center w-full h-full">
           <span className="text-body-sm text-caption font-medium">タップして検索する</span>
         </div>
       ) : (
         <div className="flex flex-col items-center justify-center w-full h-full">
-          <span className="text-sm font-medium text-foreground">{getLocationText(location)}</span>
-          <div className="flex items-center gap-1.5">
-            <div className="flex items-center gap-1.5">
-              <Calendar className="h-4 w-4 text-muted-foreground" />
-              <span className="text-xs text-muted-foreground font-medium">{formatDateRange()}</span>
-            </div>
-            <span className="text-xs text-muted-foreground mx-1">・</span>
-            <div className="flex items-center gap-1.5">
-              <Users className="h-4 w-4 text-muted-foreground" />
-              <span className="text-xs text-muted-foreground font-medium">{getGuestsText()}</span>
-            </div>
+        {/* 上部テキストを画像通りに表示 */}
+        <div className="flex items-center justify-center gap-2">
+          <span>{getKeywordText(q, location)}</span>
+          {badgeCount > 0 && (
+            <span className="ml-1 rounded-full bg-gray-200 text-gray-700 text-xs font-bold px-2 py-0.5">
+              +{badgeCount}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="flex items-center gap-1">
+            <MapPin className="h-4 w-4 text-muted-foreground" />
+            <span className="text-xs text-muted-foreground font-medium">{getLocationText(location, true)}</span>
+          </div>
+          <span className="text-xs text-muted-foreground mx-1">・</span>
+          <div className="flex items-center gap-1">
+            <Calendar className="h-4 w-4 text-muted-foreground" />
+            <span className="text-xs text-muted-foreground font-medium">{formatDateRange()}</span>
+          </div>
+          <span className="text-xs text-muted-foreground mx-1">・</span>
+          <div className="flex items-center gap-1">
+            <Users className="h-4 w-4 text-muted-foreground" />
+            <span className="text-xs text-muted-foreground font-medium">{getGuestsText()}</span>
           </div>
         </div>
+      </div>
       )}
     </Button>
   );

--- a/src/app/search/components/SearchFilterSheet.tsx
+++ b/src/app/search/components/SearchFilterSheet.tsx
@@ -5,12 +5,11 @@ import { Minus, Plus } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Calendar } from "@/components/ui/calendar";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import { DateRange } from "react-day-picker";
 import { SearchFilterType } from "@/app/search/hooks/useSearch";
 import { IPrefecture } from "@/app/search/data/type";
+import { Checkbox } from "@/components/ui/checkbox";
 
 interface FilterSheetsProps {
   activeForm: SearchFilterType;
@@ -23,6 +22,8 @@ interface FilterSheetsProps {
   setGuests: (guests: number) => void;
   useTicket: boolean;
   setUseTicket: (useTicket: boolean) => void;
+  usePoints: boolean;
+  setUsePoints: (usePoints: boolean) => void;
   clearActiveFilter: () => void;
   getSheetHeight: () => string;
   prefectures: IPrefecture[];
@@ -39,6 +40,8 @@ const SearchFilterSheets: React.FC<FilterSheetsProps> = ({
   setGuests,
   useTicket,
   setUseTicket,
+  usePoints,
+  setUsePoints,
   clearActiveFilter,
   getSheetHeight,
   prefectures,
@@ -141,14 +144,37 @@ const SearchFilterSheets: React.FC<FilterSheetsProps> = ({
   const renderOtherContent = () => (
     <div className="h-full pb-20 relative">
       <SheetHeader className="text-left pb-6">
-        <SheetTitle>その他の条件</SheetTitle>
+        <SheetTitle>その他の条件を設定</SheetTitle>
       </SheetHeader>
       <div className="space-y-4">
-        <div className="flex items-center gap-x-2">
-          <Switch id="use-ticket" checked={useTicket} onCheckedChange={setUseTicket} />
-          <Label htmlFor="use-ticket" className="text-label-md">
-            チケットを使って参加する
-          </Label>
+        <p className="text-label-md font-bold">決済手段</p>
+        <div className="rounded-xl border px-4 py-3">
+          <div className="flex items-start gap-x-2">
+            <Checkbox id="use-ticket" checked={useTicket} onCheckedChange={setUseTicket} />
+            <div>
+              <Label htmlFor="use-ticket" className="text-label-md font-bold">
+                チケット利用可
+              </Label>
+              <p className="text-muted-foreground text-sm mt-1 leading-tight">
+                主催者からもらったチケットを使って、<br />
+                無料で参加することができます。
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="rounded-xl border px-4 py-3">
+          <div className="flex items-start gap-x-2">
+            <Checkbox id="use-points" checked={usePoints} onCheckedChange={setUsePoints} />
+            <div>
+              <Label htmlFor="use-points" className="text-label-md font-bold">
+                ポイント利用可
+              </Label>
+              <p className="text-muted-foreground text-sm mt-1 leading-tight">
+              お手伝いでもらったポイントを使って、<br />
+              無料で参加することができます。
+              </p>
+            </div>
+          </div>
         </div>
       </div>
       {renderFooterButtons()}

--- a/src/app/search/components/SearchFilters.tsx
+++ b/src/app/search/components/SearchFilters.tsx
@@ -17,6 +17,7 @@ interface SearchFiltersProps {
   dateRange: DateRange | undefined;
   guests: number;
   useTicket: boolean;
+  usePoints: boolean;
 }
 
 const SearchFilters: React.FC<SearchFiltersProps> = ({
@@ -27,6 +28,7 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
   dateRange,
   guests,
   useTicket,
+  usePoints,
 }) => {
   const { control } = useFormContext();
 
@@ -103,7 +105,9 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
                 verticalLayout={true}
                 className="rounded-b-xl"
               >
-                {useTicket && "チケットで支払える"}
+              {[useTicket && "チケット利用可", usePoints && "ポイント利用可"]
+                .filter(Boolean)
+                .join(",")}
               </FilterButton>
             </FormControl>
           </FormItem>

--- a/src/app/search/components/SearchForm.tsx
+++ b/src/app/search/components/SearchForm.tsx
@@ -5,19 +5,29 @@ import { Input } from "@/components/ui/input";
 import { FormField, FormItem, FormControl } from "@/components/ui/form";
 import { useFormContext } from "react-hook-form";
 import { Search } from "lucide-react";
+import { useRouter } from "next/navigation";
 
 interface SearchFormProps {
   name?: string;
   onSearch?: () => void;
+  redirectTo?: string;
 }
 
-const SearchForm: React.FC<SearchFormProps> = ({ name = "searchQuery", onSearch }) => {
-  const { control } = useFormContext();
+const SearchForm: React.FC<SearchFormProps> = ({ name = "searchQuery", onSearch, redirectTo }) => {
+  const { control, getValues } = useFormContext();
+  const router = useRouter();
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Enter" && onSearch) {
+    if (event.key === "Enter") {
       event.preventDefault();
-      onSearch();
+      if (onSearch) {
+        onSearch();
+      } else if (redirectTo) {
+        const value = getValues(name);
+        const params = new URLSearchParams();
+        if (value) params.set(name, value);
+        router.push(`${redirectTo}?${params.toString()}`);
+      }
     }
   };
 

--- a/src/app/search/components/Tabs.tsx
+++ b/src/app/search/components/Tabs.tsx
@@ -1,4 +1,3 @@
-/*
 "use client";
 
 import React from "react";
@@ -39,4 +38,3 @@ const SearchTabs: React.FC<SearchTabsProps> = ({ selectedTab, onTabChange }) => 
 };
 
 export default SearchTabs;
-*/

--- a/src/app/search/data/presenter.ts
+++ b/src/app/search/data/presenter.ts
@@ -5,6 +5,7 @@ import { format } from "date-fns";
 import { ja } from "date-fns/locale";
 import { GqlOpportunity as GraphQLOpportunity, GqlOpportunityEdge } from "@/types/graphql";
 import { ActivityCard } from "@/app/activities/data/type";
+import { QuestCard } from "@/app/activities/data/type";
 
 export interface SearchParams {
   location?: string;
@@ -13,7 +14,9 @@ export interface SearchParams {
   guests?: string;
   type?: "activity" | "quest";
   ticket?: string;
+  points?: string;
   q?: string;
+  redirectTo?: string;
 }
 
 export const formatDateRange = (range: DateRange | undefined): string => {
@@ -28,6 +31,7 @@ export function buildSearchResultParams(
   dateRange: DateRange | undefined,
   guests: number,
   useTicket: boolean,
+  usePoints: boolean,
   type: "activity" | "quest",
 ): URLSearchParams {
   const params = new URLSearchParams();
@@ -38,6 +42,7 @@ export function buildSearchResultParams(
   if (dateRange?.to) params.set("to", formatDateToJST(dateRange.to));
   if (guests > 0) params.set("guests", guests.toString());
   if (useTicket) params.set("ticket", "1");
+  if (usePoints) params.set("points", "1");
   params.set("type", type);
 
   return params;
@@ -57,6 +62,8 @@ export const mapNodeToCardProps = (node: GraphQLOpportunity): ActivityCard => ({
   images: node.images || [],
   communityId: node.community?.id || "",
   hasReservableTicket: node.isReservableWithTicket || false,
+  pointsToRequired: node.pointsToRequired || null,
+  slots: node.slots || [],
 });
 
 export const groupOpportunitiesByDate = (
@@ -86,6 +93,33 @@ export const groupOpportunitiesByDate = (
       }
     });
 
+    return acc;
+  }, {});
+};
+
+// ActivityCard | QuestCard[] を受け取り、各カードのslotから日付ごとにグループ化
+export const groupCardsByDate = (
+  cards: (ActivityCard | QuestCard)[],
+  dateRange?: { gte?: Date; lte?: Date },
+): { [key: string]: (ActivityCard | QuestCard)[] } => {
+  return cards.reduce((acc: { [key: string]: (ActivityCard | QuestCard)[] }, card) => {
+    // QuestCard/ActivityCardともにslotsプロパティがある前提
+    // slotsがなければスキップ
+    // @ts-ignore
+    const slots = card.slots || [];
+    if (!slots.length) return acc;
+
+    slots.forEach((slot: any) => {
+      const start = new Date(slot.startsAt);
+      if (dateRange?.gte && start < dateRange.gte) return;
+      if (dateRange?.lte && start > dateRange.lte) return;
+      const dateKey = format(new Date(slot.startsAt), "yyyy-MM-dd");
+      if (!acc[dateKey]) acc[dateKey] = [];
+      // 同じidのカードが既に入っていればスキップ
+      if (!acc[dateKey].some((c) => c.id === card.id)) {
+        acc[dateKey].push(card);
+      }
+    });
     return acc;
   }, {});
 };

--- a/src/app/search/hooks/useSearchForm.ts
+++ b/src/app/search/hooks/useSearchForm.ts
@@ -18,6 +18,8 @@ export function useSearchForm() {
     setValue("dateRange", undefined);
     setValue("guests", 1);
     setValue("useTicket", false);
+    setValue("usePoints", false);
+    setValue("type", "activity");
   };
 
   const baseClearActiveFilter = (activeForm: SearchFilterType) => {

--- a/src/app/search/hooks/useSearchForm.ts
+++ b/src/app/search/hooks/useSearchForm.ts
@@ -11,6 +11,7 @@ export function useSearchForm() {
   const dateRange = watch("dateRange") as DateRange | undefined;
   const guests = watch("guests") as number;
   const useTicket = watch("useTicket") as boolean;
+  const usePoints = watch("usePoints") as boolean;
 
   const handleClear = () => {
     setValue("location", "");
@@ -41,6 +42,7 @@ export function useSearchForm() {
     dateRange,
     guests,
     useTicket,
+    usePoints,
     handleClear,
     baseClearActiveFilter,
     getValues,

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -29,6 +29,9 @@ export default function SearchPage() {
   useHeaderConfig(headerConfig);
 
   const searchParams = useSearchParams();
+  const redirectTo = searchParams.get("redirectTo") || "/search/result";
+  const typeParam = searchParams.get("type");
+  const type = typeParam === "quest" ? "quest" : "activity";
 
   // Initialize form with search parameters from URL
   const methods = useForm({
@@ -81,6 +84,8 @@ export default function SearchPage() {
               formatDateRange={formatDateRange}
               prefectureLabels={visiblePrefectureLabels}
               router={router}
+              redirectTo={redirectTo}
+              type={type}
             />
           </FormProvider>
         </div>
@@ -96,6 +101,8 @@ function SearchPageContent({
   formatDateRange,
   prefectureLabels,
   router,
+  redirectTo,
+  type,
 }: {
   activeForm: SearchFilterType;
   setActiveForm: (f: SearchFilterType) => void;
@@ -103,12 +110,15 @@ function SearchPageContent({
   formatDateRange: (r: DateRange | undefined) => string;
   prefectureLabels: Record<string, string>;
   router: ReturnType<typeof useRouter>;
+  redirectTo: string;
+  type: "activity" | "quest";
 }) {
   const {
     location,
     dateRange,
     guests,
     useTicket,
+    usePoints,
     getValues,
     setValue,
     handleClear,
@@ -130,10 +140,11 @@ function SearchPageContent({
       values.dateRange,
       values.guests,
       values.useTicket,
-      "activity",
+      values.usePoints,
+      type,
       // selectedTab,
     );
-    router.push(`/search/result?${params.toString()}`);
+    router.push(`${redirectTo}?${params.toString()}`);
   };
 
   return (
@@ -147,6 +158,7 @@ function SearchPageContent({
         dateRange={dateRange}
         guests={guests}
         useTicket={useTicket}
+        usePoints={usePoints}
       />
       <SearchFilterSheets
         activeForm={activeForm}
@@ -159,6 +171,8 @@ function SearchPageContent({
         setGuests={(val) => setValue("guests", val)}
         useTicket={useTicket}
         setUseTicket={(val) => setValue("useTicket", val)}
+        usePoints={usePoints}
+        setUsePoints={(val) => setValue("usePoints", val)}
         clearActiveFilter={clearActiveFilter}
         getSheetHeight={() => "90vh"}
         prefectures={Object.entries(prefectureLabels).map(([id, name]) => ({ id, name }))}

--- a/src/app/search/result/components/DateGroupedOpportunities.tsx
+++ b/src/app/search/result/components/DateGroupedOpportunities.tsx
@@ -3,11 +3,13 @@
 import React from "react";
 import { format } from "date-fns";
 import { ja } from "date-fns/locale";
-import { ActivityCard } from "@/app/activities/data/type";
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
 import ActivitiesCarouselSection from "@/app/activities/components/CarouselSection/CarouselSection";
+import { GqlOpportunityCategory } from "@/types/graphql";
+import { CarouselSection } from "@/app/components/CarouselSection";
 
 interface DateGroupedOpportunitiesProps {
-  groupedOpportunities: Record<string, ActivityCard[]>;
+  groupedOpportunities: Record<string, (ActivityCard | QuestCard)[]>;
 }
 
 const DateGroupedOpportunities: React.FC<DateGroupedOpportunitiesProps> = ({
@@ -21,14 +23,31 @@ const DateGroupedOpportunities: React.FC<DateGroupedOpportunitiesProps> = ({
 
   return (
     <section>
-      {sortedEntries.map(([dateKey, opportunities]) => (
-        <ActivitiesCarouselSection
-          key={dateKey}
-          title={format(new Date(dateKey), "M/d(E)", { locale: ja })}
-          opportunities={opportunities}
-          isSearchResult={true}
-        />
-      ))}
+      {sortedEntries.map(([dateKey, opportunities]) => {
+        if (opportunities.length === 0) return null;
+        const first = opportunities[0];
+        if (first.category === GqlOpportunityCategory.Activity) {
+          return (
+            <ActivitiesCarouselSection
+              key={dateKey}
+              title={format(new Date(dateKey), "M/d(E)", { locale: ja })}
+              opportunities={opportunities as ActivityCard[]}
+              isSearchResult={true}
+            />
+          );
+        }
+        if (first.category === GqlOpportunityCategory.Quest) {
+          return (
+            <CarouselSection
+              key={dateKey}
+              title={format(new Date(dateKey), "M/d(E)", { locale: ja })}
+              opportunities={opportunities as QuestCard[]}
+              isSearchResult={true}
+            />
+          );
+        }
+        return null;
+      })}
     </section>
   );
 };

--- a/src/app/search/result/components/SearchResultHeader.tsx
+++ b/src/app/search/result/components/SearchResultHeader.tsx
@@ -13,7 +13,8 @@ const useSearchResultHeader = (searchParams: SearchParams) => {
       previousSearchParams.location !== searchParams.location ||
       previousSearchParams.from !== searchParams.from ||
       previousSearchParams.to !== searchParams.to ||
-      previousSearchParams.guests !== searchParams.guests
+      previousSearchParams.guests !== searchParams.guests ||
+      previousSearchParams.q !== searchParams.q
     ) {
       updateConfig({
         showSearchForm: true,
@@ -22,9 +23,13 @@ const useSearchResultHeader = (searchParams: SearchParams) => {
           from: searchParams.from,
           to: searchParams.to,
           guests: searchParams.guests && !isNaN(parseInt(searchParams.guests, 10)) ? parseInt(searchParams.guests, 10) : undefined,
+          redirectTo: searchParams.redirectTo,
+          q: searchParams.q,
+          points: searchParams.points,
+          ticket: searchParams.ticket,
         },
         showLogo: false,
-        showBackButton: true,
+        showBackButton: false,
       });
 
       setPreviousSearchParams(searchParams);

--- a/src/app/search/result/hooks/useSearchResults.ts
+++ b/src/app/search/result/hooks/useSearchResults.ts
@@ -153,7 +153,7 @@ function buildFilter(searchParams: SearchParams): OpportunityFilterInput {
     }
   }
 
-  if (searchParams.ticket === "true") {
+  if (searchParams.ticket === "1") {
     filter.isReservableWithTicket = true;
   }
 

--- a/src/app/users/components/UserProfileSection.tsx
+++ b/src/app/users/components/UserProfileSection.tsx
@@ -40,7 +40,7 @@ const UserProfileSection: React.FC<UserProfileSectionProps> = ({
       {isOwner && (
         <UserTicketsAndPoints
           ticketCount={userAsset.tickets.filter(t => t.status === GqlTicketStatus.Available).length || 0}
-          pointCount={userAsset.points.currentPoint || 0}
+          pointCount={Number(userAsset.points.currentPoint) || 0}
         />
       )}
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -13,7 +13,6 @@ import { cn } from "@/lib/utils";
 import SearchBox from "@/app/search/components/SearchBox";
 import { AuthEnvironment, detectEnvironment } from "@/lib/auth/environment-detector";
 import { currentCommunityConfig } from "@/lib/communities/metadata";
-
 interface HeaderProps {
   className?: string;
 }
@@ -34,7 +33,7 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
     } else if (pathname === "/search/result") {
       // When on search results page, preserve all search parameters when going back to search page
       const params = new URLSearchParams(searchParams);
-      router.push(`/search?${params.toString()}`);
+      router.push(`${config.searchParams?.redirectTo ?? "/search"}?${params.toString()}`);
     } else {
       navigateBack();
     }
@@ -80,6 +79,11 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
             from={config.searchParams?.from}
             to={config.searchParams?.to}
             guests={config.searchParams?.guests?.toString()}
+            q={config.searchParams?.q}
+            type={config.searchParams?.type}
+            ticket={config.searchParams?.ticket}
+            points={config.searchParams?.points}
+            redirectTo={config.searchParams?.redirectTo}
           />
         </div>
       )}

--- a/src/components/providers/HeaderProvider.tsx
+++ b/src/components/providers/HeaderProvider.tsx
@@ -16,6 +16,11 @@ export interface HeaderConfig {
     from?: string;
     to?: string;
     guests?: number;
+    redirectTo?: string;
+    q?: string;
+    type?: string;
+    ticket?: string;
+    points?: string;
   };
 }
 
@@ -68,7 +73,14 @@ const HeaderProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const pathname = usePathname();
 
   const updateConfig = useCallback((newConfig: Partial<HeaderConfig>) => {
-    setConfig((prevConfig: HeaderConfig) => ({ ...prevConfig, ...newConfig }));
+    setConfig((prevConfig: HeaderConfig) => ({
+      ...prevConfig,
+      ...newConfig,
+      searchParams: {
+        ...prevConfig.searchParams,
+        ...newConfig.searchParams,
+      },
+    }));
   }, []);
 
   const resetConfig = useCallback(() => {

--- a/src/graphql/experience/opportunity/fragment.ts
+++ b/src/graphql/experience/opportunity/fragment.ts
@@ -15,6 +15,7 @@ export const OPPORTUNITY_FRAGMENT = gql`
 
     feeRequired
     pointsToEarn
+    pointsToRequired
 
     earliestReservableAt
   }

--- a/src/graphql/experience/opportunity/query.ts
+++ b/src/graphql/experience/opportunity/query.ts
@@ -105,6 +105,8 @@ export const GET_OPPORTUNITY = gql`
       requireApproval
       requiredUtilities {
         id
+        pointsRequired
+        publishStatus
       }
     }
   }

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -1062,6 +1062,7 @@ export type GqlOpportunity = {
   isReservableWithTicket?: Maybe<Scalars["Boolean"]["output"]>;
   place?: Maybe<GqlPlace>;
   pointsToEarn?: Maybe<Scalars["Int"]["output"]>;
+  pointsToRequired?: Maybe<Scalars["Boolean"]["output"]>;
   publishStatus: GqlPublishStatus;
   requireApproval: Scalars["Boolean"]["output"];
   requiredUtilities?: Maybe<Array<GqlUtility>>;
@@ -1249,18 +1250,16 @@ export type GqlOpportunitySortInput = {
 
 export type GqlOpportunityUpdateContentInput = {
   body?: InputMaybe<Scalars["String"]["input"]>;
-  capacity?: InputMaybe<Scalars["Int"]["input"]>;
   category: GqlOpportunityCategory;
   description: Scalars["String"]["input"];
-  endsAt?: InputMaybe<Scalars["Datetime"]["input"]>;
   feeRequired?: InputMaybe<Scalars["Int"]["input"]>;
   images?: InputMaybe<Array<GqlImageInput>>;
-  place?: InputMaybe<GqlNestedPlaceConnectOrCreateInput>;
+  placeId?: InputMaybe<Scalars["ID"]["input"]>;
   pointsToEarn?: InputMaybe<Scalars["Int"]["input"]>;
   publishStatus: GqlPublishStatus;
+  relatedArticleIds?: InputMaybe<Array<Scalars["ID"]["input"]>>;
   requireApproval: Scalars["Boolean"]["input"];
   requiredUtilityIds?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  startsAt?: InputMaybe<Scalars["Datetime"]["input"]>;
   title: Scalars["String"]["input"];
 };
 
@@ -3162,6 +3161,7 @@ export type GqlGetUserFlexibleQuery = {
       requireApproval: boolean;
       feeRequired?: number | null;
       pointsToEarn?: number | null;
+      pointsToRequired?: boolean | null;
       earliestReservableAt?: Date | null;
       community?: {
         __typename?: "Community";
@@ -3624,6 +3624,7 @@ export type GqlGetArticleQuery = {
         requireApproval: boolean;
         feeRequired?: number | null;
         pointsToEarn?: number | null;
+        pointsToRequired?: boolean | null;
         earliestReservableAt?: Date | null;
         place?: {
           __typename?: "Place";
@@ -3902,6 +3903,7 @@ export type GqlOpportunityFieldsFragment = {
   requireApproval: boolean;
   feeRequired?: number | null;
   pointsToEarn?: number | null;
+  pointsToRequired?: boolean | null;
   earliestReservableAt?: Date | null;
 };
 
@@ -3943,6 +3945,7 @@ export type GqlGetOpportunitiesQuery = {
         requireApproval: boolean;
         feeRequired?: number | null;
         pointsToEarn?: number | null;
+        pointsToRequired?: boolean | null;
         earliestReservableAt?: Date | null;
         place?: {
           __typename?: "Place";
@@ -3988,6 +3991,7 @@ export type GqlGetOpportunityQuery = {
     isReservableWithTicket?: boolean | null;
     feeRequired?: number | null;
     pointsToEarn?: number | null;
+    pointsToRequired?: boolean | null;
     earliestReservableAt?: Date | null;
     community?: {
       __typename?: "Community";
@@ -4092,6 +4096,7 @@ export type GqlGetOpportunityQuery = {
         requireApproval: boolean;
         feeRequired?: number | null;
         pointsToEarn?: number | null;
+        pointsToRequired?: boolean | null;
         earliestReservableAt?: Date | null;
         community?: {
           __typename?: "Community";
@@ -4221,6 +4226,7 @@ export type GqlGetOpportunitySlotsQuery = {
           requireApproval: boolean;
           feeRequired?: number | null;
           pointsToEarn?: number | null;
+          pointsToRequired?: boolean | null;
           earliestReservableAt?: Date | null;
         } | null;
         reservations?: Array<{
@@ -4287,6 +4293,7 @@ export type GqlGetOpportunitySlotWithParticipationsQuery = {
       requireApproval: boolean;
       feeRequired?: number | null;
       pointsToEarn?: number | null;
+      pointsToRequired?: boolean | null;
       earliestReservableAt?: Date | null;
       community?: {
         __typename?: "Community";
@@ -4439,6 +4446,7 @@ export type GqlGetParticipationQuery = {
           requireApproval: boolean;
           feeRequired?: number | null;
           pointsToEarn?: number | null;
+          pointsToRequired?: boolean | null;
           earliestReservableAt?: Date | null;
           community?: {
             __typename?: "Community";
@@ -4502,6 +4510,7 @@ export type GqlGetParticipationQuery = {
         requireApproval: boolean;
         feeRequired?: number | null;
         pointsToEarn?: number | null;
+        pointsToRequired?: boolean | null;
         earliestReservableAt?: Date | null;
         community?: {
           __typename?: "Community";
@@ -4819,6 +4828,7 @@ export type GqlGetReservationQuery = {
         requireApproval: boolean;
         feeRequired?: number | null;
         pointsToEarn?: number | null;
+        pointsToRequired?: boolean | null;
         earliestReservableAt?: Date | null;
         slots?: Array<{
           __typename?: "OpportunitySlot";
@@ -5107,6 +5117,7 @@ export type GqlGetPlaceQuery = {
       requireApproval: boolean;
       feeRequired?: number | null;
       pointsToEarn?: number | null;
+      pointsToRequired?: boolean | null;
       earliestReservableAt?: Date | null;
       place?: {
         __typename?: "Place";
@@ -5835,6 +5846,7 @@ export const OpportunityFieldsFragmentDoc = gql`
     requireApproval
     feeRequired
     pointsToEarn
+    pointsToRequired
     earliestReservableAt
   }
 `;

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -1133,6 +1133,7 @@ export type GqlOpportunityFilterInput = {
   not?: InputMaybe<GqlOpportunityFilterInput>;
   or?: InputMaybe<Array<GqlOpportunityFilterInput>>;
   placeIds?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+  pointsToRequired?: InputMaybe<Scalars["Boolean"]["input"]>;
   publishStatus?: InputMaybe<Array<GqlPublishStatus>>;
   requiredUtilityIds?: InputMaybe<Array<Scalars["ID"]["input"]>>;
   slotDateRange?: InputMaybe<GqlDateTimeRangeFilter>;
@@ -4144,7 +4145,12 @@ export type GqlGetOpportunityQuery = {
       }> | null;
       nftWallet?: { __typename?: "NftWallet"; id: string; walletAddress: string } | null;
     } | null;
-    requiredUtilities?: Array<{ __typename?: "Utility"; id: string }> | null;
+    requiredUtilities?: Array<{
+      __typename?: "Utility";
+      id: string;
+      pointsRequired: number;
+      publishStatus: GqlPublishStatus;
+    }> | null;
   } | null;
 };
 
@@ -8057,6 +8063,8 @@ export const GetOpportunityDocument = gql`
       requireApproval
       requiredUtilities {
         id
+        pointsRequired
+        publishStatus
       }
     }
   }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -72,3 +72,20 @@ export function formatSlotRange(startsAt: string, endsAt: string): string {
     return `${startDate}~${endDate}`;
   }
 }
+
+export function formatJapaneseDateTime(startDateTime: string, endDateTime: string): string {
+  const start = new Date(startDateTime);
+  const end = new Date(endDateTime);
+
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  
+  // 曜日の配列
+  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
+  const weekday = weekdays[start.getDay()];
+
+  const date = `${start.getFullYear()}年${pad(start.getMonth() + 1)}月${pad(start.getDate())}日(${weekday})`;
+  const startTime = `${pad(start.getHours())}:${pad(start.getMinutes())}`;
+  const endTime = `${pad(end.getHours())}:${pad(end.getMinutes())}`;
+
+  return `${date} ${startTime}~${endTime}`;
+}


### PR DESCRIPTION
- ホームページのコンポーネントをリファクタリングし、`HomeSection`を追加。
- `ActivitiesPageClient`でのカード表示を改善し、SVGアイコンを新規追加。初期読み込み状態の管理を強化。

> トップページ

https://github.com/user-attachments/assets/0ff63d0f-c49b-4053-a705-3e2129b2a858

> questsページ

https://github.com/user-attachments/assets/9500902e-3069-4a2c-860b-5465d16c2c24


