### PR TITLE
adminのwallet,memberにmanager権限でアクセスしたときにAdminGuardを使用してトップページへ遷移させるようにする

### DIFF
--- a/src/components/auth/AdminGuard.tsx
+++ b/src/components/auth/AdminGuard.tsx
@@ -8,10 +8,11 @@ import { GET_CURRENT_USER } from "@/graphql/account/identity/query";
 import { toast } from "sonner";
 import LoadingIndicator from "@/components/shared/LoadingIndicator";
 import { COMMUNITY_ID } from "@/lib/communities/metadata";
-import { GqlRole } from "@/types/graphql";
+import { GqlRole, GqlCurrentUserQuery } from "@/types/graphql";
 import { AuthRedirectService } from "@/lib/auth/auth-redirect-service";
 import { logger } from "@/lib/logging";
 import { AdminRoleContext } from "@/app/admin/context/AdminRoleContext";
+import { GqlMembership } from "@/types/graphql";
 
 /**
  * 管理者ガードコンポーネントのプロパティ
@@ -28,7 +29,7 @@ export const AdminGuard: React.FC<AdminGuardProps> = ({ children }) => {
   const { isAuthenticated, loading: authLoading } = useAuth();
   const router = useRouter();
 
-  const { data: userData, loading: userLoading } = useQuery(GET_CURRENT_USER, {
+  const { data: userData, loading: userLoading } = useQuery<GqlCurrentUserQuery>(GET_CURRENT_USER, {
     skip: !isAuthenticated,
   });
 
@@ -86,8 +87,8 @@ export const AdminGuard: React.FC<AdminGuardProps> = ({ children }) => {
     return null;
   }
 
-  const targetMembership = currentUser.memberships.find(
-    (m: any) => m.community?.id === COMMUNITY_ID,
+  const targetMembership = currentUser.memberships?.find(
+    (m: GqlMembership) => m.community?.id === COMMUNITY_ID,
   );
   if (!targetMembership) {
     logger.debug("No membership found for community", { component: "AdminGuard" });

--- a/src/lib/auth/auth-redirect-service.ts
+++ b/src/lib/auth/auth-redirect-service.ts
@@ -1,5 +1,5 @@
 import { AuthStateManager } from "./auth-state-manager";
-import { GqlRole } from "@/types/graphql";
+import { GqlRole, GqlUser } from "@/types/graphql";
 import { COMMUNITY_ID } from "@/lib/communities/metadata";
 import {
   encodeURIComponentWithType,
@@ -194,7 +194,7 @@ export class AuthRedirectService {
    * 管理者権限チェック用のユーザー情報を取得
    */
   public async checkAdminAccess(
-    currentUser: any,
+    currentUser: GqlUser | null | undefined,
     pathname?: string,
   ): Promise<{ hasAccess: boolean; redirectPath: string | null }> {
     if (!currentUser) {
@@ -213,7 +213,7 @@ export class AuthRedirectService {
     }
 
     // Owner専用のパスチェック
-    if (pathname && OWNER_ONLY_PATHS.some(ownerPath => pathname.startsWith(ownerPath))) {
+    if (pathname && OWNER_ONLY_PATHS.some(ownerPath => matchPaths(pathname, ownerPath))) {
       if (targetMembership.role !== GqlRole.Owner) {
         return { hasAccess: false, redirectPath: "/" };
       }


### PR DESCRIPTION
- ※テスト時の権限はMANAGERです

https://github.com/user-attachments/assets/a7ed27cc-adc2-4854-a163-fa7cef668898


https://github.com/user-attachments/assets/c3142e02-930b-4665-ad0e-d9f33161bb5c

