### PR TITLE
feat: デフォルトの予約を7日前までにする上で、任意の体験を任意の日数前まで受け付けられるようにする

### DIFF
--- a/src/app/activities/data/reservationConfig.ts
+++ b/src/app/activities/data/reservationConfig.ts
@@ -1,0 +1,73 @@
+// Configuration for activity reservation deadlines
+import { addDays, endOfDay, subDays } from "date-fns";
+
+// 予約締切タイプの定義
+export enum ReservationDeadlineType {
+  // デフォルト: 開催7日前まで予約可能（既存の実装）
+  DEFAULT = "DEFAULT",
+  // 前日23:59まで予約可能
+  DAY_BEFORE = "DAY_BEFORE",
+  // 当日まで予約可能（開催直前まで）
+  SAME_DAY = "SAME_DAY",
+}
+
+// 予約締切設定
+export interface ReservationDeadlineConfig {
+  // デフォルトの予約締切（開催7日前）
+  defaultDeadline: () => Date;
+
+  // 特定のスロットIDに対する予約締切タイプ
+  slotDeadlineTypes: Record<string, ReservationDeadlineType>;
+}
+
+// デフォルト設定
+export const RESERVATION_CONFIG: ReservationDeadlineConfig = {
+  // デフォルト: 開催7日前まで（既存の実装）
+  defaultDeadline: () => addDays(new Date(), 7),
+
+  // 特定のスロットIDに対する予約締切タイプ
+  slotDeadlineTypes: {
+    // 例: 前日23:59まで予約可能なスロット
+    // "slot-id-1": ReservationDeadlineType.DAY_BEFORE,
+
+    // 例: 当日まで予約可能なスロット
+    // "slot-id-2": ReservationDeadlineType.SAME_DAY,
+    cmc07ao5c0005s60nnc8ravvk: ReservationDeadlineType.SAME_DAY,
+  },
+};
+
+/**
+ * 特定のスロットの予約締切日時を取得する
+ * @param slotId スロットID
+ * @param activityDate アクティビティの開催日
+ * @returns 予約締切日時
+ */
+export function getReservationDeadline(
+  slotId: string | null | undefined,
+  activityDate: Date,
+): Date {
+  // スロットIDがない場合はデフォルトの締切を返す
+  if (!slotId) {
+    return RESERVATION_CONFIG.defaultDeadline();
+  }
+
+  // このスロットの予約締切タイプを取得
+  const deadlineType =
+    RESERVATION_CONFIG.slotDeadlineTypes[slotId] || ReservationDeadlineType.DEFAULT;
+
+  // 予約締切タイプに応じて締切日時を計算
+  switch (deadlineType) {
+    case ReservationDeadlineType.DAY_BEFORE:
+      // 前日23:59まで
+      return endOfDay(subDays(activityDate, 1));
+
+    case ReservationDeadlineType.SAME_DAY:
+      // 当日まで（開催直前まで）- 開催時間の直前
+      return activityDate;
+
+    case ReservationDeadlineType.DEFAULT:
+    default:
+      // デフォルト: 開催7日前まで（既存の実装）
+      return RESERVATION_CONFIG.defaultDeadline();
+  }
+}

--- a/src/app/participations/[id]/data/presenter.ts
+++ b/src/app/participations/[id]/data/presenter.ts
@@ -17,7 +17,7 @@ import {
 import { ReservationStatus } from "@/types/participationStatus";
 import { presenterPlace } from "@/app/places/data/presenter";
 import { presenterOpportunityHost } from "@/app/activities/data/presenter";
-import { subDays } from "date-fns";
+import { getReservationDeadline } from "@/app/activities/data/reservationConfig";
 
 export const presenterParticipation = (raw: GqlParticipation): ParticipationDetail => {
   // if (
@@ -192,7 +192,10 @@ export const getStatusInfo = (status: GqlReservationStatus): ReservationStatus |
   }
 };
 
-export const calculateCancellationDeadline = (startTime?: Date): Date | null => {
+export const calculateCancellationDeadline = (startTime?: Date, slotId?: string): Date | null => {
   if (!startTime) return null;
-  return subDays(startTime, 7); // ← 7日前
+
+  // 予約締切と同じロジックを使用してキャンセル期限を計算
+  // これにより、スロットごとに異なるキャンセル期限を設定できる
+  return getReservationDeadline(slotId, startTime);
 };

--- a/src/app/reservation/select-date/components/TimeSlotList.tsx
+++ b/src/app/reservation/select-date/components/TimeSlotList.tsx
@@ -2,7 +2,8 @@ import React, { useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { ActivitySlot, ActivitySlotGroup } from "@/app/reservation/data/type/opportunitySlot";
 import { formatTimeRange } from "@/utils/date";
-import { addDays, isBefore } from "date-fns";
+import { isBefore } from "date-fns";
+import { getReservationDeadline } from "../../../activities/data/reservationConfig";
 
 interface TimeSlotListProps {
   dateSections: ActivitySlotGroup[];
@@ -40,8 +41,6 @@ const TimeSlotList: React.FC<TimeSlotListProps> = ({
     [onSelectSlot],
   );
 
-  const registrationCutoff = addDays(new Date(), 7);
-
   return (
     <div className="space-y-8">
       {dateSections.map((section, sectionIndex) => (
@@ -56,10 +55,9 @@ const TimeSlotList: React.FC<TimeSlotListProps> = ({
 
               const startsAtDate = new Date(slot.startsAt);
 
-              const FORCE_RESERVABLE_SLOT_IDS = ["cmc07ao5c0005s60nnc8ravvk"];
-              const isForceReservable = FORCE_RESERVABLE_SLOT_IDS.includes(slot.id);
-              const isRegistrationClosed =
-                !isForceReservable && isBefore(startsAtDate, registrationCutoff);
+              // 予約締切日時を取得して現在時刻と比較
+              const reservationDeadline = getReservationDeadline(slot.id, startsAtDate);
+              const isRegistrationClosed = isBefore(new Date(), reservationDeadline);
 
               return (
                 <div


### PR DESCRIPTION
予約（および）キャンセル締め切り
- DEFAULT - 開催7日前まで予約可能（既存の実装）
- DAY_BEFORE - 前日23:59まで予約可能
- SAME_DAY - 当日まで予約可能（開催直前まで）


#424 