### PR TITLE
feat: ヘッダータイトルのサイズ縮小と左寄せ対応

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -88,8 +88,21 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
         </div>
       )}
       {config.title && !config.showSearchForm && (
-        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
-          <h1 className="text-title-md truncate max-w-[80vw] text-center">{config.title}</h1>
+        <div
+          className={cn(
+            config.showLogo
+              ? "absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+              : "",
+          )}
+        >
+          <h1
+            className={cn(
+              "text-title-sm truncate max-w-[80vw]",
+              config.showLogo ? "text-center" : "text-left",
+            )}
+          >
+            {config.title}
+          </h1>
         </div>
       )}
       {config.action && (


### PR DESCRIPTION
- タイトルのフォントサイズを text-title-md から text-title-sm に変更
- ロゴ非表示時（showLogo: false）はタイトルを左寄せに変更
- ロゴ表示時は従来通り中央配置を維持