### PR TITLE
chore: update ACTIVITY_BOOKING_CONFIG 予約受付日数のカスタム設定

### DIFF
--- a/src/config/activityBookingConfig.ts
+++ b/src/config/activityBookingConfig.ts
@@ -33,6 +33,8 @@ export const ACTIVITY_BOOKING_CONFIG: ActivityBookingConfig = {
   "cmaoctvav0029s60nr45s27bj": 1, // ［５７］道後の湯あがりに一杯！ビール工場見学
   "cmee4z2ii000bs60e41et8krq": 0, // ショート動画制作を覚えて 地域(お店)の発信力を上げよう！
   "cmb3a6qny01hcs60ncbsokqz8": 0, // ［８］藍ある暮らしに触れる
+  "cmajrynj70000s60nnm7djfbo": 2, // ［８８］地質で旅する夏、塩江ジオ川登り
+  "cmajsmuff0006s60nlsaxpnme": 1, // ［７２］みらい社小屋で出会うITの世界
   // === for development ===
   "cmdoet4xa002ds60e7f5akwcb": 0,
   "cmdoesowc002bs60eytbbxkxe": 1,


### PR DESCRIPTION
CloudRun の値は更新済みなので、このまま問題なければマージ可能

予約受け入れ日数を前日・2日前まで受付られるようにするものを2つ追加した

背景：https://github.com/Hopin-inc/civicship-portal/pull/559

こちらの関係でフロントのみ環境変数ではなく、ハードコードで対応している