### PR TITLE
詳細画面でのBottomBarの表示と画像のパスの修正

### DIFF
--- a/src/app/components/PageClient.tsx
+++ b/src/app/components/PageClient.tsx
@@ -76,7 +76,7 @@ export default function PageClient() {
           <div className="ml-2">
             <div className="flex justify-between">
               <p className="text-base font-bold text-left">ポイントを獲得すると、<br/>無料で体験に参加できます。</p>
-              <Image src={"icons/arrow.svg"} alt="arrow" width={32} height={32} className="mt-6 ml-4"/>
+              <Image src="/icons/arrow.svg" alt="arrow" width={32} height={32} className="mt-6 ml-4"/>
             </div>
             <span className="text-xs">ポイントがもらえるお手伝いを探してみましょう</span>
             </div>

--- a/src/components/layout/BottomBar.tsx
+++ b/src/components/layout/BottomBar.tsx
@@ -32,6 +32,7 @@ const BottomBar: React.FC<HeaderProps> = ({ className }) => {
     pathname.startsWith("/admin") ||
     (pathname.startsWith("/reservation") && !pathname.includes("/complete")) ||
     pathname.startsWith("/activities/") ||
+    pathname.startsWith("/quests/") ||
     pathname.startsWith("/participations/") ||
     pathname.startsWith("/sign-up") ||
     pathname === "/users/me/edit" ||


### PR DESCRIPTION
> タスク

- 問題 : Questsの詳細画面でBottomBarが表示されているため見にくい
  - PRで解決したこと : BottomBarの非表示の条件にquestsを追加し表示されないようにした
- 問題 : Questsへのリンクのバナーの矢印の画像がdevelop環境だとリンク切れになっている
  - PRで解決したこと : パスが相対パスになっていたのでpublicからの絶対パスに修正
  - ローカルでは確認できないのでdevelp環境へマージを画像が表示されているか確認したい  

> Questsの詳細画面でBottomBarが表示されているため見にくい(画面収録)

https://github.com/user-attachments/assets/4e819108-de9f-434f-8890-5a375288713b


