### PR TITLE
ActivitiesListとQuestsListに無限スクロール用のローディングインジケーターを追加

### DIFF
--- a/src/app/activities/components/ActivitiesList.tsx
+++ b/src/app/activities/components/ActivitiesList.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 import { CarouselSection } from "@/app/components/CarouselSection";
 import EmptySearchResults from "@/app/search/result/components/EmptySearchResults";
+import LoadingIndicator from "@/components/shared/LoadingIndicator";
 
 export default function ActivitiesList() {
     const searchParams = useSearchParams();
@@ -27,8 +28,16 @@ export default function ActivitiesList() {
   
     useSearchResultHeader(queryParams);
   
-    const { recommendedOpportunities, groupedOpportunities, loading, error, refetch } =
-    useSearchResults(queryParams);
+    const { 
+      recommendedOpportunities, 
+      groupedOpportunities, 
+      loading, 
+      refetch,
+      error,
+      loadMoreRef,
+      hasNextPage,
+      isLoadingMore,
+    } = useSearchResults(queryParams);
 
     const isEmpty =
     recommendedOpportunities.length === 0 && Object.keys(groupedOpportunities).length === 0;
@@ -47,6 +56,14 @@ export default function ActivitiesList() {
           isVertical={false}
         />
         <DateGroupedOpportunities groupedOpportunities={groupedOpportunities} />
+        {/* 無限スクロール用のローディング要素 - 常に表示 */}
+        <div ref={loadMoreRef} className="flex justify-center py-8">
+          {isLoadingMore && (
+            <div className="flex items-center space-x-2">
+              <LoadingIndicator fullScreen={false}/>
+            </div>
+          )}
+        </div>
       </main>
     </div>
     </>

--- a/src/app/quests/components/QuestsList.tsx
+++ b/src/app/quests/components/QuestsList.tsx
@@ -31,10 +31,7 @@ export default function QuestsList() {
       recommendedOpportunities, 
       groupedOpportunities, 
       loading, 
-      refetch,
-      error,
       loadMoreRef,
-      hasNextPage,
       isLoadingMore,
     } = useSearchResults(queryParams);
 

--- a/src/app/quests/components/QuestsList.tsx
+++ b/src/app/quests/components/QuestsList.tsx
@@ -4,6 +4,7 @@ import DateGroupedOpportunities from "@/app/search/result/components/DateGrouped
 import EmptySearchResults from "@/app/search/result/components/EmptySearchResults";
 import useSearchResultHeader from "@/app/search/result/components/SearchResultHeader";
 import useSearchResults from "@/app/search/result/hooks/useSearchResults";
+import LoadingIndicator from "@/components/shared/LoadingIndicator";
 import { useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 
@@ -26,8 +27,16 @@ export default function QuestsList() {
 
     useSearchResultHeader(queryParams);
 
-    const { recommendedOpportunities, groupedOpportunities, loading, error, refetch } =
-    useSearchResults(queryParams);
+    const { 
+      recommendedOpportunities, 
+      groupedOpportunities, 
+      loading, 
+      refetch,
+      error,
+      loadMoreRef,
+      hasNextPage,
+      isLoadingMore,
+    } = useSearchResults(queryParams);
 
     const isEmpty =
     recommendedOpportunities.length === 0 && Object.keys(groupedOpportunities).length === 0;
@@ -46,6 +55,14 @@ export default function QuestsList() {
           isVertical={false}
         />
         <DateGroupedOpportunities groupedOpportunities={groupedOpportunities} />
+        {/* 無限スクロール用のローディング要素 - 常に表示 */}
+        <div ref={loadMoreRef} className="flex justify-center py-8">
+          {isLoadingMore && (
+            <div className="flex items-center space-x-2">
+              <LoadingIndicator fullScreen={false}/>
+            </div>
+          )}
+        </div>
       </main>
     </div>
     </>


### PR DESCRIPTION
- LoadingIndicatorコンポーネントをインポートし、無限スクロールのローディング状態を表示する要素を追加
- useSearchResultsフックに無限スクロールのロジックを実装し、データの取得を最適化
- 各リストコンポーネントでローディング状態を管理し、ユーザー体験を向上

動画はテストのため一件ずつ取得するようにしていますので若干挙動変かもです
実際にローカルで試していただけますと嬉しいです。

https://github.com/user-attachments/assets/831b6e36-376a-4404-a0b1-df17be91b5b2

