### PR TITLE
Fix incorrect role labels in MembersList dropdown.

### DIFF
--- a/src/app/admin/members/components/MembersList.tsx
+++ b/src/app/admin/members/components/MembersList.tsx
@@ -81,8 +81,8 @@ export function MembersList({
                     disabled={currentUserRole !== "OWNER"}
                   >
                     <option value="OWNER">管理者</option>
-                    <option value="MEMBER">運用担当者</option>
-                    <option value="MANAGER">参加者</option>
+                    <option value="MANAGER">運用担当者</option>
+                    <option value="MEMBER">参加者</option>
                   </select>
                 </TableCell>
               </TableRow>


### PR DESCRIPTION
### Description

This pull request fixes the issue of incorrect role labels displayed in the MembersList dropdown.

### Changes

- Corrected the mapping of role labels to ensure accurate display in the dropdown.

### Additional notes

_No additional notes._