### PR TITLE
feat: 管理画面とユーザー画面の切り替えボタンを改善

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -4,10 +4,13 @@ import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { useRouter } from "next/navigation";
 import { useMemo } from "react";
 import useHeaderConfig from "@/hooks/useHeaderConfig";
-import { ClipboardList, Ticket, Users, Wallet } from "lucide-react";
+import { ClipboardList, Ticket, Users, Wallet, ArrowLeftRight } from "lucide-react";
 import { currentCommunityConfig, FeaturesType } from "@/lib/communities/metadata";
 import { useAdminRole } from "@/app/admin/context/AdminRoleContext";
 import { GqlRole } from "@/types/graphql";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { useTranslations } from "next-intl";
 
 const adminSettings = [
   {
@@ -41,13 +44,23 @@ const operatorSettings = [
 export default function AdminPage() {
   const router = useRouter();
   const role = useAdminRole();
+  const t = useTranslations();
 
   const headerConfig = useMemo(
     () => ({
       title: "管理画面",
-      showBackButton: true,
+      showBackButton: false,
+      showLogo: false,
+      action: (
+        <Link href="/users/me">
+          <Button variant="outline" size="sm">
+            {t("navigation.adminHeader.toUserScreen")}
+            <ArrowLeftRight className="w-4 h-4 ml-1" />
+          </Button>
+        </Link>
+      ),
     }),
-    [],
+    [t],
   );
   useHeaderConfig(headerConfig);
 

--- a/src/app/users/me/page.tsx
+++ b/src/app/users/me/page.tsx
@@ -8,9 +8,9 @@ import { GqlMembership, GqlRole } from "@/types/graphql";
 import useHeaderConfig from "@/hooks/useHeaderConfig";
 import { useMemo } from "react";
 import Link from "next/link";
-import { buttonVariants } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import { useTranslations } from "next-intl";
+import { ArrowLeftRight } from "lucide-react";
 
 export default function MyProfilePage() {
   const { gqlUser, isOwner, portfolios } = useUserProfileContext();
@@ -30,11 +30,11 @@ export default function MyProfilePage() {
   const headerConfig = useMemo(
     () => ({
       action: hasAdminRole ? (
-        <Link
-          href="/admin"
-          className={cn(buttonVariants({ variant: "text", size: "sm" }), "text-black")}
-        >
-          {t("users.profileHeader.adminButton")}
+        <Link href="/admin">
+          <Button variant="outline" size="sm">
+            {t("users.profileHeader.adminButton")}
+            <ArrowLeftRight className="w-4 h-4 ml-1" />
+          </Button>
         </Link>
       ) : undefined,
     }),

--- a/src/messages/en/navigation.json
+++ b/src/messages/en/navigation.json
@@ -6,5 +6,6 @@
   "navigation.adminBottomBar.reservations": "Reservations",
   "navigation.adminBottomBar.tickets": "Tickets",
   "navigation.adminBottomBar.credentials": "Credentials",
-  "navigation.adminBottomBar.settings": "Settings"
+  "navigation.adminBottomBar.settings": "Settings",
+  "navigation.adminHeader.toUserScreen": "User Screen"
 }

--- a/src/messages/ja/navigation.json
+++ b/src/messages/ja/navigation.json
@@ -6,5 +6,6 @@
   "navigation.adminBottomBar.reservations": "予約",
   "navigation.adminBottomBar.tickets": "チケット",
   "navigation.adminBottomBar.credentials": "証明書",
-  "navigation.adminBottomBar.settings": "設定"
+  "navigation.adminBottomBar.settings": "設定",
+  "navigation.adminHeader.toUserScreen": "ユーザー画面"
 }


### PR DESCRIPTION
- /adminページ: ヘッダーのロゴと戻るボタンを非表示化
- /adminページ: ヘッダー右に「ユーザー画面」ボタンを追加（outline、ArrowLeftRightアイコン）
- /users/meページ: 「管理画面」ボタンをoutlineスタイルに変更し、ArrowLeftRightアイコンを追加
- 国際化対応: navigation.adminHeader.toUserScreen を追加