### PR TITLE
Add communityId filter to evaluation queries

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -3561,6 +3561,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "communityId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "evaluatorId",
             "description": null,
             "type": {
@@ -10542,18 +10554,6 @@
             "deprecationReason": null
           },
           {
-            "name": "capacity",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "category",
             "description": null,
             "type": {
@@ -10580,18 +10580,6 @@
                 "name": "String",
                 "ofType": null
               }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "endsAt",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Datetime",
-              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -10630,11 +10618,11 @@
             "deprecationReason": null
           },
           {
-            "name": "place",
+            "name": "placeId",
             "description": null,
             "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "NestedPlaceConnectOrCreateInput",
+              "kind": "SCALAR",
+              "name": "ID",
               "ofType": null
             },
             "defaultValue": null,
@@ -10663,6 +10651,26 @@
                 "kind": "ENUM",
                 "name": "PublishStatus",
                 "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "relatedArticleIds",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               }
             },
             "defaultValue": null,
@@ -10700,18 +10708,6 @@
                   "ofType": null
                 }
               }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "startsAt",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Datetime",
-              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/src/app/admin/credentials/components/CredentialList.tsx
+++ b/src/app/admin/credentials/components/CredentialList.tsx
@@ -5,110 +5,130 @@ import { Card } from "@/components/ui/card";
 import { GqlEvaluationStatus, GqlVcIssuanceStatus, useGetEvaluationsQuery } from "@/types/graphql";
 import { useRouter } from "next/navigation";
 import { AlertTriangle } from "lucide-react";
-import { useMemo, useEffect } from "react";
+import { useMemo } from "react";
+import { COMMUNITY_ID } from "@/lib/communities/metadata";
 
 function getIssuanceStats(evaluations: any[]) {
-  const allRequests = evaluations.flatMap(ev => {
+  const allRequests = evaluations.flatMap((ev) => {
     const req = ev.node?.vcIssuanceRequest;
     if (!req) return [];
     return Array.isArray(req) ? req : [req];
   });
   const denominator = allRequests.length;
-  const numerator = allRequests.filter(req => req?.status === GqlVcIssuanceStatus.Completed).length;
-  const hasPending = allRequests.some(req => req?.status === GqlVcIssuanceStatus.Pending || req?.status === GqlVcIssuanceStatus.Processing);
-  const hasFailed = allRequests.some(req => req?.status === GqlVcIssuanceStatus.Failed);
+  const numerator = allRequests.filter(
+    (req) => req?.status === GqlVcIssuanceStatus.Completed,
+  ).length;
+  const hasPending = allRequests.some(
+    (req) =>
+      req?.status === GqlVcIssuanceStatus.Pending || req?.status === GqlVcIssuanceStatus.Processing,
+  );
+  const hasFailed = allRequests.some((req) => req?.status === GqlVcIssuanceStatus.Failed);
   return { denominator, numerator, hasPending, hasFailed };
 }
 
 export default function CredentialList() {
-    const router = useRouter();
-    const { data, loading, error } = useGetEvaluationsQuery();
-    
-    const evaluationList = useMemo(() => {
-        if (!data?.evaluations.edges) return [];
-        
-        return data.evaluations.edges
-            .filter((evaluation) => evaluation.node?.status === GqlEvaluationStatus.Passed)
-            .sort((a, b) => {
-                const aDate = a.node?.createdAt ? new Date(a.node.createdAt).getTime() : 0;
-                const bDate = b.node?.createdAt ? new Date(b.node.createdAt).getTime() : 0;
-                return bDate - aDate; 
-            });
-    }, [data?.evaluations.edges]);
+  const router = useRouter();
+  const { data, loading, error } = useGetEvaluationsQuery({
+    variables: { filter: { communityId: COMMUNITY_ID } },
+  });
 
-    const slotEvaluationsMap = useMemo(() => {
-        return evaluationList.reduce((acc, evaluation) => {
-            const slotId = evaluation.node?.participation?.opportunitySlot?.id;
-            if (!slotId) return acc;
-            if (!acc[slotId]) acc[slotId] = [];
-            acc[slotId].push(evaluation);
-            return acc;
-        }, {} as Record<string, typeof evaluationList>);
-    }, [evaluationList]);
+  const evaluationList = useMemo(() => {
+    if (!data?.evaluations.edges) return [];
 
-    const uniqueSlotEvaluations = useMemo(() => {
-        return Object.entries(slotEvaluationsMap).map(([slotId, evaluations]) => ({
-            slotId,
-            evaluations,
-            representative: evaluations[0],
-        }));
-    }, [slotEvaluationsMap]);
+    return data.evaluations.edges
+      .filter((evaluation) => evaluation.node?.status === GqlEvaluationStatus.Passed)
+      .sort((a, b) => {
+        const aDate = a.node?.createdAt ? new Date(a.node.createdAt).getTime() : 0;
+        const bDate = b.node?.createdAt ? new Date(b.node.createdAt).getTime() : 0;
+        return bDate - aDate;
+      });
+  }, [data?.evaluations.edges]);
 
-    if (loading || !data?.evaluations.edges) return <Loading />;
-    if (error) return <div>Error: {error.message}</div>;
-    
-    return (
-        <div className="space-y-4">
-            {uniqueSlotEvaluations.length === 0 ? <div className="text-[#71717A]">証明書はまだありません</div> :
-                uniqueSlotEvaluations.map(({ slotId, evaluations, representative }) => {
-                    const { denominator, numerator, hasPending, hasFailed } = getIssuanceStats(evaluations);
-                    const evaluationData = representative.node;
-                    const title = evaluationData?.participation?.opportunitySlot?.opportunity?.title ?? "";
-                    const start = evaluationData?.participation?.opportunitySlot?.startsAt
-                        ? new Date(evaluationData.participation.opportunitySlot.startsAt)
-                        : null;
-                    const end = evaluationData?.participation?.opportunitySlot?.endsAt
-                        ? new Date(evaluationData.participation.opportunitySlot.endsAt)
-                        : null;
-                    const issuedAt = evaluationData?.createdAt
-                        ? new Date(evaluationData.createdAt).toLocaleDateString("ja-JP", { year: "numeric", month: "numeric", day: "numeric" })
-                        : "";
-
-                    return (
-                        <Card
-                            key={evaluationData?.id}
-                            className="rounded-xl border border-gray-200 p-4 flex flex-col cursor-pointer"
-                            onClick={() => router.push(`/admin/credentials/${evaluationData?.id}`)}
-                        >
-                            <div className="flex-1">
-                                <div className="font-bold text-lg truncate" style={{ maxWidth: "100%" }}>
-                                    {title}
-                                </div>
-                                <div className="text-gray-500 text-sm mt-1">
-                                    {start && end ? (
-                                        start.getFullYear() === end.getFullYear() &&
-                                        start.getMonth() === end.getMonth() &&
-                                        start.getDate() === end.getDate() ? (
-                                            `${start.getFullYear()}年${start.getMonth() + 1}月${start.getDate()}日 ${start.getHours()}:${String(start.getMinutes()).padStart(2, '0')}~${end.getHours()}:${String(end.getMinutes()).padStart(2, '0')}`
-                                        ) : (
-                                            `${start.getFullYear()}年${start.getMonth() + 1}月${start.getDate()}日~${end.getMonth() + 1}月${end.getDate()}日`
-                                        )
-                                    ) : ""}
-                                </div>
-                            </div>
-                            <div className="flex justify-between items-end mt-4">
-                                <div className="text-gray-400 text-sm flex items-center">
-                                    <span>発行数</span>
-                                    {hasFailed ? <AlertTriangle className="text-red-400 w-5 h-5 mx-1" />  : hasPending && <AlertTriangle className="text-yellow-400 w-5 h-5 mx-1" />}
-                                    <span className="font-bold text-lg text-black mx-1">{numerator}</span>
-                                    <span>/</span>
-                                    <span>{denominator}</span>
-                                </div>
-                                <div className="text-gray-400 text-sm">{issuedAt}</div>
-                            </div>
-                        </Card>
-                    );
-                })}
-        </div>
+  const slotEvaluationsMap = useMemo(() => {
+    return evaluationList.reduce(
+      (acc, evaluation) => {
+        const slotId = evaluation.node?.participation?.opportunitySlot?.id;
+        if (!slotId) return acc;
+        if (!acc[slotId]) acc[slotId] = [];
+        acc[slotId].push(evaluation);
+        return acc;
+      },
+      {} as Record<string, typeof evaluationList>,
     );
+  }, [evaluationList]);
+
+  const uniqueSlotEvaluations = useMemo(() => {
+    return Object.entries(slotEvaluationsMap).map(([slotId, evaluations]) => ({
+      slotId,
+      evaluations,
+      representative: evaluations[0],
+    }));
+  }, [slotEvaluationsMap]);
+
+  if (loading || !data?.evaluations.edges) return <Loading />;
+  if (error) return <div>Error: {error.message}</div>;
+
+  return (
+    <div className="space-y-4">
+      {uniqueSlotEvaluations.length === 0 ? (
+        <div className="text-[#71717A]">証明書はまだありません</div>
+      ) : (
+        uniqueSlotEvaluations.map(({ slotId, evaluations, representative }) => {
+          const { denominator, numerator, hasPending, hasFailed } = getIssuanceStats(evaluations);
+          const evaluationData = representative.node;
+          const title = evaluationData?.participation?.opportunitySlot?.opportunity?.title ?? "";
+          const start = evaluationData?.participation?.opportunitySlot?.startsAt
+            ? new Date(evaluationData.participation.opportunitySlot.startsAt)
+            : null;
+          const end = evaluationData?.participation?.opportunitySlot?.endsAt
+            ? new Date(evaluationData.participation.opportunitySlot.endsAt)
+            : null;
+          const issuedAt = evaluationData?.createdAt
+            ? new Date(evaluationData.createdAt).toLocaleDateString("ja-JP", {
+                year: "numeric",
+                month: "numeric",
+                day: "numeric",
+              })
+            : "";
+
+          return (
+            <Card
+              key={evaluationData?.id}
+              className="rounded-xl border border-gray-200 p-4 flex flex-col cursor-pointer"
+              onClick={() => router.push(`/admin/credentials/${evaluationData?.id}`)}
+            >
+              <div className="flex-1">
+                <div className="font-bold text-lg truncate" style={{ maxWidth: "100%" }}>
+                  {title}
+                </div>
+                <div className="text-gray-500 text-sm mt-1">
+                  {start && end
+                    ? start.getFullYear() === end.getFullYear() &&
+                      start.getMonth() === end.getMonth() &&
+                      start.getDate() === end.getDate()
+                      ? `${start.getFullYear()}年${start.getMonth() + 1}月${start.getDate()}日 ${start.getHours()}:${String(start.getMinutes()).padStart(2, "0")}~${end.getHours()}:${String(end.getMinutes()).padStart(2, "0")}`
+                      : `${start.getFullYear()}年${start.getMonth() + 1}月${start.getDate()}日~${end.getMonth() + 1}月${end.getDate()}日`
+                    : ""}
+                </div>
+              </div>
+              <div className="flex justify-between items-end mt-4">
+                <div className="text-gray-400 text-sm flex items-center">
+                  <span>発行数</span>
+                  {hasFailed ? (
+                    <AlertTriangle className="text-red-400 w-5 h-5 mx-1" />
+                  ) : (
+                    hasPending && <AlertTriangle className="text-yellow-400 w-5 h-5 mx-1" />
+                  )}
+                  <span className="font-bold text-lg text-black mx-1">{numerator}</span>
+                  <span>/</span>
+                  <span>{denominator}</span>
+                </div>
+                <div className="text-gray-400 text-sm">{issuedAt}</div>
+              </div>
+            </Card>
+          );
+        })
+      )}
+    </div>
+  );
 }

--- a/src/graphql/experience/evaluation/query.ts
+++ b/src/graphql/experience/evaluation/query.ts
@@ -1,8 +1,8 @@
-import { gql } from '@apollo/client';
+import { gql } from "@apollo/client";
 
 export const GET_EVALUATIONS = gql`
-  query GetEvaluations ($withDidIssuanceRequests: Boolean! = false) {
-    evaluations {
+  query GetEvaluations($filter: EvaluationFilterInput, $withDidIssuanceRequests: Boolean! = false) {
+    evaluations(filter: $filter) {
       edges {
         node {
           id
@@ -68,22 +68,22 @@ export const GET_EVALUATION = gql`
         }
       }
       participation {
-          opportunitySlot {
+        opportunitySlot {
+          id
+          startsAt
+          endsAt
+          capacity
+          opportunity {
             id
-            startsAt
-            endsAt
-            capacity
-            opportunity {
+            title
+            description
+            createdByUser {
               id
-              title
-              description
-              createdByUser {
-                id
-                name
-              }
+              name
             }
           }
         }
+      }
     }
   }
 `;

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -416,6 +416,7 @@ export type GqlEvaluationEdge = GqlEdge & {
 };
 
 export type GqlEvaluationFilterInput = {
+  communityId?: InputMaybe<Scalars["ID"]["input"]>;
   evaluatorId?: InputMaybe<Scalars["ID"]["input"]>;
   participationId?: InputMaybe<Scalars["ID"]["input"]>;
   status?: InputMaybe<GqlEvaluationStatus>;
@@ -1249,18 +1250,16 @@ export type GqlOpportunitySortInput = {
 
 export type GqlOpportunityUpdateContentInput = {
   body?: InputMaybe<Scalars["String"]["input"]>;
-  capacity?: InputMaybe<Scalars["Int"]["input"]>;
   category: GqlOpportunityCategory;
   description: Scalars["String"]["input"];
-  endsAt?: InputMaybe<Scalars["Datetime"]["input"]>;
   feeRequired?: InputMaybe<Scalars["Int"]["input"]>;
   images?: InputMaybe<Array<GqlImageInput>>;
-  place?: InputMaybe<GqlNestedPlaceConnectOrCreateInput>;
+  placeId?: InputMaybe<Scalars["ID"]["input"]>;
   pointsToEarn?: InputMaybe<Scalars["Int"]["input"]>;
   publishStatus: GqlPublishStatus;
+  relatedArticleIds?: InputMaybe<Array<Scalars["ID"]["input"]>>;
   requireApproval: Scalars["Boolean"]["input"];
   requiredUtilityIds?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  startsAt?: InputMaybe<Scalars["Datetime"]["input"]>;
   title: Scalars["String"]["input"];
 };
 
@@ -3777,6 +3776,7 @@ export type GqlEvaluationFieldsFragment = {
 };
 
 export type GqlGetEvaluationsQueryVariables = Exact<{
+  filter?: InputMaybe<GqlEvaluationFilterInput>;
   withDidIssuanceRequests?: Scalars["Boolean"]["input"];
 }>;
 
@@ -7681,8 +7681,8 @@ export type EvaluationBulkCreateMutationOptions = Apollo.BaseMutationOptions<
   GqlEvaluationBulkCreateMutationVariables
 >;
 export const GetEvaluationsDocument = gql`
-  query GetEvaluations($withDidIssuanceRequests: Boolean! = false) {
-    evaluations {
+  query GetEvaluations($filter: EvaluationFilterInput, $withDidIssuanceRequests: Boolean! = false) {
+    evaluations(filter: $filter) {
       edges {
         node {
           id
@@ -7746,6 +7746,7 @@ export const GetEvaluationsDocument = gql`
  * @example
  * const { data, loading, error } = useGetEvaluationsQuery({
  *   variables: {
+ *      filter: // value for 'filter'
  *      withDidIssuanceRequests: // value for 'withDidIssuanceRequests'
  *   },
  * });


### PR DESCRIPTION
### Description

This pull request introduces changes to ensure evaluation queries are scoped by `communityId`. Key updates include:

- **Filtering**: Added `communityId` filter to credential evaluations query and updated `GqlEvaluationFilterInput` to support this filter.
- **Schema Updates**: Adjusted GraphQL schema and queries, including replacing `place` with `placeId` and removing unused input fields (`capacity`, `startsAt`, `endsAt`).
- **Code Refinements**: Minor formatting adjustments for improved readability and consistency.

These changes enhance query precision and maintain schema alignment with backend requirements.