### PR TITLE
電話認証の検証コードエラーのログレベルをERRORからWARNに変更

### DIFF
--- a/src/lib/auth/service/phone-auth-service.ts
+++ b/src/lib/auth/service/phone-auth-service.ts
@@ -171,7 +171,7 @@ export class PhoneAuthService {
         },
       };
     } catch (error) {
-      logger.error("verifyPhoneCode failed", {
+      logger.warn("verifyPhoneCode failed", {
         error: error instanceof Error ? error.message : String(error),
         component: "PhoneAuthService",
       });


### PR DESCRIPTION
## 概要
電話番号認証で無効な検証コードが入力された際のログレベルをERRORからWARNに変更しました。

## 変更理由
ユーザーが誤った検証コードを入力することは、システムエラーではなく予期される通常の動作です。そのため、ログレベルをWARNにすることで、より適切なログレベルになります。

## 変更内容
- `src/lib/auth/service/phone-auth-service.ts`の`verifyPhoneCode`メソッド内のエラーログを`logger.error`から`logger.warn`に変更

## 影響
Google Cloud Identity Toolkitのログで、`INVALID_CODE`エラーの`severity`が`ERROR`から`WARNING`に変わります。

## テスト計画
- [ ] 電話認証フローで無効な検証コードを入力
- [ ] ログが`WARN`レベルで記録されることを確認
