### PR TITLE
Apply TransactionCard pattern to /wallets/me and /admin/wallet

### DIFF
--- a/src/app/admin/wallet/data/presenter.ts
+++ b/src/app/admin/wallet/data/presenter.ts
@@ -13,4 +13,14 @@ export const getFromWalletImage = (node: GqlTransaction): string => {
     return node.fromWallet.community?.image || PLACEHOLDER_IMAGE;
   }
   return node.fromWallet?.user?.image || PLACEHOLDER_IMAGE;
-}
+};
+
+export const getCounterpartyImage = (node: GqlTransaction, perspectiveWalletId: string): string => {
+  const isOutgoing = node.fromWallet?.id === perspectiveWalletId;
+  const counterpartyWallet = isOutgoing ? node.toWallet : node.fromWallet;
+  
+  if (counterpartyWallet?.type === GqlWalletType.Community) {
+    return counterpartyWallet.community?.image || PLACEHOLDER_IMAGE;
+  }
+  return counterpartyWallet?.user?.image || PLACEHOLDER_IMAGE;
+};

--- a/src/app/admin/wallet/page.tsx
+++ b/src/app/admin/wallet/page.tsx
@@ -149,23 +149,25 @@ export default function WalletPage() {
             {t("transactions.list.communityHistoryLink")}
         </Link>
       </div>
-      <div className="space-y-2 mt-2">
+      <div className="mt-2">
         {connection.edges?.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center pt-6">
             {t("transactions.list.emptyState")}
           </p>
         ) : (
-          connection.edges?.map((edge) => {
-            const node = edge?.node;
-            if (!node) return null;
-            const transaction = presenterTransaction(node, walletId);
-            if (!transaction) return null;
-            const image = getToWalletImage(node);
-            return <TransactionItem key={transaction.id} transaction={transaction} image={image} />;
-          })
-        )}
+          <div className="divide-y-8 divide-zinc-100">
+            {connection.edges?.map((edge) => {
+              const node = edge?.node;
+              if (!node) return null;
+              const transaction = presenterTransaction(node, walletId);
+              if (!transaction) return null;
+              const image = getToWalletImage(node);
+              return <TransactionItem key={transaction.id} transaction={transaction} image={image} />;
+            })}
 
-        <div ref={loadMoreRef} className="h-10" />
+            <div ref={loadMoreRef} className="flex justify-center py-4" />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/app/transactions/components/InfiniteTransactionList.tsx
+++ b/src/app/transactions/components/InfiniteTransactionList.tsx
@@ -4,24 +4,44 @@ import { TransactionCard } from "./TransactionCard";
 import { GqlTransactionsConnection } from "@/types/graphql";
 import LoadingIndicator from "@/components/shared/LoadingIndicator";
 import { useInfiniteTransactions } from "@/hooks/transactions/useInfiniteTransactions";
-import { getServerCommunityTransactionsWithCursor } from "@/hooks/transactions/server-community-transactions";
-import { getFromWalletImage } from "@/app/admin/wallet/data/presenter";
+import { getFromWalletImage, getCounterpartyImage } from "@/app/admin/wallet/data/presenter";
 
 interface InfiniteTransactionListProps {
   initialTransactions: GqlTransactionsConnection;
+  fetchMore: (cursor: string, first: number) => Promise<GqlTransactionsConnection>;
+  perspectiveWalletId?: string;
+  showSignedAmount?: boolean;
+  showDid?: boolean;
 }
 
-export const InfiniteTransactionList = ({ initialTransactions }: InfiniteTransactionListProps) => {
+export const InfiniteTransactionList = ({
+  initialTransactions,
+  fetchMore,
+  perspectiveWalletId,
+  showSignedAmount = false,
+  showDid = false,
+}: InfiniteTransactionListProps) => {
   const { transactions, hasNextPage, loading, loadMoreRef } = useInfiniteTransactions({
     initialTransactions,
-    fetchMore: getServerCommunityTransactionsWithCursor,
+    fetchMore,
   });
 
   return (
     <div className="divide-y-8 divide-zinc-100">
       {transactions.map((transaction) => {
-        const image = getFromWalletImage(transaction);
-        return <TransactionCard key={transaction.id} transaction={transaction} image={image} />;
+        const image = perspectiveWalletId
+          ? getCounterpartyImage(transaction, perspectiveWalletId)
+          : getFromWalletImage(transaction);
+        return (
+          <TransactionCard
+            key={transaction.id}
+            transaction={transaction}
+            image={image}
+            perspectiveWalletId={perspectiveWalletId}
+            showSignedAmount={showSignedAmount}
+            showDid={showDid}
+          />
+        );
       })}
 
       {hasNextPage && (

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -3,6 +3,7 @@ import { getServerCommunityTransactions } from "@/hooks/transactions/server";
 import { InfiniteTransactionList } from "./components/InfiniteTransactionList";
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { getServerCommunityTransactionsWithCursor } from "@/hooks/transactions/server-community-transactions";
 
 export default async function TransactionsPage() {
     const t = await getTranslations();
@@ -18,7 +19,10 @@ export default async function TransactionsPage() {
                 {t("transactions.empty")}
             </p>
             ) : (
-            <InfiniteTransactionList initialTransactions={transactions} />
+            <InfiniteTransactionList 
+                initialTransactions={transactions}
+                fetchMore={getServerCommunityTransactionsWithCursor}
+            />
             )}
         </div>
         </>

--- a/src/app/wallets/features/transactions/TransactionList.tsx
+++ b/src/app/wallets/features/transactions/TransactionList.tsx
@@ -29,7 +29,7 @@ export function TransactionList() {
           {t("transactions.list.communityHistoryLink")}
         </Link>
       </div>
-      <div className="space-y-2 mt-2">
+      <div className="divide-y-8 divide-zinc-100 mt-2">
         {transactions.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center pt-6">
             {t("transactions.list.emptyState")}
@@ -40,8 +40,8 @@ export function TransactionList() {
               <TransactionItem key={transaction.id} transaction={transaction} image={transaction.image} />
             ))}
             {hasNextPage && (
-              <div ref={targetRef} className="h-10 flex items-center justify-center">
-                {isLoadingTransactions && <LoadingIndicator />}
+              <div ref={targetRef} className="flex justify-center py-4">
+                {isLoadingTransactions && <LoadingIndicator fullScreen={false} />}
               </div>
             )}
           </>


### PR DESCRIPTION
# Apply TransactionCard pattern spacing to /wallets/me and /admin/wallet

## Summary

This PR enhances the `TransactionCard` component with perspective-based display capabilities and applies the `divide-y-8 divide-zinc-100` spacing pattern to transaction lists in `/wallets/me` and `/admin/wallet` pages.

**Key changes:**
- Added perspective-based props to `TransactionCard`: `perspectiveWalletId`, `showSignedAmount`, `showDid`
- Implemented signed amount calculation with +/- display and green color for positive amounts (when `showSignedAmount=true`)
- Restored colored status label badges (green for donations/payments, blue for grants, red for refunds/returns)
- Added DID display support (shown when `showDid=true`)
- Created `getCounterpartyImage()` helper for perspective-based image selection
- Updated `InfiniteTransactionList` to accept `fetchMore` function and perspective props
- Applied `divide-y-8 divide-zinc-100` spacing to `/wallets/me` and `/admin/wallet` transaction lists
- Created `server-wallet-transactions.ts` for future wallet-specific transaction fetching

**Important note:** This PR primarily updates the spacing and enhances the `TransactionCard` component with new capabilities. The actual migration of `/wallets/me` and `/admin/wallet` to use `TransactionCard` instead of `TransactionItem` is NOT included in this PR - those pages still use the old `TransactionItem` component.

## Review & Testing Checklist for Human

- [ ] **Verify spacing on all three pages**: Check that `/transactions`, `/wallets/me`, and `/admin/wallet` all display transactions with the new `divide-y-8 divide-zinc-100` spacing (8-unit vertical dividers between items)
- [ ] **Test /transactions page**: Ensure it still shows absolute amounts (no +/- signs) and works correctly with infinite scroll
- [ ] **Verify TransactionCard enhancements work**: The new props (`perspectiveWalletId`, `showSignedAmount`, `showDid`) are added but only `/transactions` page currently uses `TransactionCard`. Future PRs will migrate the other pages.
- [ ] **Check status badges**: Confirm colored status labels (badges) appear correctly on `/transactions` page with appropriate colors (green for donations/payments, blue for grants, red for refunds)

### Test Plan
1. Navigate to `/transactions` and verify:
   - Transactions display with `divide-y-8` spacing
   - Status badges show with correct colors
   - Amounts show as absolute values (no +/- signs)
   - Infinite scroll works correctly
2. Navigate to `/wallets/me` and verify:
   - Transactions display with `divide-y-8` spacing (visual change only)
   - Existing functionality remains unchanged
3. Navigate to `/admin/wallet` and verify:
   - Transactions display with `divide-y-8` spacing (visual change only)
   - Existing functionality remains unchanged

### Notes
- The `server-wallet-transactions.ts` file was created for future use but is not currently utilized
- The `getCounterpartyImage()` helper is available but only used by `InfiniteTransactionList` when `perspectiveWalletId` is provided
- Future work: Migrate `/wallets/me` and `/admin/wallet` to use `TransactionCard` instead of `TransactionItem` to take advantage of the new perspective-based features

**Session info:**
- Requested by: Naoki Sakata (naoki.sakata@hopin.co.jp) / @709sakata
- Link to Devin run: https://app.devin.ai/sessions/f189fbb56d9e41ba925e22d786f20b15