### PR TITLE
予約確認ページにNoticeCardコンポーネントを追加し、申し込み未確定の注意メッセージを表示する機能を実装

### DIFF
--- a/src/app/reservation/confirm/components/NotesSection.tsx
+++ b/src/app/reservation/confirm/components/NotesSection.tsx
@@ -3,12 +3,24 @@
 import React from "react";
 import { AlertCircle } from "lucide-react";
 import IconWrapper from "@/components/shared/IconWrapper";
+import { useAuth } from "@/contexts/AuthProvider";
 
 const NotesSection = () => {
+  const { isAuthenticated } = useAuth();
   return (
     <div className="rounded-lg p-6 mb-6">
       <h3 className="text-display-sm mb-6">注意事項</h3>
       <div className="space-y-4">
+        {!isAuthenticated && (
+          <div className="flex items-start gap-3">
+            <IconWrapper color="warning">
+              <AlertCircle size={18} strokeWidth={1.5} />
+            </IconWrapper>
+            <p className="text-body-md flex-1 font-bold">
+              この先はログインが必要です。ボタンを押し、ログインしてから再度お申し込みください。
+            </p>
+          </div>
+        )}
         <div className="flex items-start gap-3">
           <IconWrapper color="warning">
             <AlertCircle size={18} strokeWidth={1.5} />

--- a/src/app/reservation/confirm/page.tsx
+++ b/src/app/reservation/confirm/page.tsx
@@ -23,7 +23,8 @@ import OpportunityCardHorizontal from "@/app/activities/components/Card/CardHori
 import { GqlOpportunityCategory } from "@/types/graphql";
 import { COMMUNITY_ID } from "@/lib/communities/metadata";
 import { logger } from "@/lib/logging";
-import { RawURIComponent } from "@/utils/path";
+import { encodeURIComponentWithType, RawURIComponent } from "@/utils/path";
+import { NoticeCard } from "@/components/shared/NoticeCard";
 
 export default function ConfirmPage() {
   const headerConfig: HeaderConfig = useMemo(
@@ -119,7 +120,10 @@ export default function ConfirmPage() {
           onClose={ () => ui.setIsLoginModalOpen(false) }
           nextPath={ window.location.pathname + window.location.search as RawURIComponent }
         />
-        <div className="px-6 py-4 mt-4">
+        <div className="px-6 py-4">
+          <NoticeCard title="申し込みは未確定です。" description="最後までご確認いただき確定させて下さい" />
+        </div>
+        <div className="px-6 py-4 mt-2">
           <OpportunityCardHorizontal
             opportunity={ {
               id: opportunity.id,

--- a/src/app/reservation/confirm/page.tsx
+++ b/src/app/reservation/confirm/page.tsx
@@ -23,7 +23,7 @@ import OpportunityCardHorizontal from "@/app/activities/components/Card/CardHori
 import { GqlOpportunityCategory } from "@/types/graphql";
 import { COMMUNITY_ID } from "@/lib/communities/metadata";
 import { logger } from "@/lib/logging";
-import { encodeURIComponentWithType, RawURIComponent } from "@/utils/path";
+import { RawURIComponent } from "@/utils/path";
 import { NoticeCard } from "@/components/shared/NoticeCard";
 
 export default function ConfirmPage() {

--- a/src/app/reservation/confirm/page.tsx
+++ b/src/app/reservation/confirm/page.tsx
@@ -121,7 +121,7 @@ export default function ConfirmPage() {
           nextPath={ window.location.pathname + window.location.search as RawURIComponent }
         />
         <div className="px-6 py-4">
-          <NoticeCard title="申し込みは未確定です。" description="最後までご確認いただき確定させて下さい" />
+          <NoticeCard title="申し込みは未確定です。" description="最後までご確認いただき、申し込みください。" />
         </div>
         <div className="px-6 py-4 mt-2">
           <OpportunityCardHorizontal
@@ -174,7 +174,7 @@ export default function ConfirmPage() {
               creatingReservation || (ui.useTickets && ticketCounter.count > availableTickets)
             }
           >
-            { creatingReservation ? "申込処理中..." : "申し込みを確定" }
+            { creatingReservation ? "申込処理中..." : "申し込みをする" }
           </Button>
         </footer>
       </main>

--- a/src/components/shared/NoticeCard.tsx
+++ b/src/components/shared/NoticeCard.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import IconWrapper from "./IconWrapper";
 import { AlertCircle } from "lucide-react";
 
@@ -21,7 +21,6 @@ export const NoticeCard = ({ title, description }: NoticeCardProps) => {
           </p>
         </div>
       </div>
-      
     </Card>
   );
 };

--- a/src/components/shared/NoticeCard.tsx
+++ b/src/components/shared/NoticeCard.tsx
@@ -1,0 +1,27 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import IconWrapper from "./IconWrapper";
+import { AlertCircle } from "lucide-react";
+
+interface NoticeCardProps {
+  title: string;
+  description: string;
+}
+
+export const NoticeCard = ({ title, description }: NoticeCardProps) => {
+  return (
+    <Card>
+      <div className="flex items-start p-4 bg-yellow-50 border border-warning rounded-lg">
+        <IconWrapper color="warning">
+          <AlertCircle size={20} strokeWidth={2.5} />
+        </IconWrapper>
+        <div className="ml-2">
+          <p className="text-sm font-bold mt-[2px]">{title}</p>
+          <p className="text-sm pt-2 text-caption">
+            {description}
+          </p>
+        </div>
+      </div>
+      
+    </Card>
+  );
+};


### PR DESCRIPTION
close #504 
予約確認ページにNoticeCardコンポーネントを追加し、申し込み未確定の注意メッセージを表示する機能を実装しました。

## 変更内容
- NoticeCardコンポーネントを新規作成
- 予約確認ページに注意メッセージを表示する機能を追加

<img width="414" height="357" alt="image" src="https://github.com/user-attachments/assets/4577f2dc-b690-458c-8f4e-2eb76457fd9e" />

- 「申し込みを確定」というボタンの名前ではなく、「申し込みをする」に変更（確定は承認後なので誤解を招く可能性がある）

- 注意書きの欄に未ログイン時には、ログインする必要があることを追記

<img width="431" height="474" alt="image" src="https://github.com/user-attachments/assets/045a676e-12ed-456e-89ba-bc8b6d20e220" />


## 関連ファイル
- src/components/shared/NoticeCard.tsx (新規作成)
- その他関連ファイルの更新

## 確認項目
- [x] 未ログイン時に申し込みページ開いた時に注意書きにログインが必要な旨が表示される
- [x] ログイン時に申し込みページ開いた時に注意書きにログインが必要な旨は表示されない
