### PR TITLE
fix: 予約画面のボタンラベルをわかりやすいように変更

### DIFF
--- a/src/app/reservation/confirm/page.tsx
+++ b/src/app/reservation/confirm/page.tsx
@@ -47,6 +47,17 @@ export default function ConfirmPage() {
   } = useReservationParams();
 
   const [participantCount, setParticipantCount] = useState<number>(initialParticipantCount);
+
+  const getButtonText = () => {
+    if (creatingReservation) {
+      return "申込処理中...";
+    }
+    if (user) {
+      return "申し込みをする";
+    }
+    return "LINEで登録に進む";
+  };
+
   const {
     opportunity,
     selectedSlot,
@@ -174,7 +185,7 @@ export default function ConfirmPage() {
               creatingReservation || (ui.useTickets && ticketCounter.count > availableTickets)
             }
           >
-            { creatingReservation ? "申込処理中..." : "申し込みをする" }
+            { getButtonText() }
           </Button>
         </footer>
       </main>


### PR DESCRIPTION
close #504 

| 未ログイン状態 | ログイン状態 |
|--------|--------|
| <img width="468" height="500" alt="image" src="https://github.com/user-attachments/assets/ad75265e-b9f3-4b7a-bf24-7ebb75bcc62a" /> | <img width="455" height="428" alt="image" src="https://github.com/user-attachments/assets/301a15b4-9704-49cd-9411-526daf41ef9f" /> | 

