### PR TITLE
fix: improve phone input placeholder text with example prefix

### DIFF
--- a/src/stories/app/sign-up/phone-verification-form.stories.tsx
+++ b/src/stories/app/sign-up/phone-verification-form.stories.tsx
@@ -168,7 +168,7 @@ const MockPhoneVerificationForm = ({
               type="tel"
               value={phoneNumber}
               onChange={(e) => setPhoneNumber(e.target.value)}
-              placeholder="090-1234-5678"
+              placeholder="例）090-1234-5678"
               className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${
                 phoneError ? "border-red-500" : "border-gray-300"
               }`}


### PR DESCRIPTION
## 解決すること
close #523 

## 対応したこと
- placeholder の先頭に `例）`を入れた（ことで、明示的に入力されたものと誤認されないように）

## 画面
<img width="570" height="438" alt="image" src="https://github.com/user-attachments/assets/f18f1418-522f-419d-a399-dfaad6ae1460" />

