### PR TITLE
refactor: 過剰ログ是正 - 成功/通過ログをdebugに格下げ、本番ログレベルをwarnに変更

### DIFF
--- a/src/app/reservation/confirm/hooks/useReservationOpportunity.ts
+++ b/src/app/reservation/confirm/hooks/useReservationOpportunity.ts
@@ -52,7 +52,7 @@ export const useReservationOpportunity = ({
 
   useEffect(() => {
     if (error)
-      logger.info("Opportunity query error", {
+      logger.warn("Opportunity query error", {
         error: error.message || String(error),
         component: "useReservationOpportunity",
         opportunityId,

--- a/src/app/reservation/confirm/hooks/useReservationWallet.ts
+++ b/src/app/reservation/confirm/hooks/useReservationWallet.ts
@@ -25,7 +25,7 @@ export const useReservationWallet = ({
 
   useEffect(() => {
     if (walletData.error)
-      logger.info("Wallet error", {
+      logger.warn("Wallet error", {
         error: walletData.error.message || String(walletData.error),
         component: "useReservationWallet",
         userId,

--- a/src/app/search/result/hooks/useSearchResults.ts
+++ b/src/app/search/result/hooks/useSearchResults.ts
@@ -206,7 +206,7 @@ export const useSearchResults = (
 
   useEffect(() => {
     if (error) {
-      logger.info("Error fetching search results", {
+      logger.warn("Error fetching search results", {
         error: error.message || String(error),
         component: "useSearchResults",
       });

--- a/src/app/sign-up/phone-verification/hooks/useCodeVerification.ts
+++ b/src/app/sign-up/phone-verification/hooks/useCodeVerification.ts
@@ -83,7 +83,7 @@ export function useCodeVerification(
         const phoneUid = useAuthStore.getState().phoneAuth.phoneUid;
 
         if (!success || !phoneUid) {
-          logger.info("[useCodeVerification] Invalid code or missing phoneUid", {
+          logger.debug("[useCodeVerification] Invalid code or missing phoneUid", {
             component: "useCodeVerification",
             errorCategory: "user_input",
             retryable: true,

--- a/src/app/users/features/shared/mappers/presentUserProfile.ts
+++ b/src/app/users/features/shared/mappers/presentUserProfile.ts
@@ -11,7 +11,7 @@ export function presentUserProfile(
 ): UserProfileViewModel {
   const wallet = gqlUser?.wallets?.find((w) => w.community?.id === COMMUNITY_ID);
 
-  logger.info("[AUTH] presentUserProfile: wallet selection", {
+  logger.debug("[AUTH] presentUserProfile: wallet selection", {
     communityId: COMMUNITY_ID,
     walletsCount: gqlUser?.wallets?.length ?? 0,
     walletCommunities: (gqlUser?.wallets ?? []).map((w) => w.community?.id),

--- a/src/app/users/features/shared/server/fetchPrivateUserServer.ts
+++ b/src/app/users/features/shared/server/fetchPrivateUserServer.ts
@@ -14,13 +14,13 @@ export async function fetchPrivateUserServer(): Promise<GqlUser | null> {
   const hasSession = await hasServerSession();
   const cookieHeader = await getServerCookieHeader();
 
-  logger.info("[AUTH] fetchPrivateUserServer: checking session", {
+  logger.debug("[AUTH] fetchPrivateUserServer: checking session", {
     hasSession,
     component: "fetchPrivateUserServer",
   });
 
   if (!hasSession) {
-    logger.info("[AUTH] fetchPrivateUserServer: no session cookie, returning null", {
+    logger.debug("[AUTH] fetchPrivateUserServer: no session cookie, returning null", {
       component: "fetchPrivateUserServer",
     });
     return null;
@@ -34,13 +34,13 @@ export async function fetchPrivateUserServer(): Promise<GqlUser | null> {
 
     const user = res.currentUser?.user ?? null;
 
-    logger.info("[AUTH] fetchPrivateUserServer: query succeeded", {
+    logger.debug("[AUTH] fetchPrivateUserServer: query succeeded", {
       hasUser: !!user,
       userId: user?.id,
       component: "fetchPrivateUserServer",
     });
 
-    logger.info("[AUTH] fetchPrivateUserServer: wallet data snapshot", {
+    logger.debug("[AUTH] fetchPrivateUserServer: wallet data snapshot", {
       hasUser: !!user,
       walletsCount: user?.wallets?.length ?? 0,
       walletSummary: (user?.wallets ?? []).map((w) => ({

--- a/src/app/users/me/ClientLayout.tsx
+++ b/src/app/users/me/ClientLayout.tsx
@@ -29,7 +29,7 @@ export function ClientLayout({ children, ssrUser }: ClientLayoutProps) {
   const csrUser = data?.currentUser?.user ?? null;
 
   // Log the current state for debugging
-  logger.info("[AUTH] /users/me ClientLayout state", {
+  logger.debug("[AUTH] /users/me ClientLayout state", {
     hasSsrUser: !!ssrUser,
     ssrUserId: ssrUser?.id,
     loading,
@@ -41,14 +41,14 @@ export function ClientLayout({ children, ssrUser }: ClientLayoutProps) {
   });
 
   if (ssrUser) {
-    logger.info("[AUTH] /users/me ClientLayout: using ssrUser", {
+    logger.debug("[AUTH] /users/me ClientLayout: using ssrUser", {
       component: "ClientLayout",
     });
     return <>{children}</>;
   }
 
   if (loading && !csrUser) {
-    logger.info("[AUTH] /users/me ClientLayout: loading spinner", {
+    logger.debug("[AUTH] /users/me ClientLayout: loading spinner", {
       loading,
       hasCsrUser: !!csrUser,
       hasError: !!error,
@@ -59,13 +59,13 @@ export function ClientLayout({ children, ssrUser }: ClientLayoutProps) {
   }
 
   if (!csrUser) {
-    logger.info("[AUTH] /users/me ClientLayout: notFound", {
+    logger.debug("[AUTH] /users/me ClientLayout: notFound", {
       component: "ClientLayout",
     });
     return notFound();
   }
 
-  logger.info("[AUTH] /users/me ClientLayout: rendering with csrUser", {
+  logger.debug("[AUTH] /users/me ClientLayout: rendering with csrUser", {
     csrUserId: csrUser.id,
     component: "ClientLayout",
   });

--- a/src/app/users/me/layout.tsx
+++ b/src/app/users/me/layout.tsx
@@ -6,7 +6,7 @@ import { logger } from "@/lib/logging";
 export default async function MyPageLayout({ children }: { children: React.ReactNode }) {
   const gqlUser = await fetchPrivateUserServer();
 
-  logger.info("[AUTH] /users/me layout fetchPrivateUserServer result", {
+  logger.debug("[AUTH] /users/me layout fetchPrivateUserServer result", {
     hasUser: !!gqlUser,
     userId: gqlUser?.id,
     component: "MyPageLayout",
@@ -29,7 +29,7 @@ export default async function MyPageLayout({ children }: { children: React.React
     );
   }
 
-  logger.info("[AUTH] /users/me layout: no SSR user, using ClientLayout with null", {
+  logger.debug("[AUTH] /users/me layout: no SSR user, using ClientLayout with null", {
     component: "MyPageLayout",
   });
 

--- a/src/app/users/me/reverify-phone/components/ReverifyPhoneForm.tsx
+++ b/src/app/users/me/reverify-phone/components/ReverifyPhoneForm.tsx
@@ -109,7 +109,7 @@ export function ReverifyPhoneForm() {
       const storeResult = await storeTokens();
 
       if (storeResult.success) {
-        logger.info("[ReverifyPhoneForm] Phone auth token stored successfully");
+        logger.debug("[ReverifyPhoneForm] Phone auth token stored successfully");
         toast.success(t("phoneVerification.verification.completed"));
         router.push("/users/me");
       } else {

--- a/src/components/auth/RouteGuard.tsx
+++ b/src/components/auth/RouteGuard.tsx
@@ -55,7 +55,7 @@ export const RouteGuard: React.FC<RouteGuardProps> = ({ children }) => {
       currentUser,
     );
 
-    logger.info("[AUTH] RouteGuard redirect check", {
+    logger.debug("[AUTH] RouteGuard redirect check", {
       pathname,
       pathWithParams,
       authenticationState: authState.authenticationState,

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -30,7 +30,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
 
     if (!authStateManager) return;
 
-    logger.info("[AUTH] AuthProvider initialization", {
+    logger.debug("[AUTH] AuthProvider initialization", {
       hasFullAuth,
       ssrCurrentUser: !!ssrCurrentUser,
       ssrCurrentUserId: ssrCurrentUser?.id,

--- a/src/hooks/auth/actions/useStorePhoneAuthToken.ts
+++ b/src/hooks/auth/actions/useStorePhoneAuthToken.ts
@@ -57,7 +57,7 @@ export const useStorePhoneAuthToken = (userId: string | undefined) => {
       const success = result.data?.storePhoneAuthToken?.success ?? false;
 
       if (success) {
-        logger.info("[useStorePhoneAuthToken] Phone auth token stored successfully");
+        logger.debug("[useStorePhoneAuthToken] Phone auth token stored successfully");
       } else {
         logger.warn("[useStorePhoneAuthToken] Failed to store phone auth token");
       }

--- a/src/hooks/auth/sideEffects/useFirebaseAuthState.ts
+++ b/src/hooks/auth/sideEffects/useFirebaseAuthState.ts
@@ -56,7 +56,7 @@ export const useFirebaseAuthState = ({
 
           TokenManager.saveLineAuthFlag(true);
         } catch (error) {
-          logger.info("Failed to sync Firebase token", {
+          logger.warn("Failed to sync Firebase token", {
             error: error instanceof Error ? error.message : String(error),
             component: "useFirebaseAuthState",
           });

--- a/src/hooks/auth/sideEffects/useLineAuthProcessing.ts
+++ b/src/hooks/auth/sideEffects/useLineAuthProcessing.ts
@@ -36,7 +36,7 @@ export const useLineAuthProcessing = ({
 
       // SSR で user/line/phone そろってるなら、LIFF 初期化も含めて全てスキップ
       if (hasFullAuth) {
-        logger.info("SSR full auth detected; skipping all LIFF processing", {
+        logger.debug("SSR full auth detected; skipping all LIFF processing", {
           authType: "liff",
           component: "useLineAuthProcessing",
         });
@@ -49,7 +49,7 @@ export const useLineAuthProcessing = ({
         const initialized = await liffService.initialize();
 
         if (!initialized) {
-          logger.info("LIFF init failed", {
+          logger.warn("LIFF init failed", {
             authType: "liff",
             component: "useLineAuthProcessing",
           });
@@ -60,14 +60,14 @@ export const useLineAuthProcessing = ({
         if (!isLoggedIn) return;
 
         if (lineAuth.currentUser) {
-          logger.info("Firebase already authenticated, skipping signInWithLiffToken", {
+          logger.debug("Firebase already authenticated, skipping signInWithLiffToken", {
             authType: "liff",
             component: "useLineAuthProcessing",
           });
         } else {
           const success = await liffService.signInWithLiffToken();
           if (!success) {
-            logger.info("signInWithLiffToken failed", {
+            logger.warn("signInWithLiffToken failed", {
               authType: "liff",
               component: "useLineAuthProcessing",
             });
@@ -100,7 +100,7 @@ export const useLineAuthProcessing = ({
           
           // Only set user_registered if BOTH phone identity AND membership exist
           if (hasMembership) {
-            logger.info("[AUTH] useLineAuthProcessing: setting user_registered", {
+            logger.debug("[AUTH] useLineAuthProcessing: setting user_registered", {
               userId: user.id,
               hasPhoneIdentity,
               hasMembership,
@@ -114,7 +114,7 @@ export const useLineAuthProcessing = ({
             authStateManager.updateState("user_registered", "useLineAuthProcessing (phone + membership)");
             await authStateManager.handleUserRegistrationStateChange(true);
           } else {
-            logger.info("[AUTH] useLineAuthProcessing: setting phone_authenticated", {
+            logger.debug("[AUTH] useLineAuthProcessing: setting phone_authenticated", {
               userId: user.id,
               hasPhoneIdentity,
               hasMembership,
@@ -137,7 +137,7 @@ export const useLineAuthProcessing = ({
           await authStateManager.handleUserRegistrationStateChange(false);
         }
       } catch (err) {
-        logger.info("Error during LINE auth", {
+        logger.warn("Error during LINE auth", {
           authType: "liff",
           error: err instanceof Error ? err.message : String(err),
           component: "useLineAuthProcessing",

--- a/src/hooks/liff/useLiffDeepLinkHandler.ts
+++ b/src/hooks/liff/useLiffDeepLinkHandler.ts
@@ -49,7 +49,7 @@ export const useLiffDeepLinkHandler = () => {
       return;
     }
 
-    logger.info("[AUTH-LIFF] Processing LIFF deep link", {
+    logger.debug("[AUTH-LIFF] Processing LIFF deep link", {
       liffState,
       component: "useLiffDeepLinkHandler",
     });

--- a/src/hooks/useLanguageSync.ts
+++ b/src/hooks/useLanguageSync.ts
@@ -82,7 +82,7 @@ export const useLanguageSync = ({ user, loading }: UseLanguageSyncOptions) => {
     })
       .then(() => {
         localStorage.setItem(storageKey, "1");
-        logger.info("[useLanguageSync] Language synced to server", {
+        logger.debug("[useLanguageSync] Language synced to server", {
           userId: user.id,
           language: mappedLanguage,
         });

--- a/src/lib/apollo.ts
+++ b/src/lib/apollo.ts
@@ -55,7 +55,7 @@ const requestLink = setContext(async (operation, prevContext) => {
 const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) => {
   if (graphQLErrors) {
     for (const error of graphQLErrors) {
-      logger.info("GraphQL error", {
+      logger.warn("GraphQL error", {
         message: error.message,
         locations: error.locations,
         path: error.path,
@@ -82,7 +82,7 @@ const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) 
 
   if (networkError) {
     if ("statusCode" in networkError && networkError.statusCode === 401) {
-      logger.info("Network authentication error", {
+      logger.warn("Network authentication error", {
         error: networkError.message || String(networkError),
         statusCode: networkError.statusCode,
         component: "ApolloErrorLink",

--- a/src/lib/auth/core/access-policy.ts
+++ b/src/lib/auth/core/access-policy.ts
@@ -29,7 +29,7 @@ export class AccessPolicy {
   }
 
   public static canAccessRole(user: GqlUser | null | undefined, pathname: string): boolean {
-    logger.info("[AUTH] AccessPolicy.canAccessRole: start", {
+    logger.debug("[AUTH] AccessPolicy.canAccessRole: start", {
       pathname,
       userId: user?.id,
       hasMemberships: !!user?.memberships?.length,
@@ -39,7 +39,7 @@ export class AccessPolicy {
     });
 
     if (!user) {
-      logger.info("[AUTH] AccessPolicy.canAccessRole: no user", {
+      logger.debug("[AUTH] AccessPolicy.canAccessRole: no user", {
         pathname,
         result: false,
         component: "AccessPolicy",
@@ -48,7 +48,7 @@ export class AccessPolicy {
     }
 
     const membership = this.getMembership(user);
-    logger.info("[AUTH] AccessPolicy.canAccessRole: membership check", {
+    logger.debug("[AUTH] AccessPolicy.canAccessRole: membership check", {
       pathname,
       userId: user.id,
       hasMembership: !!membership,
@@ -60,7 +60,7 @@ export class AccessPolicy {
     });
 
     if (!membership) {
-      logger.info("[AUTH] AccessPolicy.canAccessRole: no membership for current community", {
+      logger.debug("[AUTH] AccessPolicy.canAccessRole: no membership for current community", {
         pathname,
         userId: user.id,
         currentCommunityId: COMMUNITY_ID,
@@ -72,7 +72,7 @@ export class AccessPolicy {
 
     if (this.isOwnerOnlyPath(pathname)) {
       const hasOwner = this.hasOwnerPrivileges(membership.role);
-      logger.info("[AUTH] AccessPolicy.canAccessRole: owner-only path", {
+      logger.debug("[AUTH] AccessPolicy.canAccessRole: owner-only path", {
         pathname,
         userId: user.id,
         role: membership.role,
@@ -84,7 +84,7 @@ export class AccessPolicy {
 
     if (this.isAdminPath(pathname)) {
       const hasManager = this.hasManagerPrivileges(membership.role);
-      logger.info("[AUTH] AccessPolicy.canAccessRole: admin path", {
+      logger.debug("[AUTH] AccessPolicy.canAccessRole: admin path", {
         pathname,
         userId: user.id,
         role: membership.role,
@@ -95,7 +95,7 @@ export class AccessPolicy {
     }
 
     // 一般ページは誰でもアクセス可能
-    logger.info("[AUTH] AccessPolicy.canAccessRole: general path allowed", {
+    logger.debug("[AUTH] AccessPolicy.canAccessRole: general path allowed", {
       pathname,
       userId: user.id,
       result: true,

--- a/src/lib/auth/core/firebase-config.ts
+++ b/src/lib/auth/core/firebase-config.ts
@@ -40,7 +40,7 @@ export const getFirebaseAnalytics = async (): Promise<Analytics | undefined> => 
     const supported = await isSupported();
     if (supported) {
       analyticsInstance = getAnalytics(defaultApp);
-      logger.info("Analytics initialized", { component: "FirebaseConfig" });
+      logger.debug("Analytics initialized", { component: "FirebaseConfig" });
     }
   }
 

--- a/src/lib/auth/init/applySsrAuthState.ts
+++ b/src/lib/auth/init/applySsrAuthState.ts
@@ -17,7 +17,7 @@ export function applySsrAuthState(
     initialState = "line_authenticated";
   }
 
-  logger.info("[AUTH] applySsrAuthState", {
+  logger.debug("[AUTH] applySsrAuthState", {
     initialState,
     ssrCurrentUser: !!ssrCurrentUser,
     ssrCurrentUserId: ssrCurrentUser?.id,

--- a/src/lib/auth/init/helper.ts
+++ b/src/lib/auth/init/helper.ts
@@ -108,7 +108,9 @@ async function createSession(idToken: string) {
     throw new Error(`Failed to create session cookie (${res.status})`);
   }
 
-  console.info("✅ Session cookie successfully created (via proxy)");
+  if (process.env.NODE_ENV !== "production") {
+    console.info("✅ Session cookie successfully created (via proxy)");
+  }
   return true;
 }
 

--- a/src/lib/auth/init/index.ts
+++ b/src/lib/auth/init/index.ts
@@ -39,7 +39,7 @@ export async function initAuth(params: InitAuthParams) {
 
   const environment = detectEnvironment();
 
-  logger.info("[AUTH] initAuth", {
+  logger.debug("[AUTH] initAuth", {
     environment,
     ssrCurrentUser: !!ssrCurrentUser,
     ssrCurrentUserId: ssrCurrentUser?.id,
@@ -107,7 +107,7 @@ async function initAuthFast({
           const firebaseUser = await initializeFirebase(liffService, environment);
           if (firebaseUser) {
             useAuthStore.getState().setState({ firebaseUser });
-            logger.info("[AUTH] initAuthFast: Firebase user hydrated for CSR", {
+            logger.debug("[AUTH] initAuthFast: Firebase user hydrated for CSR", {
               uid: firebaseUser.uid,
             });
           }

--- a/src/lib/auth/service/auth-redirect-service.ts
+++ b/src/lib/auth/service/auth-redirect-service.ts
@@ -29,7 +29,7 @@ export class AuthRedirectService {
     const basePath = pathname.split("?")[0];
     const nextParam = next ? this.generateNextParam(next) : this.generateNextParam(pathname);
 
-    logger.info("[AUTH] AuthRedirectService.getRedirectPath", {
+    logger.debug("[AUTH] AuthRedirectService.getRedirectPath", {
       pathname,
       basePath,
       authState,
@@ -39,7 +39,7 @@ export class AuthRedirectService {
     });
 
     if (authState === "loading" || authState === "authenticating") {
-      logger.info("[AUTH] AuthRedirectService: skipping (loading/authenticating)");
+      logger.debug("[AUTH] AuthRedirectService: skipping (loading/authenticating)");
       return null;
     }
 
@@ -51,7 +51,7 @@ export class AuthRedirectService {
       nextParam,
     );
     if (redirectFromLogin) {
-      logger.info("[AUTH] AuthRedirectService: redirect from handleAuthEntryFlow", {
+      logger.debug("[AUTH] AuthRedirectService: redirect from handleAuthEntryFlow", {
         redirectPath: redirectFromLogin,
       });
       return redirectFromLogin;
@@ -59,7 +59,7 @@ export class AuthRedirectService {
 
     const redirectFromUserPath = this.handleUserPath(basePath, authState, currentUser, nextParam);
     if (redirectFromUserPath) {
-      logger.info("[AUTH] AuthRedirectService: redirect from handleUserPath", {
+      logger.debug("[AUTH] AuthRedirectService: redirect from handleUserPath", {
         redirectPath: redirectFromUserPath,
       });
       return redirectFromUserPath;
@@ -67,13 +67,13 @@ export class AuthRedirectService {
 
     const redirectByRole = this.handleRoleRestriction(currentUser, basePath);
     if (redirectByRole) {
-      logger.info("[AUTH] AuthRedirectService: redirect from handleRoleRestriction", {
+      logger.debug("[AUTH] AuthRedirectService: redirect from handleRoleRestriction", {
         redirectPath: redirectByRole,
       });
       return redirectByRole;
     }
 
-    logger.info("[AUTH] AuthRedirectService: no redirect needed");
+    logger.debug("[AUTH] AuthRedirectService: no redirect needed");
     return null;
   }
 
@@ -162,7 +162,7 @@ export class AuthRedirectService {
     currentUser: GqlUser | null | undefined,
     basePath: string,
   ): RawURIComponent | null {
-    logger.info("[AUTH] handleRoleRestriction: start", {
+    logger.debug("[AUTH] handleRoleRestriction: start", {
       basePath,
       userId: currentUser?.id,
       hasMemberships: !!currentUser?.memberships?.length,
@@ -172,14 +172,14 @@ export class AuthRedirectService {
     });
 
     if (!currentUser) {
-      logger.info("[AUTH] handleRoleRestriction: no currentUser", {
+      logger.debug("[AUTH] handleRoleRestriction: no currentUser", {
         component: "AuthRedirectService",
       });
       return null;
     }
 
     const canAccess = AccessPolicy.canAccessRole(currentUser, basePath);
-    logger.info("[AUTH] handleRoleRestriction: canAccessRole result", {
+    logger.debug("[AUTH] handleRoleRestriction: canAccessRole result", {
       basePath,
       userId: currentUser.id,
       canAccess,
@@ -188,7 +188,7 @@ export class AuthRedirectService {
 
     if (!canAccess) {
       const fallbackPath = AccessPolicy.getFallbackPath(currentUser);
-      logger.info("[AUTH] handleRoleRestriction: redirecting to fallback (master logic)", {
+      logger.debug("[AUTH] handleRoleRestriction: redirecting to fallback (master logic)", {
         basePath,
         userId: currentUser.id,
         fallbackPath,
@@ -198,7 +198,7 @@ export class AuthRedirectService {
       return fallbackPath as RawURIComponent;
     }
 
-    logger.info("[AUTH] handleRoleRestriction: access allowed", {
+    logger.debug("[AUTH] handleRoleRestriction: access allowed", {
       basePath,
       userId: currentUser.id,
       component: "AuthRedirectService",

--- a/src/lib/auth/service/liff-service.ts
+++ b/src/lib/auth/service/liff-service.ts
@@ -152,7 +152,7 @@ export class LiffService {
     } else {
       const infoMessage = operation === "login" ? "LIFF login process failed" : "LIFF initialization failed";
       const errorCategory = operation === "login" ? "auth_temporary" : "initialization_error";
-      logger.info(infoMessage, {
+      logger.warn(infoMessage, {
         ...logContext,
         errorCategory,
       });
@@ -174,7 +174,7 @@ export class LiffService {
       };
     } catch (error) {
       const processedError = error instanceof Error ? error : new Error(String(error));
-      logger.info("Failed to get LIFF profile", {
+      logger.warn("Failed to get LIFF profile", {
         authType: "liff",
         error: processedError.message,
         component: "LiffService",

--- a/src/lib/auth/service/phone-auth-service.ts
+++ b/src/lib/auth/service/phone-auth-service.ts
@@ -58,7 +58,7 @@ export class PhoneAuthService {
         try {
           (window as any).grecaptcha.reset();
         } catch (e) {
-          logger.info("reCAPTCHA reset (expected)", {
+          logger.debug("reCAPTCHA reset (expected)", {
             authType: "phone",
             error: e instanceof Error ? e.message : String(e),
             component: "PhoneAuthService",
@@ -68,7 +68,7 @@ export class PhoneAuthService {
       this.recaptchaContainerElement = null;
       this.isRecaptchaRendered = false;
     } catch (e) {
-      logger.info("Error clearing reCAPTCHA", {
+      logger.debug("Error clearing reCAPTCHA", {
         authType: "phone",
         error: e instanceof Error ? e.message : String(e),
         component: "PhoneAuthService",
@@ -105,7 +105,7 @@ export class PhoneAuthService {
           }
         },
         "expired-callback": () => {
-          logger.info("[PhoneAuthService] reCAPTCHA expired");
+          logger.debug("[PhoneAuthService] reCAPTCHA expired");
           this.clearRecaptcha();
         },
       });

--- a/src/lib/logging/client/index.ts
+++ b/src/lib/logging/client/index.ts
@@ -22,6 +22,12 @@ const shouldThrottle = (message: string, level: string): boolean => {
 };
 
 const forwardLogToServer = async (level: string, message: string, meta?: Record<string, any>) => {
+  // In production, only forward warn/error logs to server
+  const isProduction = process.env.NODE_ENV === "production";
+  if (isProduction && (level === "debug" || level === "info")) {
+    return;
+  }
+
   const { authType = "general", ...restMeta } = meta ?? {};
   
   const isBrowserIssue = message.includes("IndexedDB") || 

--- a/src/lib/logging/server/index.ts
+++ b/src/lib/logging/server/index.ts
@@ -3,6 +3,7 @@ import { LoggingWinston } from "@google-cloud/logging-winston";
 import { ILogger } from "@/lib/logging/type";
 
 const isLocal = process.env.ENV === "LOCAL";
+const isProduction = process.env.NODE_ENV === "production";
 
 const severity = winston.format((log) => {
   log.severity = log.level.toUpperCase();
@@ -47,7 +48,7 @@ if (isLocal) {
 }
 
 const winstonLogger = winston.createLogger({
-  level: process.env.NEXT_PUBLIC_LOG_LEVEL || "debug",
+  level: isProduction ? "warn" : (process.env.NEXT_PUBLIC_LOG_LEVEL || "debug"),
   format: winston.format.combine(...format),
   transports,
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -35,7 +35,9 @@ export function middleware(request: NextRequest) {
         }
 
         if (pathname === route || pathname.startsWith(`${route}/`)) {
-          console.log(`Redirecting from disabled feature path: ${pathname} to ${rootPath}`);
+          if (isDev) {
+            console.log(`Redirecting from disabled feature path: ${pathname} to ${rootPath}`);
+          }
           return NextResponse.redirect(new URL(rootPath, request.url));
         }
       }


### PR DESCRIPTION
# refactor: 過剰ログ是正 - 成功/通過ログをdebugに格下げ、本番ログレベルをwarnに変更

## Summary

本番環境での過剰なログ出力を是正するため、ログレベル制御を追加しました。ログは削除せず、本番環境でのみガードする「将来の武器として残す」方針を採用しています。

**主な変更点:**

1. **サーバーログレベル変更** (`src/lib/logging/server/index.ts`): 本番環境で `warn` 以上のみ出力するよう変更

2. **クライアントloggerフィルタ追加** (`src/lib/logging/client/index.ts`): 本番環境では debug/info をサーバーに送信しないよう変更

3. **console.log/info のガード**: middleware.ts と helper.ts で開発環境限定に変更

4. **成功/通過ログを debug に格下げ** (~25ファイル): 認証フロー、ユーザー取得、状態遷移などの正常系ログを `logger.debug` に変更

5. **エラー/異常ログを warn に昇格**: GraphQL エラー、ネットワークエラー、LIFF 失敗、クエリエラーなどを `logger.warn` に変更

## Review & Testing Checklist for Human

- [ ] **ログ分類の妥当性確認**: debug に格下げされたログが本当に本番で不要か確認（特に認証フロー関連: `useLineAuthProcessing.ts`, `auth-redirect-service.ts`）
- [ ] **warn に昇格されたログの確認**: エラー系ログが適切に warn になっているか確認（`apollo.ts`, `liff-service.ts`）
- [ ] **本番ビルドでのログ出力テスト**: `NODE_ENV=production` でビルドし、warn/error のみ出力されることを確認
- [ ] **クライアントログのフィルタ動作確認**: ブラウザコンソールで debug/info が `/api/client-log` に送信されないことを確認

**推奨テスト手順:**
1. `pnpm build` で本番ビルド作成
2. `pnpm start` で起動
3. 認証フローを実行し、Cloud Logging で warn/error のみ出力されることを確認
4. 開発環境 (`pnpm dev`) で debug ログが出力されることを確認

### Notes

- 関連PR: [civicship-api#598](https://github.com/Hopin-inc/civicship-api/pull/598) (API側の同様の是正)
- Link to Devin run: https://app.devin.ai/sessions/58441cc330d341869a7b714e91c8d5fe
- Requested by: Naoki Sakata (naoki.sakata@hopin.co.jp) @709sakata