### PR TITLE
users/meの画面でQuestとActivityに対応できるように実装

### DIFF
--- a/src/lib/communities/metadata.ts
+++ b/src/lib/communities/metadata.ts
@@ -73,7 +73,7 @@ const COMMUNITY_BASE_CONFIG: Record<string, CommunityBaseConfig> = {
     logoPath: "/communities/neo88/logo.jpg",
     squareLogoPath: "/communities/neo88/logo-square.jpg",
     ogImagePath: "https://storage.googleapis.com/prod-civicship-storage-public/asset/neo88/ogp.jpg",
-    enableFeatures: ["opportunities", "places", "points", "articles", "tickets", "prefectures","quests"],
+    enableFeatures: ["opportunities", "places", "points", "articles", "tickets", "prefectures"],
     rootPath: "/activities",
     adminRootPath: "/admin/reservations",
   },


### PR DESCRIPTION
- questだがactivityのurlになっていることでacivityとしてのデザインになっている
- 主催中体験がquestだが、activity仕様で表示されている


https://github.com/user-attachments/assets/2521771c-43cc-4d2c-9be9-aadb549d3850

