### PR TITLE
fix: remove empty Authorization header for session-based auth in Apollo Client

### DIFF
--- a/src/lib/apollo.ts
+++ b/src/lib/apollo.ts
@@ -38,13 +38,16 @@ const requestLink = setContext(async (operation, prevContext) => {
     }
   }
 
-  const headers = {
+  const headers: Record<string, string> = {
     ...prevContext.headers,
-    Authorization: token ? `Bearer ${token}` : "",
     "X-Auth-Mode": authMode,
-    "X-Civicship-Tenant": process.env.NEXT_PUBLIC_FIREBASE_AUTH_TENANT_ID,
-    "X-Community-Id": process.env.NEXT_PUBLIC_COMMUNITY_ID,
+    "X-Civicship-Tenant": process.env.NEXT_PUBLIC_FIREBASE_AUTH_TENANT_ID || "",
+    "X-Community-Id": process.env.NEXT_PUBLIC_COMMUNITY_ID || "",
   };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
 
   return { headers };
 });


### PR DESCRIPTION
# fix: remove empty Authorization header for session-based auth in Apollo Client

## Summary
Fixes CSR query cancellations for users authenticated via `initAuthFast` with session cookies. The issue was that Apollo Client was sending an empty `Authorization: ""` header when no Firebase token was available, which the backend was rejecting even when `X-Auth-Mode: session` was set.

**Changes:**
- Only include `Authorization` header when a valid token exists (not as empty string)
- For session-based auth, rely solely on `credentials: 'include'` (cookies) + `X-Auth-Mode: session`
- Add type safety with `Record<string, string>` and null coalescing for env vars

**Affected Queries:**
This change affects all client-side GraphQL queries, including the reported `GetMemberWallets` query in wallets/donate page.

## Review & Testing Checklist for Human

- [ ] **Critical: Test initAuthFast + CSR query flow** - Authenticate via initAuthFast (session-based), then navigate to a page with CSR queries (e.g., wallets/donate, admin pages). Verify queries execute successfully without cancellation errors. Check browser Network tab to confirm `Authorization` header is absent and `X-Auth-Mode: session` is present.

- [ ] **Critical: Verify token-based auth still works** - Authenticate normally (with Firebase ID token), verify all queries work. Check Network tab to confirm `Authorization: Bearer <token>` and `X-Auth-Mode: id_token` are present.

- [ ] **Backend behavior verification** - Confirm the backend correctly handles requests with NO Authorization header when `X-Auth-Mode: session` is set. The fix assumes empty Authorization headers were being rejected, but this should be verified against actual backend implementation.

- [ ] **Regression testing** - Test common user flows (login, profile viewing, reservations, admin operations) to ensure no authentication regressions were introduced.

- [ ] **Edge case: Auth state transitions** - Test scenarios where auth state changes mid-session (e.g., token expiration, logout, re-login) to ensure the conditional Authorization header logic handles transitions correctly.

### Notes
- This is a critical authentication path change affecting ALL GraphQL queries
- The fix is based on standard HTTP authentication practices (don't send empty auth headers)
- Cannot be fully tested locally without real authentication flows
- Risk: If backend expectations differ from assumptions, this could break authentication entirely
- Consider monitoring error rates after deployment to catch any unexpected issues

Link to Devin run: https://app.devin.ai/sessions/883bbd8340544fd99616a9d8902d644f
Requested by: Naoki Sakata (naoki.sakata@hopin.co.jp) / @709sakata