### PR TITLE
Restore comment background color in TransactionCardBase

### DIFF
--- a/src/shared/transactions/components/TransactionCardBase.tsx
+++ b/src/shared/transactions/components/TransactionCardBase.tsx
@@ -73,7 +73,7 @@ export const TransactionCardBase = ({
         )}
 
         {comment && (
-          <p className="text-label-xs text-foreground leading-relaxed whitespace-pre-line break-words">
+          <p className="text-label-xs text-caption bg-background-hover leading-relaxed whitespace-pre-line break-words p-2 rounded-sm">
             {comment}
           </p>
         )}


### PR DESCRIPTION
# Restore comment background color in TransactionCardBase

## Summary

This PR restores the original comment styling in `TransactionCardBase` that was inadvertently changed during the TransactionCard refactoring (PR #809). Transaction comments now display with a light background color, padding, and rounded corners, matching the design before the refactoring.

**Changes:**
- Added `bg-background-hover` background color to comment text
- Changed text color from `text-foreground` to `text-caption`
- Added `p-2` padding and `rounded-sm` border radius

## Review & Testing Checklist for Human

- [ ] **Visual verification**: View transaction cards with comments on `/transactions`, `/wallets/me`, and `/admin/wallet` pages to confirm the background color displays correctly
- [ ] **Design consistency**: Verify the comment styling matches the original design (light gray background with padding and rounded corners)

### Test Plan
1. Navigate to `/transactions` page
2. Find a transaction with a comment
3. Verify the comment has a light background color (`bg-background-hover`) with padding and rounded corners
4. Repeat for `/wallets/me` and `/admin/wallet` pages

### Notes
- This is a styling-only change that restores the original `bg-background-hover`, `text-caption`, `p-2`, and `rounded-sm` classes
- The original styling was present in the TransactionCard component before the refactoring but was lost during the extraction to TransactionCardBase
- No functional changes - purely visual restoration

**Link to Devin run:** https://app.devin.ai/sessions/f189fbb56d9e41ba925e22d786f20b15  
**Requested by:** Naoki Sakata (naoki.sakata@hopin.co.jp), GitHub: @709sakata