### PR TITLE
fix: ユーザーの名前を必ず登録されるように修正

### DIFF
--- a/src/app/sign-up/components/SignUpForm.tsx
+++ b/src/app/sign-up/components/SignUpForm.tsx
@@ -24,7 +24,7 @@ import { logger } from "@/lib/logging";
 import { currentCommunityConfig } from "@/lib/communities/metadata";
 
 const FormSchema = z.object({
-  name: z.string({ required_error: "名前を入力してください。" }),
+  name: z.string({ required_error: "名前を入力してください。" }).min(1, "名前を入力してください。"),
   prefecture: z.nativeEnum(GqlCurrentPrefecture, {
     required_error: "居住地を選択してください。",
   }),

--- a/src/app/sign-up/components/SignUpForm.tsx
+++ b/src/app/sign-up/components/SignUpForm.tsx
@@ -150,7 +150,11 @@ export function SignUpForm() {
             />
           )}
 
-          <Button type="submit" className="w-full h-12 text-base" disabled={isLoading}>
+          <Button 
+            type="submit" 
+            className="w-full h-12 text-base" 
+            disabled={isLoading || !!form.formState.errors.name}
+          >
             {isLoading ? "作成中..." : "アカウントを作成"}
           </Button>
         </form>

--- a/src/app/sign-up/components/SignUpForm.tsx
+++ b/src/app/sign-up/components/SignUpForm.tsx
@@ -27,7 +27,7 @@ const FormSchema = z.object({
   name: z
     .string({ required_error: "名前を入力してください。" })
     .trim()
-    .min(1, "名前を入力してください。"),
+    .nonempty("名前を入力してください。"),
   prefecture: z.nativeEnum(GqlCurrentPrefecture, {
     required_error: "居住地を選択してください。",
   }),

--- a/src/app/sign-up/components/SignUpForm.tsx
+++ b/src/app/sign-up/components/SignUpForm.tsx
@@ -24,7 +24,10 @@ import { logger } from "@/lib/logging";
 import { currentCommunityConfig } from "@/lib/communities/metadata";
 
 const FormSchema = z.object({
-  name: z.string({ required_error: "名前を入力してください。" }).min(1, "名前を入力してください。"),
+  name: z
+    .string({ required_error: "名前を入力してください。" })
+    .trim()
+    .min(1, "名前を入力してください。"),
   prefecture: z.nativeEnum(GqlCurrentPrefecture, {
     required_error: "居住地を選択してください。",
   }),
@@ -40,7 +43,7 @@ export function SignUpForm() {
   const form = useForm<FormValues>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
-      name: "",
+      name: undefined,
       prefecture: GqlCurrentPrefecture.Unknown,
     },
   });


### PR DESCRIPTION
close #575 

## 起きていたこと
以下の理由で、何も入力せず登録できてしまっていた
- Zodのz.string()は、文字列型であることを検証しますが、空文字列（""）も有効な文字列として扱います
-  required_errorは、フィールドがundefinedやnullの場合にのみ発動し、空文字列には適用されません
- フォームのデフォルト値がname: ""（空文字列）に設定されていたため、フィールドは技術的には「存在」していた

## 解決策
- フォームのデフォルト値を undefined した
- trim をした上で validation を挟んで、スペースや空文字だけでも登録できないようにした
- name のフォームバリデーショんエラーがあったら、アカウントを作成のボタンを disabled にした

## 確認項目
<img width="412" height="579" alt="image" src="https://github.com/user-attachments/assets/6d32fe05-cc73-4df6-8b23-b7b7a2cb9dc2" />

<img width="436" height="574" alt="image" src="https://github.com/user-attachments/assets/e621dcf1-9f01-42f5-b1f3-c0cfebf7323c" />

<img width="414" height="637" alt="image" src="https://github.com/user-attachments/assets/50332f0b-8b62-44b7-b4b6-57b490630328" />

<img width="425" height="571" alt="image" src="https://github.com/user-attachments/assets/854a4531-2861-4158-a9ff-47199dc28ae5" />
