### PR TITLE
予約締切時刻を1日の終わり（23:59）まで延長

### DIFF
--- a/src/app/reservation/data/presenter/opportunitySlot.ts
+++ b/src/app/reservation/data/presenter/opportunitySlot.ts
@@ -1,21 +1,24 @@
 "use client";
 import { GqlOpportunitySlot, GqlOpportunitySlotEdge } from "@/types/graphql";
-import { addDays, isAfter } from "date-fns";
+import { addDays, isAfter, endOfDay } from "date-fns";
 import { ActivitySlot, ActivitySlotGroup } from "../type/opportunitySlot";
 import { getAdvanceBookingDays, DEFAULT_ADVANCE_BOOKING_DAYS } from "@/config/activityBookingConfig";
 
 /**
  * 予約可能判定のための閾値（現在時刻から何日後まで予約可能か）を返す
+ * N日前の23:59まで予約を受け付ける
  * @param activityId アクティビティID（指定されない場合はデフォルト値を使用）
  * @returns 予約可能判定のための閾値
  */
 export const getReservationThreshold = (activityId?: string): Date => {
   const advanceBookingDays = getAdvanceBookingDays(activityId);
-  return addDays(new Date(), advanceBookingDays);
+  const thresholdDate = addDays(new Date(), advanceBookingDays);
+  return endOfDay(thresholdDate);
 };
 
 /**
  * 指定された日時が予約可能かどうかを判定する
+ * N日前の23:59まで予約を受け付ける
  * @param date 判定対象の日時
  * @param activityId アクティビティID（指定されない場合はデフォルト値を使用）
  * @returns 予約可能かどうか
@@ -23,7 +26,8 @@ export const getReservationThreshold = (activityId?: string): Date => {
 export const isDateReservable = (date: Date | string, activityId?: string): boolean => {
   const targetDate = typeof date === "string" ? new Date(date) : date;
   const advanceBookingDays = getAdvanceBookingDays(activityId);
-  const threshold = addDays(new Date(), advanceBookingDays);
+  const thresholdDate = addDays(new Date(), advanceBookingDays);
+  const threshold = endOfDay(thresholdDate);
   return isAfter(targetDate, threshold);
 };
 


### PR DESCRIPTION
## 概要

アクティビティ予約の締切時刻ロジックを改善し、より分かりやすい予約システムを実現します。

## 変更内容

### 🔧 変更点
- 予約締切時刻の計算方法を変更
- `date-fns`の`endOfDay`関数を新たに利用
- 関数のコメントを更新して新しい挙動を明記

### 📝 詳細
- **変更前**: 現在時刻からN×24時間後まで予約可能（例：8月19日 14:30 + 3日 = 8月22日 14:30まで）
- **変更後**: N日前の23:59まで予約可能（例：8月19日に予約する場合、8月22日 23:59まで）

### 🎯 期待される効果
- 予約締切のタイミングがより直感的になる
- 「N日前まで予約可能」の意味がユーザーにとって分かりやすくなる
- 締切日の終日まで予約を受け付けることでユーザビリティが向上

## 技術的な変更

```typescript
// 変更前
return addDays(new Date(), advanceBookingDays);

// 変更後  
const thresholdDate = addDays(new Date(), advanceBookingDays);
return endOfDay(thresholdDate);
```

## テスト

- [ ] 予約可能日時の判定が正しく動作することを確認
- [ ] エッジケースでの動作確認（23:59直前など）
- [ ] 既存の予約フローに影響がないことを確認

## 影響範囲

- `src/app/reservation/data/presenter/opportunitySlot.ts`のみの変更
- 既存のAPIインターフェースに変更はなし
- バックワード互換性を維持