### PR TITLE
Fix CSP violations for Firebase Analytics and Radix UI inline styles

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -58,7 +58,6 @@ export function middleware(request: NextRequest) {
 
   const styleSrcElem = [
     `'self'`,
-    `'nonce-${nonce}'`,
     "https://fonts.googleapis.com",
     `'unsafe-inline'`,
   ].join(" ");
@@ -69,9 +68,8 @@ export function middleware(request: NextRequest) {
 
   const styleSrc = [
     `'self'`,
-    `'nonce-${nonce}'`,
     "https://fonts.googleapis.com",
-    ...(isDev ? [`'unsafe-inline'`] : []),
+    `'unsafe-inline'`,
   ].join(" ");
 
   const connectSrc = [


### PR DESCRIPTION
# Firebase Analytics と Radix UI インラインスタイルの CSP 違反を修正

## 概要
本番環境で重要な機能をブロックしていた Content Security Policy (CSP) 違反を解決します。本 PR は、実際の本番環境のエラーレポートに基づいて 3 回の反復を経て修正されました。

**フェーズ 1 - Firebase と Analytics の接続:**
- Firebase Installations API と GA4 データ収集のため、`firebaseinstallations.googleapis.com`、`www.google-analytics.com`、`analytics.google.com`、`region1.google-analytics.com` を `connect-src` に追加

**フェーズ 2 - Google Maps と reCAPTCHA のサービス:**
- `apis.google.com`、`maps.googleapis.com`、`www.gstatic.com` を `script-src` と `frame-src` に追加

**フェーズ 3 - スタイルディレクティブ（CSP Level 3）:**
- `<style>` タグと style 属性を分離制御するため、`style-src-elem` と `style-src-attr` を実装
- **重要な変更**: CSP 仕様により、nonce が存在すると `'unsafe-inline'` が無視されるため、スタイルディレクティブから nonce を削除
- GTM などのサードパーティ `<style>` タグ用に `style-src-elem` に、Radix UI の動的配置用に `style-src-attr` に `'unsafe-inline'` を追加

**セキュリティトレードオフ**: スタイルディレクティブから nonce を削除し `'unsafe-inline'` を追加することで、スタイルに対する CSP 保護が弱まります。これはサードパーティとの互換性（GTM、next/font）のために必要ですが、インラインスタイルが厳密に制御されなくなることを意味します。スクリプトは nonce のみの厳格な保護を維持しています。

## レビュー＆テストチェックリスト
- [ ] **重要**: ステージング/本番環境にデプロイし、ブラウザコンソールに CSP 違反が表示されないことを確認（DevTools → Console、"Content Security Policy" でフィルタ）
- [ ] **重要**: Firebase Analytics が正しくデータを収集していることを確認（GA4 リアルタイムダッシュボードを確認）
- [ ] **重要**: すべての Radix UI コンポーネントが正しくレンダリングされることをテスト（ダイアログ、ポップオーバー、ドロップダウン、セレクト）- 配置の問題を確認
- [ ] 複数のブラウザでテスト、特に古い Safari（CSP Level 3 のサポートが異なる。style-src-attr が認識されない可能性あり）
- [ ] Google Maps を使用している場合、正しく読み込まれることを確認
- [ ] reCAPTCHA を使用した電話認証を使用している場合、動作することを確認
- [ ] セキュリティトレードオフをレビュー: サードパーティの要件を考慮して、スタイルに `'unsafe-inline'` を許可することは許容できるか？

### テスト計画
1. ステージング環境にデプロイ
2. ブラウザ DevTools → Console を開く
3. 主要なユーザーフロー（ログイン、プロフィール編集、機会予約、ウォレット管理など）を操作
4. CSP 違反エラーがないか確認
5. Firebase Analytics イベントが送信されていることを確認（Network タブ → analytics.google.com でフィルタ）
6. Radix UI を使用する UI コンポーネント（モーダル、ドロップダウン、ポップオーバーなど）をテスト
7. Chrome、Firefox、Safari（特に古いバージョン）でテスト

### 注意事項
- 本 PR は、ユーザーからの本番環境エラーレポートに基づいて 3 回の反復修正を経ています
- スタイルディレクティブの `'unsafe-inline'` は、サードパーティとの互換性（GTM、next/font、styled-jsx）のための既知のセキュリティトレードオフです
- CSP 仕様の動作: ディレクティブに nonce が存在する場合、`'unsafe-inline'` は無視されます。これが、スタイルディレクティブから nonce を削除した理由です
- デプロイ後に追加の CSP 違反が表示される場合、新しいサードパーティスクリプトやサービスが使用されていることを示している可能性があります
- 本番環境で適用する前に、Content-Security-Policy-Report-Only モードを使用して残りの違反をキャッチすることを検討してください
- スクリプトは nonce のみの厳格な保護を維持しています（スクリプトに `'unsafe-inline'` なし）

**Devin 実行へのリンク:** https://app.devin.ai/sessions/7de34541829946debea77a1f3351e159  
**依頼者:** Naoki Sakata (naoki.sakata@hopin.co.jp) / @709sakata
