### PR TITLE
feat: add vertical layout option for InfoCard component

### DIFF
--- a/src/app/transactions/[id]/page.tsx
+++ b/src/app/transactions/[id]/page.tsx
@@ -65,16 +65,16 @@ export default function TransactionDetailPage({
         label: t("transactions.detail.pointAmount"),
         value: `${detail.pointAmount.toLocaleString()}pt`,
       },
-            ...(detail.comment
-              ? [
-                  {
-                    label: t("transactions.detail.comment"),
-                    value: detail.comment,
-                    showTruncate: false,
-                    valueAlign: 'left' as const,
-                  },
-                ]
-              : []),
+                        ...(detail.comment
+                          ? [
+                              {
+                                label: t("transactions.detail.comment"),
+                                value: detail.comment,
+                                showTruncate: false,
+                                layout: 'vertical' as const,
+                              },
+                            ]
+                          : []),
     ];
 
         return (

--- a/src/components/shared/InfoCard.tsx
+++ b/src/components/shared/InfoCard.tsx
@@ -86,7 +86,8 @@ export const InfoCard = ({
   truncatePattern,
   truncateHead,
   truncateTail,
-  valueAlign = 'right'
+  valueAlign = 'right',
+  layout = 'horizontal'
 }: InfoCardProps) => {
   if (!label) {
     console.warn('InfoCard: label is required');
@@ -95,18 +96,33 @@ export const InfoCard = ({
 
   const hasSecondaryContent = secondaryValue || warningText;
   
-  let displayValue = value;
-  if (showTruncate && value) {
-    if (truncatePattern === 'middle' && truncateHead !== undefined && truncateTail !== undefined) {
-      displayValue = shortenMiddle(value, truncateHead, truncateTail);
-    } else {
-      displayValue = truncateText(value, 15, truncatePattern);
+    let displayValue = value;
+    if (showTruncate && value) {
+      if (truncatePattern === 'middle' && truncateHead !== undefined && truncateTail !== undefined) {
+        displayValue = shortenMiddle(value, truncateHead, truncateTail);
+      } else {
+        displayValue = truncateText(value, 15, truncatePattern);
+      }
     }
-  }
 
-    return (
-      <Card className="rounded-2xl border border-gray-200 bg-card shadow-none">
-        <CardHeader className="flex flex-row items-center gap-4 py-4 px-6">
+    if (layout === 'vertical') {
+      return (
+        <Card className="rounded-2xl border border-gray-200 bg-card shadow-none">
+          <CardHeader className="flex flex-col gap-1 py-4 px-6">
+            <div className="text-gray-400 text-xs">
+              {label}
+            </div>
+            <div className="text-sm text-black font-bold whitespace-pre-wrap break-words text-left">
+              {displayValue?.length === 0 ? "データが存在しません" : displayValue}
+            </div>
+          </CardHeader>
+        </Card>
+      );
+    }
+
+      return (
+        <Card className="rounded-2xl border border-gray-200 bg-card shadow-none">
+          <CardHeader className="flex flex-row items-center gap-4 py-4 px-6">
           <div className="text-gray-400 text-xs whitespace-pre-wrap shrink-0">
             {label}
           </div>
@@ -155,4 +171,4 @@ export const InfoCard = ({
       </CardHeader>
     </Card>
   );
-};                                
+};                                        

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,4 +36,5 @@ export interface InfoCardProps {
   truncateHead?: number;
   truncateTail?: number;
   valueAlign?: 'left' | 'right';
+  layout?: 'horizontal' | 'vertical';
 }


### PR DESCRIPTION
## Summary
Adds a `layout` prop to the InfoCard component to support vertical layout (label on top, value below) in addition to the existing horizontal layout. This is used for the comment field on the transaction detail page to improve readability of long comments.

**Changes:**
- Added `layout?: 'horizontal' | 'vertical'` prop to `InfoCardProps` (default: `'horizontal'`)
- Implemented vertical layout rendering in InfoCard with label above and left-aligned value below
- Applied vertical layout to comment InfoCard in `/transactions/[id]` page

## Review & Testing Checklist for Human
- [ ] **Verify comment display on transaction detail page** - Navigate to `/transactions/[id]` with a transaction that has a comment and confirm the comment shows in vertical layout (label on top, value below, left-aligned)
- [ ] **Test with long comments** - Verify that long comments wrap properly with `whitespace-pre-wrap` and `break-words`
- [ ] **Check other InfoCard usages** - Verify that InfoCard on other pages (`/nfts/[id]`, `/admin/wallet/grant`, `/credentials/[id]`) still displays correctly with horizontal layout

**Recommended test plan:**
1. Find or create a transaction with a comment
2. Navigate to `/transactions/[id]` and verify the comment field has vertical layout
3. Test with a very long comment to ensure proper text wrapping
4. Spot-check other pages using InfoCard to confirm no regression

### Notes
- The vertical layout implementation is intentionally simplified and doesn't include ActionButtons, ExternalLinkButton, or secondaryValue handling since the comment use case doesn't need these features
- There are some indentation inconsistencies in the diff that don't affect functionality

Link to Devin run: https://app.devin.ai/sessions/c528ff4a6a4843609d7977df4797e541
Requested by: Naoki Sakata (@709sakata)