### PR TITLE
fix: 本番workflowにNODE_ENV=production追加、スケーリング設定追加

### DIFF
--- a/.github/workflows/deploy-to-cloud-run-prod.yml
+++ b/.github/workflows/deploy-to-cloud-run-prod.yml
@@ -111,3 +111,8 @@ jobs:
           service: ${{ env.APPLICATION_NAME }}-${{ matrix.community }}
           image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}-${{ matrix.community }}:latest
           region: ${{ env.GCP_REGION }}
+          env_vars: |
+            NODE_ENV=production
+          flags: >
+            --min-instances=0
+            --max-instances=10


### PR DESCRIPTION
## Summary

本番環境のCloud Run deploymentワークフローに環境変数とスケーリング設定を追加します。

**変更内容:**
- `NODE_ENV=production` 環境変数を追加 → ログレベル制御（warn以上のみ出力）が正しく動作するために必要
- スケーリング設定を追加: `--min-instances=0`, `--max-instances=10`（dev環境と同じ設定）

この変更は、先にマージされた過剰ログ是正PR (#863) のログレベル制御を本番環境で有効にするために必要です。

## Review & Testing Checklist for Human

- [ ] **スケーリング設定の妥当性確認**: `min-instances=0` はコールドスタートが発生する可能性があります。本番環境でこれが許容されるか確認してください
- [ ] **NODE_ENV=production の確認**: この設定により `src/lib/logging/server/index.ts` のログレベルが `warn` になります
- [ ] **デプロイ後の動作確認**: masterにマージ後、Cloud Loggingでwarn/errorのみ出力されることを確認

**テスト手順:**
1. developにマージ後、develop → master PRを作成
2. masterにマージしてデプロイを実行
3. Cloud Runコンソールで環境変数 `NODE_ENV=production` が設定されていることを確認
4. Cloud Loggingでログレベルがwarn以上のみになっていることを確認

### Notes

- 関連PR: #863 (過剰ログ是正)
- 関連PR (API): https://github.com/Hopin-inc/civicship-api/pull/600
- Link to Devin run: https://app.devin.ai/sessions/58441cc330d341869a7b714e91c8d5fe
- Requested by: Naoki Sakata (naoki.sakata@hopin.co.jp) @709sakata