### PR TITLE
fix: GET_PUBLIC_USER_SERVER_QUERYにnftInstancesを追加

### DIFF
--- a/src/graphql/account/user/server.ts
+++ b/src/graphql/account/user/server.ts
@@ -154,6 +154,19 @@ export const GET_PUBLIC_USER_SERVER_QUERY = `
         title
         images
       }
+
+      nftInstances {
+        totalCount
+        edges {
+          node {
+            id
+            instanceId
+            name
+            imageUrl
+            createdAt
+          }
+        }
+      }
     }
   }
 `;


### PR DESCRIPTION
users/[id]ページで証明書を表示するために、
公開ユーザークエリにnftInstancesフィールドを追加しました。