### PR TITLE
feat: トランザクションミューテーションにfirebaseUserガードを追加

### DIFF
--- a/src/app/admin/wallet/grant/GrantPageClient.tsx
+++ b/src/app/admin/wallet/grant/GrantPageClient.tsx
@@ -14,6 +14,7 @@ import { Tabs } from "./types/tabs";
 import { ErrorState } from "@/components/shared";
 import { useMemberWallets } from "@/hooks/members/useMemberWallets";
 import { useTranslations } from "next-intl";
+import { errorMessages } from "@/utils/errorMessage";
 
 const DEFAULT_TAB: Tabs = Tabs.History;
 const isValidTab = (tab: string): tab is Tabs => {
@@ -41,7 +42,7 @@ export default function GrantPageClient({ initialConnection }: GrantPageClientPr
 
   const { data, loading, error, refetch, loadMoreRef, isLoadingMore } = useMemberWallets();
 
-  const { grantPoint } = useTransactionMutations();
+  const { grantPoint, isAuthReady } = useTransactionMutations();
 
   const refetchRef = useRef<(() => void) | null>(null);
   useEffect(() => {
@@ -75,7 +76,8 @@ export default function GrantPageClient({ initialConnection }: GrantPageClientPr
         toast.success(t("adminWallet.grant.success", { amount: amount.toLocaleString() }));
         router.push("/admin/wallet?refresh=true");
       } else {
-        toast.error(t("adminWallet.grant.errorWithCode", { code: res.code }));
+        const errorMessage = errorMessages[res.code] ?? t("adminWallet.grant.errorGeneric");
+        toast.error(errorMessage);
       }
     } catch {
       toast.error(t("adminWallet.grant.errorGeneric"));
@@ -135,6 +137,7 @@ export default function GrantPageClient({ initialConnection }: GrantPageClientPr
           user={selectedUser}
           currentPoint={currentPoint}
           isLoading={isLoading}
+          isAuthReady={isAuthReady}
           onBack={() => setSelectedUser(null)}
           onSubmit={handleGrantPoint}
         />

--- a/src/app/admin/wallet/grant/components/TransferInputStep.tsx
+++ b/src/app/admin/wallet/grant/components/TransferInputStep.tsx
@@ -18,6 +18,7 @@ interface Props {
   user: GqlUser;
   currentPoint: bigint;
   isLoading: boolean;
+  isAuthReady?: boolean;
   onBack: () => void;
   onSubmit: (amount: number, comment?: string) => void;
   title?: string;
@@ -34,6 +35,7 @@ function TransferInputStep({
   user,
   currentPoint,
   isLoading,
+  isAuthReady = true,
   onBack,
   onSubmit,
   title,
@@ -159,7 +161,7 @@ function TransferInputStep({
             <Button
               onClick={() => amount && amount > 0 && amount <= currentPoint && onSubmit(amount, comment.trim() || undefined)}
               disabled={
-                !amount || amount <= 0 || amount > currentPoint || isLoading || amount > INT_LIMIT
+                !amount || amount <= 0 || amount > currentPoint || isLoading || amount > INT_LIMIT || !isAuthReady
               }
               className="w-full"
             >

--- a/src/app/admin/wallet/hooks/useTransactionMutations.ts
+++ b/src/app/admin/wallet/hooks/useTransactionMutations.ts
@@ -42,6 +42,10 @@ const checkFirebaseAuth = (): { success: false; code: GqlErrorCode } | null => {
 };
 
 export const useTransactionMutations = () => {
+  // firebaseUserの状態をsubscribeして、UIが反応的に更新されるようにする
+  const firebaseUser = useAuthStore((s) => s.state.firebaseUser);
+  const isAuthReady = !!firebaseUser;
+
   // Apollo Hooks
   const [issuePointMutation, { loading: loadingIssue }] = usePointIssueMutation();
   const [grantPointMutation, { loading: loadingGrant }] = usePointGrantMutation();
@@ -161,5 +165,6 @@ export const useTransactionMutations = () => {
     grantPoint,
     donatePoint,
     isLoading: loadingIssue || loadingGrant || loadingDonate,
+    isAuthReady,
   };
 };

--- a/src/app/wallets/features/donate/components/DonateForm.tsx
+++ b/src/app/wallets/features/donate/components/DonateForm.tsx
@@ -9,6 +9,7 @@ interface Props {
   user: GqlUser;
   currentPoint: bigint;
   isLoading: boolean;
+  isAuthReady?: boolean;
   onBack: () => void;
   onSubmit: (amount: number, comment?: string) => void;
 }
@@ -17,6 +18,7 @@ export function DonateForm({
   user,
   currentPoint,
   isLoading,
+  isAuthReady,
   onBack,
   onSubmit,
 }: Props) {
@@ -25,6 +27,7 @@ export function DonateForm({
     <TransferInputStep
       user={user}
       isLoading={isLoading}
+      isAuthReady={isAuthReady}
       onBack={onBack}
       onSubmit={onSubmit}
       currentPoint={currentPoint}

--- a/src/app/wallets/features/donate/components/DonatePointContent.tsx
+++ b/src/app/wallets/features/donate/components/DonatePointContent.tsx
@@ -28,7 +28,7 @@ export function DonatePointContent({
     refetchRef.current = refetch;
   }, [refetch]);
 
-  const { selectedUser, setSelectedUser, handleDonate, isLoading } = useDonateFlow(
+  const { selectedUser, setSelectedUser, handleDonate, isLoading, isAuthReady } = useDonateFlow(
     currentUser,
     currentPoint,
   );
@@ -52,6 +52,7 @@ export function DonatePointContent({
         <DonateForm
           user={selectedUser}
           isLoading={isLoading}
+          isAuthReady={isAuthReady}
           onBack={() => setSelectedUser(null)}
           onSubmit={handleDonate}
           currentPoint={currentPoint}

--- a/src/app/wallets/features/donate/hooks/useDonateFlow.ts
+++ b/src/app/wallets/features/donate/hooks/useDonateFlow.ts
@@ -7,12 +7,13 @@ import { useDonatePoint } from "@/app/wallets/features/donate/hooks";
 import { toast } from "react-toastify";
 import { GqlUser } from "@/types/graphql";
 import { useTranslations } from "next-intl";
+import { errorMessages } from "@/utils/errorMessage";
 
 export function useDonateFlow(currentUser?: GqlUser | null, currentPoint?: bigint) {
   const t = useTranslations();
   const router = useRouter();
   const track = useAnalytics();
-  const { donate, isLoading } = useDonatePoint();
+  const { donate, isLoading, isAuthReady } = useDonatePoint();
   const [selectedUser, setSelectedUser] = useState<GqlUser | null>(null);
 
   const handleDonate = async (amount: number, comment?: string) => {
@@ -39,7 +40,8 @@ export function useDonateFlow(currentUser?: GqlUser | null, currentPoint?: bigin
         toast.success(t("wallets.donate.toast.success", { amount: amount.toLocaleString() }));
         router.push("/wallets/me?refresh=true");
       } else {
-        toast.error(t("wallets.donate.toast.errorWithCode", { code: res.code }));
+        const errorMessage = errorMessages[res.code] ?? t("wallets.donate.toast.genericError");
+        toast.error(errorMessage);
       }
     } catch {
       toast.error(t("wallets.donate.toast.genericError"));
@@ -51,6 +53,7 @@ export function useDonateFlow(currentUser?: GqlUser | null, currentPoint?: bigin
     setSelectedUser,
     handleDonate,
     isLoading,
+    isAuthReady,
     currentPoint,
   };
 }

--- a/src/app/wallets/features/donate/hooks/useDonatePoint.ts
+++ b/src/app/wallets/features/donate/hooks/useDonatePoint.ts
@@ -13,7 +13,7 @@ interface DonatePointInput {
 
 export function useDonatePoint() {
   const [isLoading, setIsLoading] = useState(false);
-  const { donatePoint } = useTransactionMutations();
+  const { donatePoint, isAuthReady } = useTransactionMutations();
 
   const donate = async ({ toUserId, amount, comment, fromUserId }: DonatePointInput) => {
     setIsLoading(true);
@@ -35,5 +35,6 @@ export function useDonatePoint() {
   return {
     donate,
     isLoading,
+    isAuthReady,
   };
 }


### PR DESCRIPTION
## Summary

本番環境で発生していた「IsSelf authorization FAILED」エラーを防止するため、`useTransactionMutations`フックの3つのミューテーション（`issuePoint`, `grantPoint`, `donatePoint`）に`firebaseUser`の初期化チェックを追加しました。

**背景:**
CSRからのミューテーションが`firebaseUser`の初期化完了前に実行されると、`X-Auth-Mode: id_token`ヘッダーは送信されるがAuthorizationヘッダーが空の状態でリクエストが送信され、API側で匿名リクエストとして処理されて認証エラーが発生していました。

**変更内容:**
- `checkFirebaseAuth()`ヘルパー関数をモジュールレベルで追加（フック外に定義）
- 各ミューテーション実行前に`firebaseUser`の存在をチェック
- 未初期化の場合は`GqlErrorCode.Unauthenticated`を返却
- `isAuthReady`フラグを追加し、UIでボタンのdisabled制御が可能に
- エラーメッセージを`errorMessages`ユーティリティを使用して日本語化

## Updates since last revision

- `isAuthReady`フラグを`useTransactionMutations`に追加（`firebaseUser`状態をZustandでsubscribe）
- `isAuthReady`を`useDonatePoint` → `useDonateFlow` → `DonatePointContent` → `DonateForm`に伝播
- `TransferInputStep`に`isAuthReady`プロパティを追加し、`false`の場合はボタンをdisabledに
- `GrantPageClient`でも`isAuthReady`を`TransferInputStep`に渡すように変更
- エラーメッセージを`errorMessages`ユーティリティを使用して日本語化（`UNAUTHENTICATED`などの生のエラーコードではなく「ログインが必要です。」などの日本語メッセージを表示）

## Review & Testing Checklist for Human

- [ ] `firebaseUser`の初期化が完了する前にボタンがdisabledになっていることを確認（ページ読み込み直後）
- [ ] `firebaseUser`の初期化完了後にボタンがenabledになることを確認
- [ ] `/admin/wallet/grant`、`/wallets/donate`ページで実際にトランザクションが正常に実行できることを確認
- [ ] エラー発生時に日本語のエラーメッセージが表示されることを確認（例：「ログインが必要です。」）
- [ ] ブラウザのコンソールで「Transaction mutation blocked」の警告が出ていないことを確認

**推奨テスト手順:**
1. ログイン後、各トランザクションページにアクセス
2. ページ読み込み直後、送信ボタンが一瞬disabledになっていることを確認
3. ポイント助成/寄付を実行し、正常に完了することを確認
4. （オプション）認証エラーを意図的に発生させ、日本語エラーメッセージが表示されることを確認

### Notes

- API側の対応PR: 認証ルールのログ強化（authMeta追加）も別途作成済み
- Link to Devin run: https://app.devin.ai/sessions/041a745dd72548758f49f50149329640
- Requested by: Naoki Sakata (@709sakata)