### PR TITLE
予約確認画面のUI改善とナビゲーション修正

### DIFF
--- a/src/app/components/CardHorizontal.tsx
+++ b/src/app/components/CardHorizontal.tsx
@@ -24,11 +24,12 @@ export const CardHorizontal = ({ opportunity, withShadow = true, category, start
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const handleOpen = useCallback(() => setIsSheetOpen(true), []);
   const handleClose = useCallback(() => setIsSheetOpen(false), []);
+  const link = category === GqlOpportunityCategory.Quest ? `/quests/${opportunity.id}?community_id=${opportunity.communityId}` : `/activities/${opportunity.id}?community_id=${opportunity.communityId}`;
 
   return (
     <>
       <Link
-        href={`/activities/${opportunity.id}?community_id=${opportunity.communityId}`}
+        href={link}
         className="block"
       >
         <div className="mx-auto max-w-md">
@@ -58,8 +59,8 @@ export const CardHorizontal = ({ opportunity, withShadow = true, category, start
           </div>
           <div>
             <h2 className="text-label-sm font-bold pt-10">日時</h2>
-            <p className="text-body-sm text-foreground pt-1">
-              {displayDuration(startDateTime?.toISOString() ?? "", endDateTime?.toISOString() ?? "")}
+            <p className="text-body-sm text-foreground pt-1 whitespace-pre-wrap">
+              {displayDuration(startDateTime?.toISOString() ?? "", endDateTime?.toISOString() ?? "", true)}
             </p>
           </div>
           <div className="border-b border-gray-200 my-4"></div>

--- a/src/app/participations/[id]/components/OpportunityInfo.tsx
+++ b/src/app/participations/[id]/components/OpportunityInfo.tsx
@@ -6,6 +6,8 @@ import { ActivityDetail, QuestDetail } from "@/app/activities/data/type";
 import { PLACEHOLDER_IMAGE } from "@/utils";
 import { displayDuration } from "@/utils/date";
 import { ArrowRight } from "lucide-react";
+import { GqlOpportunityCategory } from "@/types/graphql";
+import Link from "next/link";
 
 interface OpportunityInfoProps {
   opportunity: ActivityDetail | QuestDetail | null;
@@ -24,9 +26,10 @@ interface OpportunityInfoProps {
 
 const OpportunityInfo: React.FC<OpportunityInfoProps> = ({ opportunity, dateTimeInfo, participationCount, phoneNumber, comment, totalPrice }) => {
   const slotDateTime = displayDuration(opportunity?.slots[0]?.startsAt ?? "", opportunity?.slots[0]?.endsAt ?? "");
+  const link = opportunity?.category === GqlOpportunityCategory.Quest ? `/quests/${opportunity?.id}?community_id=${opportunity?.communityId}` : `/activities/${opportunity?.id}?community_id=${opportunity?.communityId}`;
   return (
     <div className="mx-6 my-6 rounded-lg">
-      <div className="flex justify-between items-center gap-4">
+      <Link href={link} className="flex justify-between items-center gap-4">
         <div className="relative w-[80px] h-[80px] rounded-lg overflow-hidden flex-shrink-0">
           <Image
             src={opportunity?.images?.[0] || PLACEHOLDER_IMAGE}
@@ -43,7 +46,7 @@ const OpportunityInfo: React.FC<OpportunityInfoProps> = ({ opportunity, dateTime
           </h1>
         </div>
         <ArrowRight size={20} className="text-primary flex-shrink-0" />
-      </div>
+      </Link>
       { dateTimeInfo && (
         <dl className="flex justify-between py-5 mt-2 border-b border-foreground-caption items-center">
           <dt className="text-label-sm font-bold w-24">日時</dt>

--- a/src/app/participations/[id]/components/OpportunityInfo.tsx
+++ b/src/app/participations/[id]/components/OpportunityInfo.tsx
@@ -10,7 +10,7 @@ import { GqlOpportunityCategory } from "@/types/graphql";
 import Link from "next/link";
 
 interface OpportunityInfoProps {
-  opportunity: ActivityDetail | QuestDetail | null;
+  opportunity: ActivityDetail | QuestDetail;
   dateTimeInfo?: {
     formattedDate: string;
     startTime: string;
@@ -25,15 +25,18 @@ interface OpportunityInfoProps {
 }
 
 const OpportunityInfo: React.FC<OpportunityInfoProps> = ({ opportunity, dateTimeInfo, participationCount, phoneNumber, comment, totalPrice }) => {
-  const slotDateTime = displayDuration(opportunity?.slots[0]?.startsAt ?? "", opportunity?.slots[0]?.endsAt ?? "");
-  const link = opportunity?.category === GqlOpportunityCategory.Quest ? `/quests/${opportunity?.id}?community_id=${opportunity?.communityId}` : `/activities/${opportunity?.id}?community_id=${opportunity?.communityId}`;
+  const slotDateTime = displayDuration(opportunity.slots[0]?.startsAt ?? "", opportunity.slots[0]?.endsAt ?? "");
+  const link = opportunity.category === GqlOpportunityCategory.Quest 
+    ? `/quests/${opportunity.id}?community_id=${opportunity.communityId}` 
+    : `/activities/${opportunity.id}?community_id=${opportunity.communityId}`;
+
   return (
     <div className="mx-6 my-6 rounded-lg">
       <Link href={link} className="flex justify-between items-center gap-4">
         <div className="relative w-[80px] h-[80px] rounded-lg overflow-hidden flex-shrink-0">
           <Image
-            src={opportunity?.images?.[0] || PLACEHOLDER_IMAGE}
-            alt={opportunity?.title ?? ""}
+            src={opportunity.images?.[0] || PLACEHOLDER_IMAGE}
+            alt={opportunity.title ?? ""}
             fill
             placeholder={"blur"}
             blurDataURL={PLACEHOLDER_IMAGE}
@@ -42,7 +45,7 @@ const OpportunityInfo: React.FC<OpportunityInfoProps> = ({ opportunity, dateTime
         </div>
         <div>
           <h1 className="text-title-md font-bold leading-tight mb-4 line-clamp-3 break-words">
-            {opportunity?.title ?? ""}
+            {opportunity.title ?? ""}
           </h1>
         </div>
         <ArrowRight size={20} className="text-primary flex-shrink-0" />

--- a/src/app/participations/[id]/page.tsx
+++ b/src/app/participations/[id]/page.tsx
@@ -128,7 +128,7 @@ export default function ParticipationPage() {
   }, [currentStatus, dateTimeInfo]);
 
   if (loading || opportunityLoading) return <LoadingIndicator />;
-  if (hasError || !reservationId || !opportunity || !participation) {
+  if (hasError || !reservationId || !opportunity || !participation || !opportunityDetail) {
     return <ErrorState title="Could not load reservation page" refetchRef={refetchRef} />;
   }
 

--- a/src/app/quests/[id]/page.tsx
+++ b/src/app/quests/[id]/page.tsx
@@ -64,8 +64,6 @@ export default function ActivityPage() {
     return notFound();
   }
 
-  console.log("opportunity", opportunity);
-
   const questSlots = sortedSlots?.filter((slot): slot is QuestSlot => "pointsToEarn" in slot) ?? [];
   const questQuests = sameStateActivities?.filter((quest): quest is QuestCard => "pointsToEarn" in quest && !("feeRequired" in quest)) ?? [];
 

--- a/src/app/reservation/complete/components/ReservationDetails.tsx
+++ b/src/app/reservation/complete/components/ReservationDetails.tsx
@@ -74,7 +74,7 @@ const ReservationDetails: React.FC<ReservationDetailsProps> = ({
         <Users size={18} strokeWidth={1.5} className="text-caption w-6 h-6 mt-0.5" />
         <span>{participantCount}人</span>
       </div>
-      { category === GqlOpportunityCategory.Activity && (
+      { category === GqlOpportunityCategory.Activity ? (
       <div className="flex items-center gap-x-2">
         <div className="flex flex-col w-full">
           <div className="flex items-center gap-x-2">
@@ -85,7 +85,7 @@ const ReservationDetails: React.FC<ReservationDetailsProps> = ({
           </div>
           
           {/* 内訳セクション */}
-          <div className="bg-muted rounded-lg p-4 ml-12 mt-2">
+          <div className="bg-muted rounded-lg p-4 mt-2">
             <div className="space-y-2">
               <h2 className="text-body-xs text-caption font-bold">内訳</h2>
               {/* 通常申し込み */}
@@ -101,7 +101,7 @@ const ReservationDetails: React.FC<ReservationDetailsProps> = ({
               </div>
 
               {/* ポイント利用 */}
-              { points && points.usedPoints > 0 && points.participantCountWithPoint > 0 && (
+              { points && points.usedPoints > 0 && points.participantCountWithPoint > 0 ? (
               <div className="flex justify-between text-body-xs text-muted-foreground">
                 <span>ポイント利用</span>
                 <div>
@@ -112,21 +112,23 @@ const ReservationDetails: React.FC<ReservationDetailsProps> = ({
                   <span className="font-bold">{ (points?.usedPoints ?? 0) * (points?.participantCountWithPoint ?? 0) }pt</span>
                   </div>
                 </div>
-              ) }
+              ) : null }
 
               {/* チケット利用 */}
+              { ticketCount > 0 ? (
               <div className="flex justify-between text-body-xs text-muted-foreground">
                 <span>チケット利用</span>
                 <div>
                   <span>{ ticketCount }名分</span>
                 </div>
               </div>
+              ) : null }
             </div>
           </div>
         </div>
       </div>
-      ) }
-      { category === GqlOpportunityCategory.Quest && (
+      ) : null }
+      { category === GqlOpportunityCategory.Quest ? (
         <div className="flex items-center gap-1 pt-1">
         <p className="bg-primary text-[11px] rounded-full w-5 h-5 flex items-center justify-center font-bold text-white leading-none">
           P
@@ -135,7 +137,7 @@ const ReservationDetails: React.FC<ReservationDetailsProps> = ({
             +{pointsToEarn.toLocaleString()}ポイント
         </p>
       </div>
-      )}
+      ) : null }
       <div className="flex items-center gap-x-2">
         {isReserved ? (
           phoneNumber ? (

--- a/src/app/reservation/complete/page.tsx
+++ b/src/app/reservation/complete/page.tsx
@@ -69,7 +69,7 @@ export default function CompletePage() {
   const { opportunity: oppotunityDetail } = useOpportunityDetail(opportunityId ?? "");
 
   if (loading) return <LoadingIndicator fullScreen />;
-  if (error || !reservation || !opportunity || !dateTimeInfo)
+  if (error || !reservation || !opportunity || !dateTimeInfo || !oppotunityDetail)
     return <ErrorState title="申込完了ページを読み込めませんでした" refetchRef={refetchRef} />;
 
   return (

--- a/src/app/reservation/confirm/components/OpportunityInfo.tsx
+++ b/src/app/reservation/confirm/components/OpportunityInfo.tsx
@@ -6,6 +6,7 @@ import { ActivityDetail, QuestDetail } from "@/app/activities/data/type";
 import { PLACEHOLDER_IMAGE } from "@/utils";
 import { displayDuration } from "@/utils/date";
 import { GqlOpportunityCategory } from "@/types/graphql";
+import Link from "next/link";
 
 interface OpportunityInfoProps {
   opportunity: ActivityDetail | QuestDetail;

--- a/src/app/reservation/confirm/components/OpportunityInfo.tsx
+++ b/src/app/reservation/confirm/components/OpportunityInfo.tsx
@@ -10,7 +10,7 @@ import { ArrowRight } from "lucide-react";
 import Link from "next/link";
 
 interface OpportunityInfoProps {
-  opportunity: ActivityDetail | QuestDetail | null;
+  opportunity: ActivityDetail | QuestDetail;
   dateTimeInfo?: {
     formattedDate: string;
     startTime: string;
@@ -108,7 +108,9 @@ const OpportunityInfo: React.FC<OpportunityInfoProps> = ({
    ticketCount
  }) => {
   const slotDateTime = displayDuration(opportunity?.slots[0]?.startsAt ?? "", opportunity?.slots[0]?.endsAt ?? "", true);
-  const link = opportunity?.category === GqlOpportunityCategory.Quest ? `/quests/${opportunity?.id}?community_id=${opportunity?.communityId}` : `/activities/${opportunity?.id}?community_id=${opportunity?.communityId}`;
+  const link = opportunity.category === GqlOpportunityCategory.Quest
+     ? `/quests/${opportunity.id}?community_id=${opportunity.communityId}`
+    : `/activities/${opportunity.id}?community_id=${opportunity.communityId}`;
 
   return (
     <div className="mx-6 my-6 border border-foreground-caption rounded-lg p-4">
@@ -116,8 +118,8 @@ const OpportunityInfo: React.FC<OpportunityInfoProps> = ({
         <div className="flex justify-between items-center gap-4">
           <div className="relative w-[120px] h-[120px] rounded-lg overflow-hidden flex-shrink-0">
             <Image
-              src={opportunity?.images?.[0] || PLACEHOLDER_IMAGE}
-              alt={opportunity?.title ?? ""}
+              src={opportunity.images?.[0] || PLACEHOLDER_IMAGE}
+              alt={opportunity.title ?? ""}
               fill
               placeholder={"blur"}
               blurDataURL={PLACEHOLDER_IMAGE}

--- a/src/app/reservation/confirm/components/OpportunityInfo.tsx
+++ b/src/app/reservation/confirm/components/OpportunityInfo.tsx
@@ -7,6 +7,7 @@ import { PLACEHOLDER_IMAGE } from "@/utils";
 import { displayDuration } from "@/utils/date";
 import { GqlOpportunityCategory } from "@/types/graphql";
 import { ArrowRight } from "lucide-react";
+import Link from "next/link";
 
 interface OpportunityInfoProps {
   opportunity: ActivityDetail | QuestDetail | null;
@@ -60,26 +61,28 @@ const getPointOrFee = (
               </div>
 
               {/* ポイント利用 */}
-              { pointsRequired && pointsRequired > 0 && participantCountWithPoint && participantCountWithPoint > 0 && (
+              { pointsRequired && pointsRequired > 0 && participantCountWithPoint && participantCountWithPoint > 0 ? (
               <div className="flex justify-between text-body-xs text-muted-foreground">
                 <span>ポイント利用</span>
-                <div>
-                  <span>{ pointsRequired?.toLocaleString() }pt</span>
-                  <span className="mx-2">×</span>
-                  <span>{ participantCountWithPoint }名</span>
-                  <span className="mx-2">=</span>
-                  <span className="font-bold">{ (pointsRequired ?? 0) * (participantCountWithPoint ?? 0) }pt</span>
+                  <div>
+                    <span>{ pointsRequired?.toLocaleString() }pt</span>
+                    <span className="mx-2">×</span>
+                    <span>{ participantCountWithPoint }名</span>
+                    <span className="mx-2">=</span>
+                    <span className="font-bold">{ pointsRequired * participantCountWithPoint }pt</span>
                   </div>
                 </div>
-              ) }
+              ) : null }
 
               {/* チケット利用 */}
+              { ticketCount && ticketCount > 0 ? (
               <div className="flex justify-between text-body-xs text-muted-foreground">
                 <span>チケット利用</span>
                 <div>
                   <span>{ ticketCount }名分</span>
                 </div>
               </div>
+              ) : null }
             </div>
           </div>
       </div>
@@ -104,32 +107,35 @@ const OpportunityInfo: React.FC<OpportunityInfoProps> = ({
    totalPrice,
    ticketCount
  }) => {
-  const slotDateTime = displayDuration(opportunity?.slots[0]?.startsAt ?? "", opportunity?.slots[0]?.endsAt ?? "");
+  const slotDateTime = displayDuration(opportunity?.slots[0]?.startsAt ?? "", opportunity?.slots[0]?.endsAt ?? "", true);
+  const link = opportunity?.category === GqlOpportunityCategory.Quest ? `/quests/${opportunity?.id}?community_id=${opportunity?.communityId}` : `/activities/${opportunity?.id}?community_id=${opportunity?.communityId}`;
 
   return (
     <div className="mx-6 my-6 border border-foreground-caption rounded-lg p-4">
-      <div className="flex justify-between items-center gap-4">
-        <div className="relative w-[120px] h-[120px] rounded-lg overflow-hidden flex-shrink-0">
-          <Image
-            src={opportunity?.images?.[0] || PLACEHOLDER_IMAGE}
-            alt={opportunity?.title ?? ""}
-            fill
-            placeholder={"blur"}
-            blurDataURL={PLACEHOLDER_IMAGE}
-            className="object-cover"
-          />
+      <Link href={link}>
+        <div className="flex justify-between items-center gap-4">
+          <div className="relative w-[120px] h-[120px] rounded-lg overflow-hidden flex-shrink-0">
+            <Image
+              src={opportunity?.images?.[0] || PLACEHOLDER_IMAGE}
+              alt={opportunity?.title ?? ""}
+              fill
+              placeholder={"blur"}
+              blurDataURL={PLACEHOLDER_IMAGE}
+              className="object-cover"
+            />
+          </div>
+          <div>
+            <h1 className="text-title-md font-bold leading-tight mb-4 line-clamp-3 break-words">
+              {opportunity?.title ?? ""}
+            </h1>
+          </div>
+          <ArrowRight size={20} className="text-primary flex-shrink-0" />
         </div>
-        <div>
-          <h1 className="text-title-md font-bold leading-tight mb-4 line-clamp-3 break-words">
-            {opportunity?.title ?? ""}
-          </h1>
-        </div>
-        <ArrowRight size={20} className="text-primary flex-shrink-0" />
-      </div>
+      </Link>
       { dateTimeInfo && (
         <dl className="flex justify-between py-5 mt-2 border-b border-foreground-caption items-center">
           <dt className="text-label-sm font-bold w-24">日時</dt>
-          <dd className="text-body-sm">{ slotDateTime }</dd>
+          <dd className="text-body-sm whitespace-pre-wrap">{ slotDateTime }</dd>
         </dl>
       ) } 
       { participationCount && (

--- a/src/app/reservation/confirm/components/PaymentSection.tsx
+++ b/src/app/reservation/confirm/components/PaymentSection.tsx
@@ -75,10 +75,18 @@ const PaymentSection: React.FC<PaymentSectionProps> = memo(
         onSelectedTicketsChange(tickets);
       }
     }, [onSelectedTicketsChange]);
-
+    const getTitle = () => {
+      if (maxTickets > 0 && userWallet && userWallet > 0 && pointsRequired > 0 && userWallet >= pointsRequired) {
+        return "ポイント・チケットを利用";
+      } else if((userWallet ?? 0) >= pointsRequired && pointsRequired > 0) {
+        return "ポイントを利用";
+      }else{
+        return "チケットを利用";
+      }
+    }
     return (
       <div className="rounded-lg px-6">
-        <h3 className="text-display-sm mb-4">ポイント・チケットを利用</h3>
+        <h3 className="text-display-sm mb-4">{getTitle()}</h3>
         {maxTickets > 0 && (
           <TicketsToggle
             useTickets={useTickets}
@@ -93,7 +101,7 @@ const PaymentSection: React.FC<PaymentSectionProps> = memo(
             onSelectedTicketsChange={handleSelectedTicketsChange}
           />
         )}
-        {userWallet && userWallet > 0 && userWallet > pointsRequired && (
+        {userWallet && userWallet > 0 && pointsRequired > 0 && userWallet >= pointsRequired && (
           <PointsToggle
             usePoints={usePoints}
             setUsePoints={setUsePoints}

--- a/src/app/reservation/confirm/components/PaymentSummary.tsx
+++ b/src/app/reservation/confirm/components/PaymentSummary.tsx
@@ -14,6 +14,7 @@ export const PaymentSummary: React.FC<PaymentSummaryProps> = memo(
   ({ pricePerPerson, participantCount, useTickets, ticketCount, usePoints, pointCount, pointsRequired }) => {
     const totalAmount = pricePerPerson != null ? pricePerPerson * (participantCount - ticketCount - pointCount) : null;
     const summaryAmount = totalAmount != null ? totalAmount : null;
+    const hasPaymentMethod = usePoints && pointCount > 0 || useTickets && ticketCount > 0;
     return (
       <>
         <div className="mb-[6px] flex justify-between items-center">
@@ -33,7 +34,7 @@ export const PaymentSummary: React.FC<PaymentSummaryProps> = memo(
             <h2 className="text-body-sm text-caption font-bold">内訳</h2>
             
             {/* 通常申し込み */}
-            <div className="flex justify-between text-body-sm text-muted-foreground border-b border-foreground-caption pb-2">
+            <div className={`flex justify-between text-body-sm text-muted-foreground  pb-2 ${hasPaymentMethod ? "border-b border-foreground-caption" : "border-none"}`}>
               <span>通常申し込み</span>
               <div>
                 {pricePerPerson != null ? (

--- a/src/app/reservation/confirm/components/PaymentSummary.tsx
+++ b/src/app/reservation/confirm/components/PaymentSummary.tsx
@@ -51,7 +51,7 @@ export const PaymentSummary: React.FC<PaymentSummaryProps> = memo(
             </div>
 
             {/* ポイント利用 */}
-            {usePoints && pointCount > 0 && (
+            {usePoints && pointCount > 0 ? (
               <div className="flex justify-between text-body-sm text-muted-foreground">
                 <span>ポイント利用</span>
                 <div>
@@ -62,15 +62,15 @@ export const PaymentSummary: React.FC<PaymentSummaryProps> = memo(
                   <span className="font-bold">{((pointsRequired ?? 0) * pointCount).toLocaleString()}pt</span>
                 </div>
               </div>
-            )}
+            ) : null }
 
             {/* チケット利用 */}
-            {/* {useTickets && ticketCount > 0 && ( */}
+            {useTickets && ticketCount > 0 ? (
               <div className="flex justify-between text-body-sm text-muted-foreground">
                 <span>チケット利用</span>
                 <span>{ticketCount}名分</span>
               </div>
-            {/* )} */}
+            ) : null }
           </div>
         </div>
       </>

--- a/src/app/reservation/confirm/page.tsx
+++ b/src/app/reservation/confirm/page.tsx
@@ -166,7 +166,7 @@ export default function ConfirmPage() {
           />
         </div>
         <div className="mx-6 border-b border-gray-200 my-6"></div>
-        {isActivity && ((userWallet && userWallet > pointsRequired) || maxTickets > 0) && (
+        {isActivity && ((userWallet && userWallet > pointsRequired) || maxTickets > 0) && pointsRequired > 0 ? (
           <>
           <PaymentSection
             ticketCount={ ticketCounter.count }
@@ -188,7 +188,7 @@ export default function ConfirmPage() {
           />
           <div className="border-b border-gray-200 my-6"></div>
           </>
-        )}
+        ) : null }
         <div className="mb-2" />
         {/* <NotesSection /> */}
         <CommentTextarea

--- a/src/app/reservation/confirm/page.tsx
+++ b/src/app/reservation/confirm/page.tsx
@@ -166,7 +166,7 @@ export default function ConfirmPage() {
           />
         </div>
         <div className="mx-6 border-b border-gray-200 my-6"></div>
-        {isActivity && ((userWallet && userWallet > pointsRequired) || maxTickets > 0) && pointsRequired > 0 ? (
+        {isActivity && ((userWallet && userWallet >= pointsRequired && pointsRequired > 0) || maxTickets > 0) ? (
           <>
           <PaymentSection
             ticketCount={ ticketCounter.count }

--- a/src/app/reservation/confirm/page.tsx
+++ b/src/app/reservation/confirm/page.tsx
@@ -194,7 +194,7 @@ export default function ConfirmPage() {
         <CommentTextarea
           title={"主催者への伝言"}
           description={"案内人の事前準備が変わる場合があるため、参加者の年齢等の記入にご協力ください"} 
-          placeholder="1歳、５歳、５１歳"
+          placeholder="例）51歳、5歳で参加します"
           value={ui.ageComment}
           onChange={ui.setAgeComment}
         />

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -102,15 +102,17 @@ export const displayDuration = (start: Date | string, end?: Date | string, multi
   if (!end) return displayDatetime(start, FULL_FMT);
   
   if (dStart.isSame(dEnd, "date")) {
-    // 同じ日付の場合は常に1行表示
-    return `${dStart.format(FULL_FMT)}〜${dEnd.format(TIME_FMT)}`;
+    // 同じ日付の場合
+    if (multiline) {
+      // 同じ日付でmultilineがtrueの場合は2行表示
+      return `${dStart.format(DATE_FMT)}\n${dStart.format(TIME_FMT)} 〜 ${dEnd.format(TIME_FMT)}`;
+    } else {
+      // 同じ日付でmultilineがfalseの場合は1行表示
+      return `${dStart.format(FULL_FMT)}〜${dEnd.format(TIME_FMT)}`;
+    }
   } else if (multiline) {
     // 日付を跨ぐ場合でmultilineがtrueの場合は2行表示
-    if (dStart.isSame(dEnd, "year")) {
-      return `${dStart.format(DATE_FMT)} 〜 ${dEnd.format(MONTH_DATE_FMT)}\n${dStart.format(TIME_FMT)} 〜 ${dEnd.format(TIME_FMT)}`;
-    } else {
-      return `${dStart.format(DATE_FMT)} 〜 ${dEnd.format(DATE_FMT)}\n${dStart.format(TIME_FMT)} 〜 ${dEnd.format(TIME_FMT)}`;
-    }
+    return `${dStart.format(FULL_FMT)} 〜\n${dEnd.format(FULL_FMT)}`;
   } else {
     // 日付を跨ぐ場合でmultilineがfalseの場合は1行表示
     if (dStart.isSame(dEnd, "year")) {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -9,6 +9,7 @@ const YEAR_FMT = "YYYY年";
 const MONTH_DATE_FMT = "M月D日(ddd)";
 const TIME_FMT = "H:mm";
 const FULL_FMT = `${YEAR_FMT}${MONTH_DATE_FMT} ${TIME_FMT}`;
+const DATE_FMT = `${YEAR_FMT}${MONTH_DATE_FMT}`;
 
 export const parseDateTime = (dateTimeStr: string | null | undefined): Date | null => {
   if (!dateTimeStr) return null;
@@ -94,15 +95,29 @@ export const displayDatetime = (date: Date | string | null | undefined, format: 
   return dayjs(date).format(format);
 };
 
-export const displayDuration = (start: Date | string, end?: Date | string) => {
+export const displayDuration = (start: Date | string, end?: Date | string, multiline: boolean = false) => {
   const dStart = dayjs(start);
   const dEnd = dayjs(end);
+  
   if (!end) return displayDatetime(start, FULL_FMT);
-  if (dStart.isSame(dEnd, "date")) {
-    return `${dStart.format(FULL_FMT)}〜${dEnd.format(TIME_FMT)}`;
-  } else if (dStart.isSame(dEnd, "year")) {
-    return `${dStart.format(FULL_FMT)} 〜 ${dEnd.format(`${MONTH_DATE_FMT} ${TIME_FMT}`)}`;
+  
+  if (multiline) {
+    // 2行表示: 日付と時間を分けて表示
+    if (dStart.isSame(dEnd, "date")) {
+      return `${dStart.format(DATE_FMT)}\n${dStart.format(TIME_FMT)}〜${dEnd.format(TIME_FMT)}`;
+    } else if (dStart.isSame(dEnd, "year")) {
+      return `${dStart.format(DATE_FMT)} 〜 ${dEnd.format(MONTH_DATE_FMT)}\n${dStart.format(TIME_FMT)} 〜 ${dEnd.format(TIME_FMT)}`;
+    } else {
+      return `${dStart.format(DATE_FMT)} 〜 ${dEnd.format(DATE_FMT)}\n${dStart.format(TIME_FMT)} 〜 ${dEnd.format(TIME_FMT)}`;
+    }
   } else {
-    return `${dStart.format(FULL_FMT)} 〜 ${dEnd.format(FULL_FMT)}`;
+    // 1行表示: 従来通りの表示
+    if (dStart.isSame(dEnd, "date")) {
+      return `${dStart.format(FULL_FMT)}〜${dEnd.format(TIME_FMT)}`;
+    } else if (dStart.isSame(dEnd, "year")) {
+      return `${dStart.format(FULL_FMT)} 〜 ${dEnd.format(`${MONTH_DATE_FMT} ${TIME_FMT}`)}`;
+    } else {
+      return `${dStart.format(FULL_FMT)} 〜 ${dEnd.format(FULL_FMT)}`;
+    }
   }
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -101,20 +101,19 @@ export const displayDuration = (start: Date | string, end?: Date | string, multi
   
   if (!end) return displayDatetime(start, FULL_FMT);
   
-  if (multiline) {
-    // 2行表示: 日付と時間を分けて表示
-    if (dStart.isSame(dEnd, "date")) {
-      return `${dStart.format(DATE_FMT)}\n${dStart.format(TIME_FMT)}〜${dEnd.format(TIME_FMT)}`;
-    } else if (dStart.isSame(dEnd, "year")) {
+  if (dStart.isSame(dEnd, "date")) {
+    // 同じ日付の場合は常に1行表示
+    return `${dStart.format(FULL_FMT)}〜${dEnd.format(TIME_FMT)}`;
+  } else if (multiline) {
+    // 日付を跨ぐ場合でmultilineがtrueの場合は2行表示
+    if (dStart.isSame(dEnd, "year")) {
       return `${dStart.format(DATE_FMT)} 〜 ${dEnd.format(MONTH_DATE_FMT)}\n${dStart.format(TIME_FMT)} 〜 ${dEnd.format(TIME_FMT)}`;
     } else {
       return `${dStart.format(DATE_FMT)} 〜 ${dEnd.format(DATE_FMT)}\n${dStart.format(TIME_FMT)} 〜 ${dEnd.format(TIME_FMT)}`;
     }
   } else {
-    // 1行表示: 従来通りの表示
-    if (dStart.isSame(dEnd, "date")) {
-      return `${dStart.format(FULL_FMT)}〜${dEnd.format(TIME_FMT)}`;
-    } else if (dStart.isSame(dEnd, "year")) {
+    // 日付を跨ぐ場合でmultilineがfalseの場合は1行表示
+    if (dStart.isSame(dEnd, "year")) {
       return `${dStart.format(FULL_FMT)} 〜 ${dEnd.format(`${MONTH_DATE_FMT} ${TIME_FMT}`)}`;
     } else {
       return `${dStart.format(FULL_FMT)} 〜 ${dEnd.format(FULL_FMT)}`;


### PR DESCRIPTION
> タスク内容

- 問題：チケット利用してないなら「チケット利用分」は不要
  - PRで解決したこと : チケットを使用していない場合は表示しないように修正
  - 画面収録 : https://4hopin.slack.com/archives/C0945JVF2DP/p1753767811389519

- 問題：日時は「日付」「時間帯」で区切って2行表示が良い
  - PRで解決したこと : 日時、時間帯を区切って二行で表示するように実装、
  - 既存のdisplayDurationの関数にフラグを追加して2行にするかしないかを選択できるように実装
  - 画面収録 : https://4hopin.slack.com/archives/C0945JVF2DP/p1753767951861949

- 問題 : 料金内訳のところに、謎の0が表示されている
  - PRで解決したこと : 条件分岐を修正して条件に満たない場合はnullを返すようにし0が表示されないように実装
  - 画面収録 : https://4hopin.slack.com/archives/C0945JVF2DP/p1753770710402659

- 問題 : 体験詳細画面へ遷移できない
  - PRで解決したこと : 再利用できるように作成したコンポーネントにLinkをつけれていなかったため追加して遷移できるように実装
  - 画面収録 : https://4hopin.slack.com/archives/C0945JVF2DP/p1753770755868519

- 問題 : 詳細画面へ遷移した際にログが出たままになっている
  - PRで解決したこと : 不要なconsole.logを削除

- 問題 : participationsのデザインは、reservationsのデザインを当てた方が良い
  - 補足 : 他の方針は待ちなので一旦左側の余白を削除するだけ実装
  - PRで解決したこと : 内訳の左側にml-12を入れて余白を開けていたのを削除
  - 画面収録 : https://4hopin.slack.com/archives/C0945JVF2DP/p1753771189439839
