### PR TITLE
ポイント、チケット関連の実装・デザイン修正

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -15983,7 +15983,7 @@
             "deprecationReason": null
           },
           {
-            "name": "participantCountWithPoints",
+            "name": "participantCountWithPoint",
             "description": null,
             "args": [],
             "type": {
@@ -16152,7 +16152,7 @@
             "deprecationReason": null
           },
           {
-            "name": "participantCountWithPoints",
+            "name": "participantCountWithPoint",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/src/app/activities/components/CarouselSection/CarouselSection.tsx
+++ b/src/app/activities/components/CarouselSection/CarouselSection.tsx
@@ -2,12 +2,13 @@
 
 import React from "react";
 import OpportunityCardVertical from "@/app/activities/components/Card/CardVertical";
-import { ActivityCard } from "@/app/activities/data/type";
+import { ActivityCard, QuestCard } from "@/app/activities/data/type";
 import CarouselSectionSkeleton from "@/app/activities/components/CarouselSection/CarouselSectionSkeleton";
 
+type CardType = ActivityCard | QuestCard;
 interface ActivitiesCarouselSectionProps {
   title: string;
-  opportunities: ActivityCard[];
+  opportunities: CardType[];
   isInitialLoading?: boolean;
   isSearchResult?: boolean;
 }

--- a/src/app/activities/data/presenter.ts
+++ b/src/app/activities/data/presenter.ts
@@ -243,6 +243,7 @@ export const presenterReservationDateTimeInfo = (
   const endDate = new Date(opportunitySlot.endsAt);
 
   const participantCount = reservation.participations?.length || 0;
+  const discountToPoints = reservation.participantCountWithPoint ? reservation.participantCountWithPoint * (opportunity.feeRequired ?? 0) : 0;
   const paidTicketIds =
     reservation.participations
       ?.map((p) => p.ticketStatusHistories?.map((h) => h.ticket?.id))
@@ -265,7 +266,10 @@ export const presenterReservationDateTimeInfo = (
     dateDiffLabel: getCrossDayLabel(startDate, endDate),
     participantCount,
     paidParticipantCount,
-    totalPrice: (opportunity.feeRequired ?? 0) * paidParticipantCount,
+    totalPrice: (opportunity.feeRequired ?? 0) * paidParticipantCount - discountToPoints,
+    usedPoints: reservation.participantCountWithPoint ? reservation.participantCountWithPoint * (opportunity.pointsRequired ?? 0) : 0,
+    participantCountWithPoint: reservation.participantCountWithPoint ?? 0,
+    ticketCount: paidTicketIds.length,
   };
 };
 

--- a/src/app/components/CardHorizontal.tsx
+++ b/src/app/components/CardHorizontal.tsx
@@ -6,8 +6,7 @@ import Image from "next/image";
 import React, { useCallback, useState } from "react";
 import { PLACEHOLDER_IMAGE } from "@/utils";
 import { GqlOpportunityCategory } from "@/types/graphql";
-import { formatDateTime } from "@/utils/date";
-import { ja } from "date-fns/locale";
+import { formatDateTimeFromISO } from "@/utils/date";
 import { Button } from "@/components/ui/button";
 import SelectionSheet from "../reservation/select-date/components/SelectionSheet";
 
@@ -60,8 +59,7 @@ export const CardHorizontal = ({ opportunity, withShadow = true, category, start
           <div>
             <h2 className="text-label-sm font-bold pt-10">日時</h2>
             <p className="text-body-sm text-foreground pt-1">
-              {formatDateTime(startDateTime, "yyyy年M月d日(E) ", { locale: ja })}
-              {formatDateTime(startDateTime, "HH:mm")}-{formatDateTime(endDateTime, "HH:mm")}
+              {formatDateTimeFromISO(startDateTime?.toISOString() ?? "", endDateTime?.toISOString() ?? "")}
             </p>
           </div>
           <div className="border-b border-gray-200 my-4"></div>

--- a/src/app/components/CardHorizontal.tsx
+++ b/src/app/components/CardHorizontal.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 import React, { useCallback, useState } from "react";
 import { PLACEHOLDER_IMAGE } from "@/utils";
 import { GqlOpportunityCategory } from "@/types/graphql";
-import { formatDateTimeFromISO } from "@/utils/date";
+import { displayDuration } from "@/utils/date";
 import { Button } from "@/components/ui/button";
 import SelectionSheet from "../reservation/select-date/components/SelectionSheet";
 
@@ -59,7 +59,7 @@ export const CardHorizontal = ({ opportunity, withShadow = true, category, start
           <div>
             <h2 className="text-label-sm font-bold pt-10">日時</h2>
             <p className="text-body-sm text-foreground pt-1">
-              {formatDateTimeFromISO(startDateTime?.toISOString() ?? "", endDateTime?.toISOString() ?? "")}
+              {displayDuration(startDateTime?.toISOString() ?? "", endDateTime?.toISOString() ?? "")}
             </p>
           </div>
           <div className="border-b border-gray-200 my-4"></div>

--- a/src/app/participations/[id]/components/OpportunityInfo.tsx
+++ b/src/app/participations/[id]/components/OpportunityInfo.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+import { ActivityDetail, QuestDetail } from "@/app/activities/data/type";
+import { PLACEHOLDER_IMAGE } from "@/utils";
+import { formatDateTimeFromISO } from "@/utils/date";
+import { ArrowRight } from "lucide-react";
+
+interface OpportunityInfoProps {
+  opportunity: ActivityDetail | QuestDetail | null;
+  dateTimeInfo?: {
+    formattedDate: string;
+    startTime: string;
+    endTime: string;
+    participantCountWithPoint: number;
+    usedPoints: number;
+  };
+  participationCount?: number;
+  phoneNumber?: string | null | undefined;
+  comment?: string | null | undefined;
+  totalPrice?: number;
+}
+
+const OpportunityInfo: React.FC<OpportunityInfoProps> = ({ opportunity, dateTimeInfo, participationCount, phoneNumber, comment, totalPrice }) => {
+  const slotDateTime = formatDateTimeFromISO(opportunity?.slots[0]?.startsAt ?? "", opportunity?.slots[0]?.endsAt ?? "");
+  return (
+    <div className="mx-6 my-6 rounded-lg">
+      <div className="flex justify-between items-center gap-4">
+        <div className="relative w-[80px] h-[80px] rounded-lg overflow-hidden flex-shrink-0">
+          <Image
+            src={opportunity?.images?.[0] || PLACEHOLDER_IMAGE}
+            alt={opportunity?.title ?? ""}
+            fill
+            placeholder={"blur"}
+            blurDataURL={PLACEHOLDER_IMAGE}
+            className="object-cover"
+          />
+        </div>
+        <div>
+          <h1 className="text-title-md font-bold leading-tight mb-4 line-clamp-3 break-words">
+            {opportunity?.title ?? ""}
+          </h1>
+        </div>
+        <ArrowRight size={20} className="text-primary flex-shrink-0" />
+      </div>
+      { dateTimeInfo && (
+        <dl className="flex justify-between py-5 mt-2 border-b border-foreground-caption items-center">
+          <dt className="text-label-sm font-bold w-24">日時</dt>
+          <dd className="text-body-sm">{ slotDateTime }</dd>
+        </dl>
+      ) } 
+      { participationCount && (
+        <dl className="flex justify-between py-5 mt-2 border-b border-foreground-caption items-center">
+          <dt className="text-label-sm font-bold">人数</dt>
+          <dd className="text-body-sm">{ participationCount }人</dd>
+        </dl>
+      ) }
+      { phoneNumber && (
+      <dl className={`flex justify-between py-5 mt-2 items-center ${comment ? "border-b border-foreground-caption" : ""}`}>
+        <div className="flex flex-col gap-y-2">
+          <dt className="text-label-sm font-bold">緊急連絡先</dt>
+          <dt className="text-label-sm font-bold">主催者の電話番号</dt>
+        </div>
+        <div className="flex flex-col gap-y-2">
+          <a
+            href={ `tel:${ phoneNumber }` }
+            className="text-body-md text-primary underline"
+          >
+            { phoneNumber }
+          </a>
+          </div>
+        </dl>
+      ) }
+      { comment && (
+        <dl className="py-5 mt-2">
+          <dt className="text-label-sm font-bold">主催者への伝言</dt>
+          <dd className="text-body-sm mt-2">{ comment }</dd>
+        </dl>
+      ) }
+    </div>
+  );
+};
+
+export default OpportunityInfo;

--- a/src/app/participations/[id]/components/OpportunityInfo.tsx
+++ b/src/app/participations/[id]/components/OpportunityInfo.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import Image from "next/image";
 import { ActivityDetail, QuestDetail } from "@/app/activities/data/type";
 import { PLACEHOLDER_IMAGE } from "@/utils";
-import { formatDateTimeFromISO } from "@/utils/date";
+import { displayDuration } from "@/utils/date";
 import { ArrowRight } from "lucide-react";
 
 interface OpportunityInfoProps {
@@ -23,7 +23,7 @@ interface OpportunityInfoProps {
 }
 
 const OpportunityInfo: React.FC<OpportunityInfoProps> = ({ opportunity, dateTimeInfo, participationCount, phoneNumber, comment, totalPrice }) => {
-  const slotDateTime = formatDateTimeFromISO(opportunity?.slots[0]?.startsAt ?? "", opportunity?.slots[0]?.endsAt ?? "");
+  const slotDateTime = displayDuration(opportunity?.slots[0]?.startsAt ?? "", opportunity?.slots[0]?.endsAt ?? "");
   return (
     <div className="mx-6 my-6 rounded-lg">
       <div className="flex justify-between items-center gap-4">

--- a/src/app/participations/[id]/page.tsx
+++ b/src/app/participations/[id]/page.tsx
@@ -12,7 +12,7 @@ import { GqlReservationStatus } from "@/types/graphql";
 import { useParams } from "next/navigation";
 import { errorMessages } from "@/utils/errorMessage";
 import useCancelReservation from "@/app/participations/[id]/hooks/useCancelReservation";
-import OpportunityInfo from "@/app/reservation/confirm/components/OpportunityInfo";
+import OpportunityInfo from "./components/OpportunityInfo";
 import { useOpportunityDetail } from "@/app/activities/[id]/hooks/useOpportunityDetail";
 import ReservationDetails from "@/app/reservation/complete/components/ReservationDetails";
 import { useCompletePageViewModel } from "@/app/reservation/complete/hooks/useCompletePageViewModel";
@@ -155,11 +155,18 @@ export default function ParticipationPage() {
             participantCount={dateTimeInfo.participantCount}
             paidParticipantCount={dateTimeInfo.paidParticipantCount}
             totalPrice={dateTimeInfo.totalPrice}
-            pricePerPerson={opportunityDetail.feeRequired ?? 0}
+            pricePerPerson={"feeRequired" in opportunityDetail ? opportunityDetail.feeRequired : 0}
             location={opportunityDetail.place}
             phoneNumber={participation.emergencyContactPhone}
             isReserved={true}
             dateDiffLabel={dateTimeInfo.dateDiffLabel}
+            points={{
+              usedPoints: dateTimeInfo.usedPoints,
+              participantCountWithPoint: dateTimeInfo.participantCountWithPoint,
+            }}
+            ticketCount={dateTimeInfo.ticketCount}
+            category={opportunityDetail.category}
+            pointsToEarn={"pointsToEarn" in opportunityDetail ? opportunityDetail.pointsToEarn : 0}
           />
         </div>
       )}

--- a/src/app/quests/components/QuestsList.tsx
+++ b/src/app/quests/components/QuestsList.tsx
@@ -41,7 +41,7 @@ export default function QuestsList() {
     <div className="min-h-screen">
       <main>
         <CarouselSection
-          title="おすすめの体験"
+          title="おすすめのお手伝い"
           opportunities={recommendedOpportunities}
           isVertical={false}
         />

--- a/src/app/reservation/complete/components/ReservationDetails.tsx
+++ b/src/app/reservation/complete/components/ReservationDetails.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { Calendar, JapaneseYen, MapPin, Phone, Users } from "lucide-react";
+import { GqlOpportunityCategory } from "@/types/graphql";
 
 interface ReservationDetailsProps {
   formattedDate: string;
@@ -11,13 +12,20 @@ interface ReservationDetailsProps {
   participantCount: number;
   paidParticipantCount: number;
   totalPrice: number;
-  pricePerPerson: number;
+  pricePerPerson: number | null;
   location?: {
     name: string;
     address: string;
   };
   phoneNumber?: string | null | undefined;
   isReserved?: boolean;
+  points?: {
+    usedPoints: number;
+    participantCountWithPoint: number;
+  } | null;
+  ticketCount: number;
+  category: GqlOpportunityCategory;
+  pointsToEarn: number;
 }
 
 const ReservationDetails: React.FC<ReservationDetailsProps> = ({
@@ -35,6 +43,10 @@ const ReservationDetails: React.FC<ReservationDetailsProps> = ({
   },
   phoneNumber,
   isReserved = false,
+  points,
+  ticketCount,
+  category,
+  pointsToEarn,
 }) => {
   return (
     <div className="bg-card rounded-lg py-6 px-4 mb-6 space-y-6 w-full">
@@ -61,16 +73,68 @@ const ReservationDetails: React.FC<ReservationDetailsProps> = ({
         <Users size={18} strokeWidth={1.5} className="text-caption w-6 h-6 mt-0.5" />
         <span>{participantCount}人</span>
       </div>
+      { category === GqlOpportunityCategory.Activity && (
       <div className="flex items-center gap-x-2">
-        <JapaneseYen size={18} strokeWidth={1.5} className="text-caption w-6 h-6 mt-0.5" />
-        <div className="flex flex-row gap-x-2 items-center">
-          <span className="text-foreground text-body-md">{totalPrice.toLocaleString()}円</span>
-          <span className="text-caption text-body-sm">
-            （{pricePerPerson.toLocaleString()}円 × {paidParticipantCount.toLocaleString()}
-            人）
-          </span>
+        <div className="flex flex-col w-full">
+          <div className="flex items-center gap-x-2">
+            <JapaneseYen size={18} strokeWidth={1.5} className="text-caption w-6 h-6 mt-0.5" />
+            <div className="flex justify-between items-center">
+              <span className="text-foreground text-body-md">{ totalPrice?.toLocaleString() }円</span>
+            </div>
+          </div>
+          
+          {/* 内訳セクション */}
+          <div className="bg-muted rounded-lg p-4 ml-12 mt-2">
+            <div className="space-y-2">
+              <h2 className="text-body-xs text-caption font-bold">内訳</h2>
+              {/* 通常申し込み */}
+              <div className="flex justify-between text-body-xs text-muted-foreground mt-1 border-b border-foreground-caption pb-2">
+                <span className="">通常申し込み</span>
+                <div>
+                  <span>{ pricePerPerson?.toLocaleString() }円</span>
+                  <span className="mx-2">×</span>
+                  <span>{ participantCount }名</span>
+                  <span className="mx-2">=</span>
+                  <span className="font-bold">{ (pricePerPerson ?? 0) * (participantCount ?? 0) }円</span>
+                </div>
+              </div>
+
+              {/* ポイント利用 */}
+              { points && points.usedPoints > 0 && points.participantCountWithPoint > 0 && (
+              <div className="flex justify-between text-body-xs text-muted-foreground">
+                <span>ポイント利用</span>
+                <div>
+                  <span>{ points?.usedPoints?.toLocaleString() }pt</span>
+                  <span className="mx-2">×</span>
+                  <span>{ points?.participantCountWithPoint }名</span>
+                  <span className="mx-2">=</span>
+                  <span className="font-bold">{ (points?.usedPoints ?? 0) * (points?.participantCountWithPoint ?? 0) }pt</span>
+                  </div>
+                </div>
+              ) }
+
+              {/* チケット利用 */}
+              <div className="flex justify-between text-body-xs text-muted-foreground">
+                <span>チケット利用</span>
+                <div>
+                  <span>{ ticketCount }名分</span>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
+      ) }
+      { category === GqlOpportunityCategory.Quest && (
+        <div className="flex items-center gap-1 pt-1">
+        <p className="bg-primary text-[11px] rounded-full w-5 h-5 flex items-center justify-center font-bold text-white leading-none">
+          P
+        </p>
+        <p className="text-body-md font-bold">
+            +{pointsToEarn.toLocaleString()}ポイント
+        </p>
+      </div>
+      )}
       <div className="flex items-center gap-x-2">
         {isReserved ? (
           phoneNumber ? (

--- a/src/app/reservation/complete/components/ReservationDetails.tsx
+++ b/src/app/reservation/complete/components/ReservationDetails.tsx
@@ -48,6 +48,7 @@ const ReservationDetails: React.FC<ReservationDetailsProps> = ({
   category,
   pointsToEarn,
 }) => {
+  const normalParticipantCount = participantCount - ticketCount - (points?.participantCountWithPoint ?? 0);
   return (
     <div className="bg-card rounded-lg py-6 px-4 mb-6 space-y-6 w-full">
       <div className="flex items-start gap-x-2">
@@ -93,9 +94,9 @@ const ReservationDetails: React.FC<ReservationDetailsProps> = ({
                 <div>
                   <span>{ pricePerPerson?.toLocaleString() }円</span>
                   <span className="mx-2">×</span>
-                  <span>{ participantCount }名</span>
+                  <span>{ normalParticipantCount }名</span>
                   <span className="mx-2">=</span>
-                  <span className="font-bold">{ (pricePerPerson ?? 0) * (participantCount ?? 0) }円</span>
+                  <span className="font-bold">{ (pricePerPerson ?? 0) * normalParticipantCount }円</span>
                 </div>
               </div>
 

--- a/src/app/reservation/complete/page.tsx
+++ b/src/app/reservation/complete/page.tsx
@@ -2,7 +2,6 @@
 
 import SameStateActivities from "@/app/activities/[id]/components/SimilarActivitiesList";
 import CompletionHeader from "@/app/reservation/complete/components/CompletionHeader";
-import ReservationDetails from "@/app/reservation/complete/components/ReservationDetails";
 import React, { useEffect, useMemo, useRef } from "react";
 import useHeaderConfig from "@/hooks/useHeaderConfig";
 import { useSearchParams } from "next/navigation";
@@ -84,6 +83,7 @@ export default function CompletePage() {
           phoneNumber={ reservation.opportunitySlot?.opportunity?.createdByUser?.phoneNumber }
           comment={ reservation.comment }
           totalPrice={ dateTimeInfo.totalPrice }
+          ticketCount={ dateTimeInfo.ticketCount }
         />
       ) }
       { opportunityId && sameStateActivities.length > 0 && (

--- a/src/app/reservation/confirm/components/ExpectedPoints.tsx
+++ b/src/app/reservation/confirm/components/ExpectedPoints.tsx
@@ -3,6 +3,15 @@ interface ExpectedPointsProps {
   participantCount: number;
 }
 
+const getPointsSharingMessage = (participantCount:number) :string => {
+  if(participantCount > 1) {
+    return "必要に応じて、一緒に参加する人にポイントを送ってあげてください。";
+  } else {
+    return "";
+  }
+}
+ 
+
 export const ExpectedPoints = ({points, participantCount}: ExpectedPointsProps) => {
   return (
     <div>
@@ -13,7 +22,7 @@ export const ExpectedPoints = ({points, participantCount}: ExpectedPointsProps) 
             </p>
         </div>
         <p className="text-body-sm text-caption px-6 mt-2 leading-1.6">参加後、予約者であるあなたのウォレットに上記の{participantCount}人分のポイントが付与されます。<br/>
-        必要に応じて、一緒に参加する人にポイントを送ってあげてください。</p>
+        {getPointsSharingMessage(participantCount)}</p>
     </div>
   );
 };

--- a/src/app/reservation/confirm/components/OpportunityInfo.tsx
+++ b/src/app/reservation/confirm/components/OpportunityInfo.tsx
@@ -27,7 +27,7 @@ interface OpportunityInfoProps {
 const getPointOrFee = (
   opportunity: ActivityDetail | QuestDetail | null,
   totalPrice?: number,
-  usedPoints?: number,
+  pointsRequired?: number,
   participantCountWithPoint?: number,
   participantCount?: number,
   ticketCount?: number
@@ -59,15 +59,15 @@ const getPointOrFee = (
               </div>
 
               {/* ポイント利用 */}
-              { usedPoints && usedPoints > 0 && participantCountWithPoint && participantCountWithPoint > 0 && (
+              { pointsRequired && pointsRequired > 0 && participantCountWithPoint && participantCountWithPoint > 0 && (
               <div className="flex justify-between text-body-xs text-muted-foreground">
                 <span>ポイント利用</span>
                 <div>
-                  <span>{ usedPoints?.toLocaleString() }pt</span>
+                  <span>{ pointsRequired?.toLocaleString() }pt</span>
                   <span className="mx-2">×</span>
                   <span>{ participantCountWithPoint }名</span>
                   <span className="mx-2">=</span>
-                  <span className="font-bold">{ (usedPoints ?? 0) * (participantCountWithPoint ?? 0) }pt</span>
+                  <span className="font-bold">{ (pointsRequired ?? 0) * (participantCountWithPoint ?? 0) }pt</span>
                   </div>
                 </div>
               ) }
@@ -140,7 +140,7 @@ const OpportunityInfo: React.FC<OpportunityInfoProps> = ({
       { getPointOrFee(
           opportunity,
           totalPrice,
-          dateTimeInfo?.usedPoints,
+          opportunity?.pointsRequired,
           dateTimeInfo?.participantCountWithPoint,
           participationCount,
           ticketCount

--- a/src/app/reservation/confirm/components/OpportunityInfo.tsx
+++ b/src/app/reservation/confirm/components/OpportunityInfo.tsx
@@ -34,6 +34,7 @@ const getPointOrFee = (
 ) => {
   if(opportunity?.category === GqlOpportunityCategory.Activity) {
     const feeRequired = "feeRequired" in opportunity ? opportunity.feeRequired : 0;
+    const normalParticipantCount = (participantCount ?? 0) - (ticketCount ?? 0) - (participantCountWithPoint ?? 0);
     return(
       <div className="border-b border-foreground-caption pb-4">
         <dl className="flex justify-between py-2 mt-2 items-center">
@@ -43,7 +44,7 @@ const getPointOrFee = (
           </div>
           <dd className="text-body-sm">{ totalPrice?.toLocaleString() }円</dd>
         </dl>
-        <div className="bg-muted rounded-lg p-4 mt-2">
+        <div className="bg-muted rounded-lg p-4">
             <div className="space-y-2">
               <h2 className="text-body-xs text-caption font-bold">内訳</h2>
               {/* 通常申し込み */}
@@ -52,9 +53,9 @@ const getPointOrFee = (
                 <div>
                   <span>{ feeRequired?.toLocaleString() }円</span>
                   <span className="mx-2">×</span>
-                  <span>{ participantCount }名</span>
+                  <span>{ normalParticipantCount }名</span>
                   <span className="mx-2">=</span>
-                  <span className="font-bold">{ (feeRequired ?? 0) * (participantCount ?? 0) }円</span>
+                  <span className="font-bold">{ (feeRequired ?? 0) * normalParticipantCount }円</span>
                 </div>
               </div>
 

--- a/src/app/reservation/confirm/components/OpportunityInfo.tsx
+++ b/src/app/reservation/confirm/components/OpportunityInfo.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import Image from "next/image";
 import { ActivityDetail, QuestDetail } from "@/app/activities/data/type";
 import { PLACEHOLDER_IMAGE } from "@/utils";
-import { formatDateTimeFromISO } from "@/utils/date";
+import { displayDuration } from "@/utils/date";
 import { GqlOpportunityCategory } from "@/types/graphql";
 import { ArrowRight } from "lucide-react";
 
@@ -104,7 +104,7 @@ const OpportunityInfo: React.FC<OpportunityInfoProps> = ({
    totalPrice,
    ticketCount
  }) => {
-  const slotDateTime = formatDateTimeFromISO(opportunity?.slots[0]?.startsAt ?? "", opportunity?.slots[0]?.endsAt ?? "");
+  const slotDateTime = displayDuration(opportunity?.slots[0]?.startsAt ?? "", opportunity?.slots[0]?.endsAt ?? "");
 
   return (
     <div className="mx-6 my-6 border border-foreground-caption rounded-lg p-4">

--- a/src/app/reservation/confirm/components/OpportunityInfo.tsx
+++ b/src/app/reservation/confirm/components/OpportunityInfo.tsx
@@ -88,7 +88,7 @@ const getPointOrFee = (
     return(
       <dl className="flex justify-between py-5 mt-2 border-b border-foreground-caption items-center">
         <dt className="text-label-sm font-bold">獲得予定ポイント数</dt>
-        <dd className="text-body-sm">{ quest.pointsToEarn?.toLocaleString() }pt</dd>
+        <dd className="text-body-sm">{( (quest.pointsToEarn ?? 0) * (participantCount ?? 0)).toLocaleString() }pt</dd>
       </dl>
     )
   }

--- a/src/app/reservation/confirm/components/PaymentSection.tsx
+++ b/src/app/reservation/confirm/components/PaymentSection.tsx
@@ -21,15 +21,12 @@ interface PaymentSectionProps {
   pointsRequired: number;
   onPointCountChange?: (count: number) => void;
   onTicketCountChange?: (count: number) => void;
+  onSelectedTicketsChange?: (selectedTickets: { [ticketId: string]: number }) => void;
 }
 
 const PaymentSection: React.FC<PaymentSectionProps> = memo(
   ({
-    ticketCount,
-    onIncrement,
-    onDecrement,
     maxTickets,
-    pricePerPerson,
     participantCount,
     useTickets,
     setUseTickets,
@@ -40,6 +37,7 @@ const PaymentSection: React.FC<PaymentSectionProps> = memo(
     availableTickets,
     onPointCountChange,
     onTicketCountChange,
+    onSelectedTicketsChange,
   }) => {
     const [selectedTicketCount, setSelectedTicketCount] = useState(0);
     const [selectedPointCount, setSelectedPointCount] = useState(0);
@@ -72,6 +70,12 @@ const PaymentSection: React.FC<PaymentSectionProps> = memo(
       }
     }, [onPointCountChange]);
 
+    const handleSelectedTicketsChange = useCallback((tickets: { [ticketId: string]: number }) => {
+      if (onSelectedTicketsChange) {
+        onSelectedTicketsChange(tickets);
+      }
+    }, [onSelectedTicketsChange]);
+
     return (
       <div className="rounded-lg px-6">
         <h3 className="text-display-sm mb-4">ポイント・チケットを利用</h3>
@@ -86,6 +90,7 @@ const PaymentSection: React.FC<PaymentSectionProps> = memo(
             selectedTicketCount={selectedTicketCount}
             remainingSlots={remainingSlots}
             allDisabled={allDisabled}
+            onSelectedTicketsChange={handleSelectedTicketsChange}
           />
         )}
         {userWallet && userWallet > 0 && userWallet > pointsRequired && (

--- a/src/app/reservation/confirm/components/PaymentSummary.tsx
+++ b/src/app/reservation/confirm/components/PaymentSummary.tsx
@@ -12,9 +12,8 @@ interface PaymentSummaryProps {
 
 export const PaymentSummary: React.FC<PaymentSummaryProps> = memo(
   ({ pricePerPerson, participantCount, useTickets, ticketCount, usePoints, pointCount, pointsRequired }) => {
-    const totalAmount = pricePerPerson != null ? pricePerPerson * participantCount : null;
-    const discount = useTickets || usePoints ? (pointCount * (pricePerPerson ?? 0))+(ticketCount * (pricePerPerson ?? 0)) : 0;
-    const summaryAmount = totalAmount != null ? totalAmount - discount : null;
+    const totalAmount = pricePerPerson != null ? pricePerPerson * (participantCount - ticketCount - pointCount) : null;
+    const summaryAmount = totalAmount != null ? totalAmount : null;
     return (
       <>
         <div className="mb-[6px] flex justify-between items-center">
@@ -30,20 +29,20 @@ export const PaymentSummary: React.FC<PaymentSummaryProps> = memo(
         <p className="text-body-sm text-caption mb-4">料金は現地でお支払いください。</p>
 
         <div className="bg-muted rounded-lg p-4">
-          <div className="space-y-3">
+          <div className="space-y-2">
             <h2 className="text-body-sm text-caption font-bold">内訳</h2>
             
             {/* 通常申し込み */}
-            <div className="flex justify-between text-body-sm text-muted-foreground">
+            <div className="flex justify-between text-body-sm text-muted-foreground border-b border-foreground-caption pb-2">
               <span>通常申し込み</span>
               <div>
                 {pricePerPerson != null ? (
                   <>
                     <span>{pricePerPerson.toLocaleString()}円</span>
                     <span className="mx-2">×</span>
-                    <span>{participantCount}名</span>
+                    <span>{participantCount - ticketCount - pointCount}名</span>
                     <span className="mx-2">=</span>
-                    <span>{totalAmount?.toLocaleString()}円</span>
+                    <span className="font-bold">{totalAmount?.toLocaleString()}円</span>
                   </>
                 ) : (
                   <span>料金未定</span>
@@ -60,7 +59,7 @@ export const PaymentSummary: React.FC<PaymentSummaryProps> = memo(
                   <span className="mx-2">×</span>
                   <span>{pointCount}名</span>
                   <span className="mx-2">=</span>
-                  <span>{(pointsRequired ?? 0) * pointCount}pt</span>
+                  <span className="font-bold">{((pointsRequired ?? 0) * pointCount).toLocaleString()}pt</span>
                 </div>
               </div>
             )}

--- a/src/app/reservation/confirm/components/PaymentSummary.tsx
+++ b/src/app/reservation/confirm/components/PaymentSummary.tsx
@@ -52,30 +52,24 @@ export const PaymentSummary: React.FC<PaymentSummaryProps> = memo(
             </div>
 
             {/* ポイント利用 */}
-            {/* {usePoints && pointCount > 0 && ( */}
+            {usePoints && pointCount > 0 && (
               <div className="flex justify-between text-body-sm text-muted-foreground">
                 <span>ポイント利用</span>
                 <div>
-                  <span>{pricePerPerson?.toLocaleString()}円</span>
+                  <span>{pointsRequired?.toLocaleString()}pt</span>
                   <span className="mx-2">×</span>
                   <span>{pointCount}名</span>
                   <span className="mx-2">=</span>
-                  <span>{(pointCount * (pricePerPerson ?? 0)).toLocaleString()}円</span>
+                  <span>{(pointsRequired ?? 0) * pointCount}pt</span>
                 </div>
               </div>
-            {/* )} */}
+            )}
 
             {/* チケット利用 */}
             {/* {useTickets && ticketCount > 0 && ( */}
               <div className="flex justify-between text-body-sm text-muted-foreground">
                 <span>チケット利用</span>
-                <div>
-                  <span>{pricePerPerson?.toLocaleString()}円</span>
-                  <span className="mx-2">×</span>
-                  <span>{ticketCount}枚</span>
-                  <span className="mx-2">=</span>
-                  <span>{(ticketCount * (pricePerPerson ?? 0)).toLocaleString()}円</span>
-                </div>
+                <span>{ticketCount}名分</span>
               </div>
             {/* )} */}
           </div>

--- a/src/app/reservation/confirm/components/payment/PointsToggle.tsx
+++ b/src/app/reservation/confirm/components/payment/PointsToggle.tsx
@@ -115,7 +115,7 @@ export const PointsToggle: React.FC<PointsToggleProps> = memo(
             </div>
             
             <p className="text-xs text-caption text-center">
-              ({pointCount * (pointsRequired ?? 0)}pt消費されます)
+              ({(pointCount * (pointsRequired ?? 0)).toLocaleString()}pt消費されます)
             </p>
           </div>
         </div>

--- a/src/app/reservation/confirm/components/payment/PointsToggle.tsx
+++ b/src/app/reservation/confirm/components/payment/PointsToggle.tsx
@@ -67,7 +67,7 @@ export const PointsToggle: React.FC<PointsToggleProps> = memo(
                 ポイントを利用する
               </span>
               <p className={`text-body-sm ${disabled ? 'text-gray-400' : ''}`}>
-                保有しているポイント: {maxPoints.toLocaleString()}pt
+                保有しているポイント: {Number(maxPoints).toLocaleString()}pt
               </p>
               {disabled && (
                 <p className="text-xs text-gray-500 mt-1">

--- a/src/app/reservation/confirm/components/payment/TicketsToggle.tsx
+++ b/src/app/reservation/confirm/components/payment/TicketsToggle.tsx
@@ -10,13 +10,14 @@ interface TicketsToggleProps {
   availableTickets: AvailableTicket[];
   participantCount: number;
   onTicketCountChange: (count: number) => void;
+  onSelectedTicketsChange?: (selectedTickets: { [ticketId: string]: number }) => void;
   selectedTicketCount: number;
   remainingSlots: number;
   allDisabled: boolean;
 }
 
 export const TicketsToggle: React.FC<TicketsToggleProps> = memo(
-  ({ useTickets, setUseTickets, maxTickets, availableTickets, onTicketCountChange, remainingSlots, participantCount, allDisabled }) => {
+  ({ useTickets, setUseTickets, maxTickets, availableTickets, onTicketCountChange, onSelectedTicketsChange, remainingSlots, participantCount, allDisabled }) => {
     const [ticketCounts, setTicketCounts] = useState<{ [key: string]: number }>({});
 
     const toggleUseTickets = useCallback(() => {
@@ -30,14 +31,6 @@ export const TicketsToggle: React.FC<TicketsToggleProps> = memo(
       if (!ticket) return;
       
       const currentCount = ticketCounts[ticketId] || 0;
-      
-      console.log('TicketsToggle handleIncrement:', {
-        ticketId,
-        currentCount,
-        ticketCount: ticket.count,
-        allDisabled,
-        canIncrement: currentCount < ticket.count && !allDisabled
-      });
       
       // チケットの枚数制限とallDisabledの制限をチェック
       if (currentCount < ticket.count && !allDisabled) {
@@ -61,6 +54,13 @@ export const TicketsToggle: React.FC<TicketsToggleProps> = memo(
     useEffect(() => {
       onTicketCountChange(totalSelectedTickets);
     }, [totalSelectedTickets, onTicketCountChange]);
+
+    // 選択されたチケットの詳細情報を親コンポーネントに通知
+    useEffect(() => {
+      if (onSelectedTicketsChange) {
+        onSelectedTicketsChange(ticketCounts);
+      }
+    }, [ticketCounts, onSelectedTicketsChange]);
 
     return (
       <div className="rounded-2xl border border-input bg-background mb-6 overflow-hidden">
@@ -91,15 +91,6 @@ export const TicketsToggle: React.FC<TicketsToggleProps> = memo(
                 const currentCount = ticketCounts[ticket.id] || 0;
                 const canIncrement = currentCount < ticket.count;
                 const isLast = index === availableTickets.length - 1;
-                
-                console.log('Ticket debug:', {
-                  ticketId: ticket.id,
-                  currentCount,
-                  ticketCount: ticket.count,
-                  canIncrement,
-                  allDisabled,
-                  buttonDisabled: !canIncrement || allDisabled
-                });
                 
                 return (
                   <div key={ticket.id} className={`p-3 bg-white ${!isLast ? 'border-b border-gray-200' : ''}`}>

--- a/src/app/reservation/confirm/page.tsx
+++ b/src/app/reservation/confirm/page.tsx
@@ -20,7 +20,7 @@ import { useReservationCommand } from "@/app/reservation/confirm/hooks/useReserv
 import { GqlOpportunityCategory, GqlWalletType, useGetMemberWalletsQuery } from "@/types/graphql";
 import { COMMUNITY_ID } from "@/lib/communities/metadata";
 import { logger } from "@/lib/logging";
-import { encodeURIComponentWithType, RawURIComponent } from "@/utils/path";
+import { RawURIComponent } from "@/utils/path";
 import { NoticeCard } from "@/components/shared/NoticeCard";
 import { CardHorizontal } from "@/app/components/CardHorizontal";
 import { ExpectedPoints } from "./components/ExpectedPoints";
@@ -49,6 +49,7 @@ export default function ConfirmPage() {
   const [participantCount, setParticipantCount] = useState<number>(initialParticipantCount);
   const [selectedPointCount, setSelectedPointCount] = useState(0);
   const [selectedTicketCount, setSelectedTicketCount] = useState(0);
+  const [selectedTickets, setSelectedTickets] = useState<{ [ticketId: string]: number }>({});
   const {
     opportunity,
     selectedSlot,
@@ -96,6 +97,8 @@ export default function ConfirmPage() {
       comment: ui.ageComment ?? undefined,
       usePoints: ui.usePoints,
       selectedPointCount: selectedPointCount,
+      selectedTicketCount: selectedTicketCount,
+      selectedTickets: selectedTickets,
     });
 
     if (creatingReservation) {
@@ -181,6 +184,7 @@ export default function ConfirmPage() {
             pointsRequired={ 'pointsRequired' in opportunity ? opportunity.pointsRequired : 0 }
             onPointCountChange={setSelectedPointCount}
             onTicketCountChange={setSelectedTicketCount}
+            onSelectedTicketsChange={setSelectedTickets}
           />
           <div className="border-b border-gray-200 my-6"></div>
           </>

--- a/src/app/search/result/components/SearchResultHeader.tsx
+++ b/src/app/search/result/components/SearchResultHeader.tsx
@@ -27,6 +27,7 @@ const useSearchResultHeader = (searchParams: SearchParams) => {
           q: searchParams.q,
           points: searchParams.points,
           ticket: searchParams.ticket,
+          type: searchParams.type,
         },
         showLogo: false,
         showBackButton: false,

--- a/src/graphql/experience/reservation/fragment.ts
+++ b/src/graphql/experience/reservation/fragment.ts
@@ -5,5 +5,6 @@ export const RESERVATION_FRAGMENT = gql`
     id
     status
     comment
+    participantCountWithPoint
   }
 `;

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -1917,7 +1917,7 @@ export type GqlReservation = {
   histories?: Maybe<Array<GqlReservationHistory>>;
   id: Scalars["ID"]["output"];
   opportunitySlot?: Maybe<GqlOpportunitySlot>;
-  participantCountWithPoints?: Maybe<Scalars["Int"]["output"]>;
+  participantCountWithPoint?: Maybe<Scalars["Int"]["output"]>;
   participations?: Maybe<Array<GqlParticipation>>;
   status: GqlReservationStatus;
   updatedAt?: Maybe<Scalars["Datetime"]["output"]>;
@@ -1932,7 +1932,7 @@ export type GqlReservationCreateInput = {
   comment?: InputMaybe<Scalars["String"]["input"]>;
   opportunitySlotId: Scalars["ID"]["input"];
   otherUserIds?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  participantCountWithPoints?: InputMaybe<Scalars["Int"]["input"]>;
+  participantCountWithPoint?: InputMaybe<Scalars["Int"]["input"]>;
   paymentMethod: GqlReservationPaymentMethod;
   ticketIdsIfNeed?: InputMaybe<Array<Scalars["ID"]["input"]>>;
   totalParticipantCount: Scalars["Int"]["input"];
@@ -4067,6 +4067,7 @@ export type GqlGetOpportunityQuery = {
         id: string;
         status: GqlReservationStatus;
         comment?: string | null;
+        participantCountWithPoint?: number | null;
         participations?: Array<{
           __typename?: "Participation";
           id: string;
@@ -4158,6 +4159,7 @@ export type GqlGetOpportunityQuery = {
             id: string;
             status: GqlReservationStatus;
             comment?: string | null;
+            participantCountWithPoint?: number | null;
             participations?: Array<{
               __typename?: "Participation";
               id: string;
@@ -4280,6 +4282,7 @@ export type GqlGetOpportunitySlotsQuery = {
           id: string;
           status: GqlReservationStatus;
           comment?: string | null;
+          participantCountWithPoint?: number | null;
           participations?: Array<{
             __typename?: "Participation";
             id: string;
@@ -4353,6 +4356,7 @@ export type GqlGetOpportunitySlotWithParticipationsQuery = {
       id: string;
       status: GqlReservationStatus;
       comment?: string | null;
+      participantCountWithPoint?: number | null;
       participations?: Array<{
         __typename?: "Participation";
         id: string;
@@ -4471,6 +4475,7 @@ export type GqlGetParticipationQuery = {
       id: string;
       status: GqlReservationStatus;
       comment?: string | null;
+      participantCountWithPoint?: number | null;
       opportunitySlot?: {
         __typename?: "OpportunitySlot";
         id: string;
@@ -4672,6 +4677,7 @@ export type GqlReservationFieldsFragment = {
   id: string;
   status: GqlReservationStatus;
   comment?: string | null;
+  participantCountWithPoint?: number | null;
 };
 
 export type GqlCreateReservationMutationVariables = Exact<{
@@ -4687,6 +4693,7 @@ export type GqlCreateReservationMutation = {
       id: string;
       status: GqlReservationStatus;
       comment?: string | null;
+      participantCountWithPoint?: number | null;
       participations?: Array<{
         __typename?: "Participation";
         id: string;
@@ -4715,6 +4722,7 @@ export type GqlCancelReservationMutation = {
       id: string;
       status: GqlReservationStatus;
       comment?: string | null;
+      participantCountWithPoint?: number | null;
     };
   } | null;
 };
@@ -4779,6 +4787,7 @@ export type GqlGetReservationsQuery = {
         id: string;
         status: GqlReservationStatus;
         comment?: string | null;
+        participantCountWithPoint?: number | null;
         createdByUser?: {
           __typename?: "User";
           id: string;
@@ -4837,6 +4846,7 @@ export type GqlGetReservationQuery = {
     id: string;
     status: GqlReservationStatus;
     comment?: string | null;
+    participantCountWithPoint?: number | null;
     createdByUser?: {
       __typename?: "User";
       id: string;
@@ -5932,6 +5942,7 @@ export const ReservationFieldsFragmentDoc = gql`
     id
     status
     comment
+    participantCountWithPoint
   }
 `;
 export const TicketFieldsFragmentDoc = gql`

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -94,6 +94,32 @@ export function formatJapaneseDateTime(startDateTime: string, endDateTime: strin
 export function formatDateTimeFromParts(formattedDate: string, startTime: string, endTime: string, endDate?: string): string {
   if (endDate && endDate !== formattedDate) {
     // 日を跨ぐ場合
+    // 開始日と終了日から年を抽出
+    const startYearMatch = formattedDate.match(/(\d{4})年/);
+    const endYearMatch = endDate.match(/(\d{4})年/);
+    
+    if (startYearMatch && endYearMatch && startYearMatch[1] === endYearMatch[1]) {
+      // 同じ年の場合は簡潔な形式
+      const startDateMatch = formattedDate.match(/(\d{4})年(\d{1,2})月(\d{1,2})日/);
+      const endDateMatch = endDate.match(/(\d{1,2})月(\d{1,2})日/);
+      
+      if (startDateMatch && endDateMatch) {
+        const startMonth = parseInt(startDateMatch[2]);
+        const endMonth = parseInt(endDateMatch[1]);
+        const startDay = parseInt(startDateMatch[3]);
+        const endDay = parseInt(endDateMatch[2]);
+        
+        // 同じ月の場合は日のみ表示
+        if (startMonth === endMonth) {
+          return `${startDateMatch[1]}年${startMonth}月${startDay}日${startTime}~${endDay}日${endTime}`;
+        } else {
+          // 月が異なる場合は月も表示
+          return `${startDateMatch[1]}年${startMonth}月${startDay}日${startTime}~${endMonth}月${endDay}日${endTime}`;
+        }
+      }
+    }
+    
+    // 年が異なる場合やマッチしない場合は元の形式
     return `${formattedDate} ${startTime}〜\n${endDate} ${endTime}`;
   } else {
     // 同じ日の場合

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,30 +9,6 @@ dayjs.extend(relativeTime);
 
 export const PLACEHOLDER_IMAGE = `/communities/${COMMUNITY_ID}/placeholder.jpg`;
 
-
-const YEAR_FMT = "YYYY年";
-const MONTH_DATE_FMT = "M月D日(ddd)";
-const TIME_FMT = "H:mm";
-const FULL_FMT = `${YEAR_FMT}${MONTH_DATE_FMT} ${TIME_FMT}`;
-
-export const displayDatetime = (date: Date | string | null | undefined, format: string = FULL_FMT, nullString: string = "未設定") => {
-  if (!date) return nullString;
-  return dayjs(date).format(format);
-};
-
-export const displayDuration = (start: Date | string, end?: Date | string) => {
-  const dStart = dayjs(start);
-  const dEnd = dayjs(end);
-  if (!end) return displayDatetime(start, FULL_FMT);
-  if (dStart.isSame(dEnd, "date")) {
-    return `${dStart.format(FULL_FMT)}〜${dEnd.format(TIME_FMT)}`;
-  } else if (dStart.isSame(dEnd, "year")) {
-    return `${dStart.format(FULL_FMT)} 〜 ${dEnd.format(`${MONTH_DATE_FMT} ${TIME_FMT}`)}`;
-  } else {
-    return `${dStart.format(FULL_FMT)} 〜 ${dEnd.format(FULL_FMT)}`;
-  }
-};
-
 export const displayRelativeTime = (date: Date | string) => {
   return dayjs(date).fromNow();
 };


### PR DESCRIPTION
> 関連タスク
- [予約完了画面でポイント、またはチケットを使用時に現地でも支払い額が正しく反映されていない](https://github.com/Hopin-inc/civicship-portal/issues/507)
- [/participations/[id] のデザイン修正](https://github.com/Hopin-inc/civicship-portal/issues/511)
- [参加人数を3人で予約して、2人だけポイント利用しても問題ないかとか見ておく](https://github.com/Hopin-inc/civicship-portal/issues/509)
- [予約完了・確認画面のデザイン修正](https://github.com/Hopin-inc/civicship-portal/issues/512)
- 日付が長い際に見出しが潰れている。同じ年の際は日付のみで良い

> 画面収録
- 日付が長い際に見出しが潰れている。同じ年の際は日付のみで良い
<img width="436" height="694" alt="スクリーンショット 2025-07-26 1 49 19" src="https://github.com/user-attachments/assets/bc368476-74c8-48ca-849b-4e01d55f8ba7" />
<img width="435" height="732" alt="スクリーンショット 2025-07-26 1 50 34" src="https://github.com/user-attachments/assets/3b3541d6-8ced-4279-a76d-5ab9ab4011fa" />

- 予約完了画面でポイント、またはチケットを使用時に現地でも支払い額が正しく反映されていない
- 参加人数を3人で予約して、2人だけポイント利用しても問題ないかとか見ておく

https://github.com/user-attachments/assets/b2a012f5-0eaa-4fc0-9c6f-1c120650a079

- /participations/[id] のデザイン修正

<img width="427" height="884" alt="スクリーンショット 2025-07-26 2 06 50" src="https://github.com/user-attachments/assets/7409685c-d4aa-484f-b1bc-a36d220f6033" />
<img width="429" height="883" alt="スクリーンショット 2025-07-26 2 07 26" src="https://github.com/user-attachments/assets/ba580f84-ec12-4a12-8613-67f07621810a" />

