### PR TITLE
Refactor cancellation status checks for clarity.

### DIFF
--- a/src/app/admin/reservations/hooks/useGetReservationStatusMeta.ts
+++ b/src/app/admin/reservations/hooks/useGetReservationStatusMeta.ts
@@ -21,7 +21,8 @@ const getReservationStatusMeta = (reservation: GqlReservation): StatusMeta => {
 
   const isApplied = status === GqlReservationStatus.Applied;
   const isRejected = status === GqlReservationStatus.Rejected;
-  const isCancelled = hostingStatus === GqlOpportunitySlotHostingStatus.Cancelled;
+  const isReservationCancelled = status === GqlReservationStatus.Canceled;
+  const isSlotCancelled = hostingStatus === GqlOpportunitySlotHostingStatus.Cancelled;
   const isAccepted = status === GqlReservationStatus.Accepted;
   const isScheduled = hostingStatus === GqlOpportunitySlotHostingStatus.Scheduled;
   const isCompleted = hostingStatus === GqlOpportunitySlotHostingStatus.Completed;
@@ -49,7 +50,11 @@ const getReservationStatusMeta = (reservation: GqlReservation): StatusMeta => {
     return { step: "approval", label: "却下済み", variant: "destructive" };
   }
 
-  if (isCancelled) {
+  if (isReservationCancelled) {
+    return { step: "cancellation", label: "キャンセル済み", variant: "outline" };
+  }
+
+  if (isSlotCancelled) {
     return { step: "cancellation", label: "開催中止", variant: "warning" };
   }
 


### PR DESCRIPTION
```
Refactor cancellation status checks to differentiate between reservation and slot cancellations.
This change improves code clarity when handling different types of cancellations, ensuring more accurate status handling.
```

<img width="416" height="908" alt="スクリーンショット 2025-07-29 17 16 50" src="https://github.com/user-attachments/assets/57f1fff3-9812-4b10-8f6f-581043495fc4" />