### PR TITLE
refactor: LIFF環境判定を集中管理するuseAuthEnvironmentフックを追加

### DIFF
--- a/src/app/opportunities/[id]/components/OpportunityDetailsFooter.tsx
+++ b/src/app/opportunities/[id]/components/OpportunityDetailsFooter.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { COMMUNITY_ID } from "@/lib/communities/metadata";
-import { AuthEnvironment, detectEnvironment } from "@/lib/auth/core/environment-detector";
+import { useAuthEnvironment } from "@/hooks/useAuthEnvironment";
 import { cn } from "@/lib/utils";
 
 export type DisableReasonType = "noSlots" | "reservationClosed" | "externalBooking";
@@ -37,8 +37,7 @@ export const OpportunityDetailsFooter: React.FC<OpportunityDetailsFooterProps> =
     community_id: communityId ?? COMMUNITY_ID,
   });
 
-  const env = detectEnvironment();
-  const isLiff = env === AuthEnvironment.LIFF;
+  const { isLiffClient } = useAuthEnvironment();
 
   const renderActionElement = () => {
     if (disableReason && disableReason in DISABLE_MESSAGES) {
@@ -63,7 +62,7 @@ export const OpportunityDetailsFooter: React.FC<OpportunityDetailsFooterProps> =
       <div
         className={cn(
           "max-w-mobile-l mx-auto px-4 flex items-center justify-between w-full",
-          isLiff ? "h-28" : "h-20",
+          isLiffClient ? "h-28" : "h-20",
         )}
       >
         <div>

--- a/src/app/sign-up/phone-verification/page.tsx
+++ b/src/app/sign-up/phone-verification/page.tsx
@@ -3,27 +3,27 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef } from "react";
 import { PhoneVerificationForm } from "./components/PhoneVerificationForm";
-import { AuthEnvironment, detectEnvironment } from "@/lib/auth/core/environment-detector";
+import { useAuthEnvironment } from "@/hooks/useAuthEnvironment";
 
 export default function PhoneVerificationPage() {
   const router = useRouter();
   const hasRedirected = useRef(false);
+  const { isLineBrowser } = useAuthEnvironment();
 
   const searchParams = useSearchParams();
   const nextParam = searchParams.get("next") ?? searchParams.get("liff.state");
 
   useEffect(() => {
     if (hasRedirected.current) return;
-    const env = detectEnvironment();
 
-    if (env === AuthEnvironment.LINE_BROWSER) {
+    if (isLineBrowser) {
       hasRedirected.current = true;
       const redirectUrl = nextParam
         ? `/sign-up/phone-verification/line-browser?next=${nextParam}`
         : "/sign-up/phone-verification/line-browser";
       router.replace(redirectUrl);
     }
-  }, [nextParam, router]);
+  }, [nextParam, router, isLineBrowser]);
 
   return (
     <div className="container mx-auto py-8">

--- a/src/components/layout/BottomBar.tsx
+++ b/src/components/layout/BottomBar.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import { cn } from "@/lib/utils";
 import { matchPaths } from "@/utils/path";
 import { useScrollDirection } from "@/hooks/useScrollDirection";
-import { AuthEnvironment, detectEnvironment } from "@/lib/auth/core/environment-detector";
+import { useAuthEnvironment } from "@/hooks/useAuthEnvironment";
 import { currentCommunityConfig } from "@/lib/communities/metadata";
 import { useTranslations } from "next-intl";
 
@@ -21,8 +21,7 @@ const BottomBar: React.FC<HeaderProps> = ({ className }) => {
   const searchParams = useSearchParams();
   const placeId = searchParams.get("placeId");
 
-  const env = detectEnvironment();
-  const isLiff = env === AuthEnvironment.LIFF;
+  const { isLiffClient } = useAuthEnvironment();
 
   const { isVisible } = useScrollDirection({ threshold: 20 });
 
@@ -61,7 +60,7 @@ const BottomBar: React.FC<HeaderProps> = ({ className }) => {
       className={cn(
         className,
         "fixed bottom-0 left-0 w-full bg-background border-t border-input z-40 transition-transform duration-300",
-        !isLiff ? "py-4" : "pt-4 pb-10",
+        !isLiffClient ? "py-4" : "pt-4 pb-10",
         !isVisible && "transform translate-y-full",
       )}
     >

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,6 +8,7 @@ import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useHeader } from "@/components/providers/HeaderProvider";
 import { useHierarchicalNavigation } from "@/hooks/useHierarchicalNavigation";
+import { useAuthEnvironment } from "@/hooks/useAuthEnvironment";
 import { cn } from "@/lib/utils";
 import SearchBox from "@/app/search/components/SearchBox";
 import { currentCommunityConfig } from "@/lib/communities/metadata";
@@ -17,8 +18,9 @@ interface HeaderProps {
 }
 
 const Header: React.FC<HeaderProps> = ({ className }) => {
-  const { config, isLiffEnvironment } = useHeader();
+  const { config } = useHeader();
   const { navigateBack } = useHierarchicalNavigation();
+  const { isInLine } = useAuthEnvironment();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -39,11 +41,11 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
     return null;
   }
 
-  // LIFF環境では戻るボタンを非表示にする
+  // LIFF/LINEブラウザ環境では戻るボタンを非表示にする
   const shouldShowBackButton =
     config.showBackButton &&
     pathname !== "/" &&
-    !isLiffEnvironment;
+    !isInLine;
 
   // レイアウト意図ベースの判定（LIFF環境でも戻るボタンの意図がある場合は左スロットとして扱う）
   const hasLeftSlotForLayout = config.showLogo || (config.showBackButton && pathname !== "/");

--- a/src/components/navigation/SwipeBackNavigation.tsx
+++ b/src/components/navigation/SwipeBackNavigation.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { useHierarchicalNavigation } from "@/hooks/useHierarchicalNavigation";
-import { detectEnvironment, AuthEnvironment } from "@/lib/auth/core/environment-detector";
+import { useAuthEnvironment } from "@/hooks/useAuthEnvironment";
 
 // スワイプジェスチャーの判定定数
 const SWIPE_START_AREA_WIDTH = 50; // 画面左端からの有効エリア (px)
@@ -19,16 +19,15 @@ interface SwipeBackNavigationProps {
  */
 export function SwipeBackNavigation({ children }: SwipeBackNavigationProps) {
   const { navigateBack } = useHierarchicalNavigation();
+  const { isLiffClient } = useAuthEnvironment();
   const touchStartX = useRef(0);
   const touchStartY = useRef(0);
   const touchId = useRef<number | null>(null);
   const isSwipeGesture = useRef(false);
 
   useEffect(() => {
-    const env = detectEnvironment();
-
     // LIFF環境でのみ有効化
-    if (env !== AuthEnvironment.LIFF) return;
+    if (!isLiffClient) return;
 
     const cancelSwipe = () => {
       isSwipeGesture.current = false;
@@ -97,7 +96,7 @@ export function SwipeBackNavigation({ children }: SwipeBackNavigationProps) {
       document.removeEventListener("touchmove", handleTouchMove);
       document.removeEventListener("touchend", handleTouchEnd);
     };
-  }, [navigateBack]);
+  }, [navigateBack, isLiffClient]);
 
   return <>{children}</>;
 }

--- a/src/components/providers/HeaderProvider.tsx
+++ b/src/components/providers/HeaderProvider.tsx
@@ -2,7 +2,6 @@
 
 import React, { ReactNode, useState, useEffect, createContext, useContext, useCallback, useMemo } from "react";
 import { usePathname } from "next/navigation";
-import { AuthEnvironment, detectEnvironment } from "@/lib/auth/core/environment-detector";
 
 export interface HeaderConfig {
   title?: string;
@@ -30,7 +29,6 @@ export type HeaderContextState = {
   resetConfig: () => void;
   lastVisitedUrls: Record<string, string>;
   addToHistory: (pageType: string, url: string) => void;
-  isLiffEnvironment: boolean;
 };
 
 const defaultConfig: HeaderConfig = {
@@ -50,7 +48,6 @@ export const HeaderContext = createContext<HeaderContextState>({
   resetConfig: () => {},
   lastVisitedUrls: {},
   addToHistory: () => {},
-  isLiffEnvironment: false,
 });
 
 export const useHeader = () => {
@@ -73,12 +70,6 @@ const HeaderProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [config, setConfig] = useState<HeaderConfig>(defaultConfig);
   const [lastVisitedUrls, setLastVisitedUrls] = useState<Record<string, string>>({});
   const pathname = usePathname();
-
-  // LIFF環境かどうかを一度だけ判定して保持
-  const isLiffEnvironment = useMemo(() => {
-    const env = detectEnvironment();
-    return env === AuthEnvironment.LIFF || env === AuthEnvironment.LINE_BROWSER;
-  }, []);
 
   const updateConfig = useCallback((newConfig: Partial<HeaderConfig>) => {
     setConfig((prevConfig: HeaderConfig) => ({
@@ -134,8 +125,7 @@ const HeaderProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
     resetConfig, 
     lastVisitedUrls,
     addToHistory,
-    isLiffEnvironment,
-  }), [config, updateConfig, resetConfig, lastVisitedUrls, addToHistory, isLiffEnvironment]);
+  }), [config, updateConfig, resetConfig, lastVisitedUrls, addToHistory]);
 
   return (
     <HeaderContext.Provider value={contextValue}>

--- a/src/hooks/useAuthEnvironment.ts
+++ b/src/hooks/useAuthEnvironment.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useAuthStore } from "@/lib/auth/core/auth-store";
+import { AuthEnvironment } from "@/lib/auth/core/environment-detector";
+
+/**
+ * LIFF環境判定を提供するフック
+ * auth-storeのenvironmentを単一の真実の源として使用
+ *
+ * @returns {Object} 環境判定結果
+ * - environment: AuthEnvironment enum値
+ * - isLiffClient: LIFFアプリ内のみ（SwipeBackNavigation等）
+ * - isLineBrowser: LINEブラウザのみ（phone-verification等）
+ * - isInLine: LIFF + LINEブラウザ両方（Header戻るボタン非表示、BottomBarパディング等）
+ */
+export const useAuthEnvironment = () => {
+  const environment = useAuthStore((s) => s.state.environment);
+
+  return {
+    environment,
+    isLiffClient: environment === AuthEnvironment.LIFF,
+    isLineBrowser: environment === AuthEnvironment.LINE_BROWSER,
+    isInLine: environment === AuthEnvironment.LIFF || environment === AuthEnvironment.LINE_BROWSER,
+  };
+};
+
+/**
+ * 非Reactコード用のヘルパー関数
+ * Zustandストアから直接環境を取得
+ */
+export const getAuthEnvironment = () => {
+  return useAuthStore.getState().state.environment;
+};


### PR DESCRIPTION
## Summary

LIFF環境でHeaderの戻るボタンが非表示になる際、タイトルが意図せず左寄せになる問題と、`redirectTo`プロパティの型エラー(S2339)を修正しました。

さらに、LIFF環境判定が複数箇所で重複して呼び出されていた問題を解決するため、`useAuthEnvironment`フックを新規作成し、環境判定を集中管理するようにリファクタリングしました。

### 変更内容

1. **`useAuthEnvironment`フックを新規作成**
   - `auth-store`の`environment`を単一の真実の源として使用
   - 3つの派生フラグを提供:
     - `isLiffClient`: LIFFアプリ内のみ（SwipeBackNavigation等）
     - `isLineBrowser`: LINEブラウザのみ（phone-verification等）
     - `isInLine`: LIFF + LINEブラウザ両方（Header戻るボタン非表示、BottomBarパディング等）

2. **タイトル中央寄せロジックの改善**
   - 「実際の表示」ではなく「レイアウト意図」ベースで判定するように変更
   - `shouldCenterTitle = hasLeftSlotForLayout || !hasRightSlot`

3. **未使用の`redirectTo`参照を削除**

4. **各コンポーネントを`useAuthEnvironment`フックに移行**
   - `Header.tsx` → `isInLine`を使用
   - `BottomBar.tsx` → `isLiffClient`を使用
   - `OpportunityDetailsFooter.tsx` → `isLiffClient`を使用
   - `SwipeBackNavigation.tsx` → `isLiffClient`を使用
   - `phone-verification/page.tsx` → `isLineBrowser`を使用
   - `HeaderProvider`から`isLiffEnvironment`を削除

## Review & Testing Checklist for Human

- [ ] **LIFF環境でのタイトル表示確認**: LIFF環境で`showBackButton: true`かつ`action`なしの画面でタイトルが中央寄せになることを確認
- [ ] **BottomBarのパディング確認**: LIFF環境で`BottomBar`の下部パディングが正しく適用されていることを確認
- [ ] **SwipeBackNavigation動作確認**: LIFF環境でのみスワイプバックが有効になっていることを確認
- [ ] **LINEブラウザでのphone-verification確認**: LINEブラウザで`/sign-up/phone-verification`にアクセスした際、`/line-browser`にリダイレクトされることを確認
- [ ] **通常ブラウザでの動作確認**: 通常ブラウザで戻るボタンが正常に表示・動作することを確認

### テスト手順
1. LIFFアプリとしてアクセスし、タイトルのみ表示されるページでタイトルが中央寄せになっていることを確認
2. LIFF環境で画面左端からスワイプして戻る機能が動作することを確認
3. 通常ブラウザで同じページにアクセスし、戻るボタンが表示されスワイプバックが無効であることを確認
4. LINEブラウザで電話認証ページにアクセスし、正しくリダイレクトされることを確認

### Notes
- Link to Devin run: https://app.devin.ai/sessions/93c8b5ef1fd84d508560605829e27eff
- Requested by: Naoki Sakata (@709sakata)