### PR TITLE
Firebase 認証の iframe CSP 違反を修正

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -94,6 +94,9 @@ export function middleware(request: NextRequest) {
     `'self'`,
     "https://www.google.com",
     "https://www.gstatic.com",
+    ...(process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+      ? [`https://${process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN}`]
+      : []),
   ].join(" ");
 
   const res = NextResponse.next();


### PR DESCRIPTION
# Firebase 認証の iframe CSP 違反を修正

## Summary
Firebase Authentication の OAuth フローで使用される iframe が CSP によってブロックされていた問題を修正します。`NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` 環境変数を使用して、Firebase 認証ドメインを `frame-src` ディレクティブに動的に追加します。

**変更内容:**
- `frame-src` に Firebase 認証ドメイン（環境変数から取得）を追加
- すべての環境（dev、staging、prod）で動作するように環境変数を使用

**修正される CSP 違反:**
```
Framing 'https://co-creation-dao-prod.firebaseapp.com/' violates the following 
Content Security Policy directive: "frame-src 'self' https://www.google.com 
https://www.gstatic.com"
```

## Review & Testing Checklist for Human
- [ ] **重要**: すべての環境（dev、staging、prod）で `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` 環境変数が正しく設定されていることを確認
- [ ] **重要**: 本番環境で Firebase 認証フロー（特に OAuth）をテストし、CSP 違反が発生しないことを確認
- [ ] ブラウザコンソール（DevTools → Console）で Firebase 関連の CSP エラーが表示されないことを確認

### Test Plan
1. 本番環境にデプロイ
2. Firebase 認証を使用する機能（OAuth ログインなど）をテスト
3. ブラウザ DevTools → Console を開き、CSP 違反エラーがないことを確認
4. 認証フローが正常に完了することを確認

### Notes
- この PR は Firebase iframe の CSP 違反のみを修正します
- PR #815 に含まれていた他の CSP 変更（`unsafe-inline` など）は含まれていません
- 環境変数が設定されていない場合、Firebase 認証ドメインは追加されず、iframe がブロックされる可能性があります

**Devin 実行へのリンク:** https://app.devin.ai/sessions/7de34541829946debea77a1f3351e159  
**依頼者:** Naoki Sakata (naoki.sakata@hopin.co.jp) / @709sakata