### PR TITLE
feat: Restore /places feature and enable for neo88 community

### DIFF
--- a/src/app/places/[id]/components/PlaceAddress.tsx
+++ b/src/app/places/[id]/components/PlaceAddress.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { IPlaceDetail } from "@/app/places/data/type";
+import AddressMap from "@/components/shared/AddressMap";
+
+const PlaceAddress = ({ detail }: { detail: IPlaceDetail }) => {
+  return (
+    <div className="px-4 pt-6 pb-8 max-w-mobile-l mx-auto space-y-4">
+      <h3 className="text-display-sm">主な拠点</h3>
+      <div>
+        <p className="text-body-md font-bold">{detail.name}</p>
+        <p className="text-body-sm text-caption mb-2">{detail.address}</p>
+        <AddressMap address={detail.address} markerTitle={detail.name} height={250} latitude={detail.latitude} longitude={detail.longitude} placeId={detail.id}/>
+      </div>
+    </div>
+  );
+};
+
+export default PlaceAddress;

--- a/src/app/places/[id]/components/PlaceFeaturedArticle.tsx
+++ b/src/app/places/[id]/components/PlaceFeaturedArticle.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import React from "react";
+import { TArticleWithAuthor } from "@/app/articles/data/type";
+import ArticleCard from "@/app/articles/components/Card";
+
+interface PlaceFeaturedArticleProps {
+  articles: TArticleWithAuthor[] | null;
+}
+
+const PlaceFeaturedArticle: React.FC<PlaceFeaturedArticleProps> = ({ articles }) => {
+  if (!articles) return null;
+
+  return (
+    <div className="px-4 pt-6 pb-8 max-w-mobile-l mx-auto space-y-4">
+      <h2 className="text-display-sm mb-4">関連記事</h2>
+      <div className="grid grid-cols-1 gap-6">
+        {articles.map((article) => (
+          <ArticleCard key={article.id} article={article} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PlaceFeaturedArticle;

--- a/src/app/places/[id]/components/PlaceHeader.tsx
+++ b/src/app/places/[id]/components/PlaceHeader.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React from 'react';
+import { MapPin, Users } from 'lucide-react';
+
+interface PlaceHeaderProps {
+  address: string;
+  participantCount: number;
+  name: string;
+  headline: string;
+  bio?: string;
+}
+
+const PlaceHeader: React.FC<PlaceHeaderProps> = ({
+  address,
+  participantCount,
+  name,
+  headline,
+  bio
+}) => {
+  return (
+    <header className="fixed top-0 left-0 right-0 z-50 bg-background border-b max-w-mobile-l mx-auto w-full h-16 flex flex-col justify-center px-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-1">
+          <MapPin className="h-4 w-4 text-muted-foreground" />
+          <span className="text-foreground">{address}</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <Users className="h-4 w-4 text-muted-foreground" />
+          <span className="text-foreground">
+            {participantCount}人
+          </span>
+        </div>
+      </div>
+
+      <h1 className="text-lg font-bold text-center truncate mb-1">{name}</h1>
+      <h2 className="text-base text-center mb-1">{headline}</h2>
+      {bio && <p className="text-gray-600 mb-6">{bio}</p>}
+    </header>
+  );
+};
+
+export default PlaceHeader;

--- a/src/app/places/[id]/components/PlaceImageSlider.tsx
+++ b/src/app/places/[id]/components/PlaceImageSlider.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import React from 'react';
+import { motion, AnimatePresence } from "framer-motion";
+import { Button } from '@/components/ui/button';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import Image from 'next/image';
+
+interface PlaceImageSliderProps {
+  images: Array<{url: string; alt: string}>;
+  currentIndex: number;
+  onNext: () => void;
+  onPrev: () => void;
+  onSelectIndex?: (index: number) => void;
+}
+
+const PlaceImageSlider: React.FC<PlaceImageSliderProps> = ({
+  images,
+  currentIndex,
+  onNext,
+  onPrev,
+  onSelectIndex
+}) => {
+  if (!images.length) return null;
+
+  return (
+    <div className="relative mx-auto w-full h-[480px]">
+      <AnimatePresence initial={false}>
+        <motion.div
+          key={currentIndex}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.5 }}
+          className="absolute inset-0"
+        >
+          <Image
+            src={images[currentIndex]?.url || "/images/place-detail.jpg"}
+            alt={images[currentIndex]?.alt || `スライド ${currentIndex + 1}`}
+            className="w-full h-full object-cover rounded-lg"
+            fill
+            sizes="(max-width: 768px) 100vw, 50vw"
+          />
+        </motion.div>
+      </AnimatePresence>
+
+      {images.length > 1 && (
+        <>
+          <Button
+            variant="secondary"
+            size="icon"
+            onClick={onPrev}
+            className="absolute left-4 top-1/2 transform -translate-y-1/2 bg-foreground/50 text-background p-2 rounded-full hover:bg-foreground/70 transition-colors"
+          >
+            <ChevronLeft className="h-6 w-6" />
+          </Button>
+          <Button
+            variant="secondary"
+            size="icon"
+            onClick={onNext}
+            className="absolute right-4 top-1/2 transform -translate-y-1/2 bg-foreground/50 text-background p-2 rounded-full hover:bg-foreground/70 transition-colors"
+          >
+            <ChevronRight className="h-6 w-6" />
+          </Button>
+
+          {/* Dots Indicator */}
+          <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 flex space-x-2">
+            {images.map((_, index) => (
+              <Button
+                key={index}
+                onClick={() => onSelectIndex && onSelectIndex(index)}
+                variant="link"
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default PlaceImageSlider;

--- a/src/app/places/[id]/components/PlaceOpportunities.tsx
+++ b/src/app/places/[id]/components/PlaceOpportunities.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from "react";
+import { ActivityCard } from "@/components/domains/opportunities/types";
+import OpportunityVerticalCard from "@/components/domains/opportunities/components/OpportunityVerticalCard";
+import { formatOpportunities } from "@/components/domains/opportunities/utils";
+
+interface PlaceOpportunitiesProps {
+  opportunities: ActivityCard[];
+}
+
+const PlaceOpportunities: React.FC<PlaceOpportunitiesProps> = ({ opportunities }) => {
+  if (!opportunities.length) return null;
+
+  const formattedOpportunities = opportunities.map(formatOpportunities);
+
+  return (
+    <div className="px-4 pt-6 pb-8 max-w-mobile-l mx-auto space-y-4">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-display-sm font-semibold text-foreground flex items-center gap-2">
+          募集中の関わり
+          <span className="bg-primary text-primary-foreground text-xs font-medium px-2 py-0.5 rounded-full">
+            {opportunities.length}
+          </span>
+        </h2>
+      </div>
+      <div className="flex gap-4 overflow-x-auto scrollbar-hide">
+        {formattedOpportunities.map((opportunity) => (
+          <OpportunityVerticalCard key={opportunity.id} {...opportunity} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PlaceOpportunities;

--- a/src/app/places/[id]/components/PlaceOverview.tsx
+++ b/src/app/places/[id]/components/PlaceOverview.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { MapPin, Users } from "lucide-react";
+import { useReadMore } from "@/hooks/useReadMore";
+import { IPlaceDetail } from "@/app/places/data/type";
+import { cn } from "@/lib/utils";
+
+const INITIAL_DISPLAY_LINES = 6;
+
+interface PlaceOverviewProps {
+  detail: IPlaceDetail;
+}
+
+const PlaceOverview = ({ detail }: PlaceOverviewProps) => {
+  return (
+    <div
+      className={cn("px-4 pt-2 max-w-mobile-l mx-auto space-y-4", {
+        "pb-4": detail.headline || detail.bio,
+      })}
+    >
+      <div className="flex flex-wrap gap-4 justify-between">
+        <div className="flex items-center gap-1 text-body-sm gap-x-1">
+          <MapPin className="h-5 w-5" />
+          <span className="text-body-md font-bold">{detail.name}</span>
+        </div>
+        <div className="flex items-center gap-1 text-body-sm text-muted-foreground gap-x-1">
+          <Users className="h-5 w-5 text-caption" />
+          <span className="text-body-md text-caption">{detail.participantCount}人</span>
+        </div>
+      </div>
+      <h2 className="text-display-md">{detail.headline}</h2>
+      <PlaceDescription bio={detail.bio} />
+    </div>
+  );
+};
+export default PlaceOverview;
+
+const PlaceDescription = ({ bio }: { bio: string }) => {
+  const { textRef, expanded, showReadMore, toggleExpanded, getTextStyle } = useReadMore({
+    text: bio,
+    maxLines: INITIAL_DISPLAY_LINES,
+  });
+
+  return (
+    <div className="relative">
+      <p
+        ref={textRef}
+        className="text-body-md text-foreground whitespace-pre-wrap transition-all duration-300"
+        style={getTextStyle()}
+      >
+        {bio}
+      </p>
+      {showReadMore && !expanded && (
+        <div className="absolute bottom-0 left-0 w-full">
+          <div className="absolute inset-0 bg-gradient-to-t from-background to-transparent"></div>
+          <div className="relative flex justify-center pt-8">
+            <Button variant="tertiary" size="sm" onClick={toggleExpanded} className="bg-white px-6">
+              <span className="text-label-sm font-bold">もっと見る</span>
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/app/places/[id]/hooks/usePlaceDetail.ts
+++ b/src/app/places/[id]/hooks/usePlaceDetail.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { useLoading } from "@/hooks/useLoading";
+import { useGetPlaceQuery } from "@/types/graphql";
+import { IPlaceDetail } from "@/app/places/data/type";
+import { presenterPlaceDetail } from "@/app/places/data/presenter";
+
+export interface UsePlaceDetailResult {
+  place: IPlaceDetail | null;
+  loading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+export const usePlaceDetail = (placeId: string): UsePlaceDetailResult => {
+  const { data, loading, error, refetch } = useGetPlaceQuery({
+    variables: { id: placeId },
+  });
+
+  const { setIsLoading } = useLoading();
+
+  useEffect(() => {
+    setIsLoading(loading);
+  }, [loading, setIsLoading]);
+
+  const place = useMemo(() => {
+    const place = data?.place;
+    return place ? presenterPlaceDetail(place) : null;
+  }, [data]);
+
+  return {
+    place,
+    loading,
+    error: error ?? null,
+    refetch,
+  };
+};

--- a/src/app/places/[id]/layout.tsx
+++ b/src/app/places/[id]/layout.tsx
@@ -1,0 +1,84 @@
+import { Metadata } from "next";
+import { apolloClient } from "@/lib/apollo";
+import {
+  GetPlaceDocument,
+  GqlGetPlaceQuery,
+  GqlGetPlaceQueryVariables,
+  GqlPlace,
+  GqlPublishStatus,
+} from "@/types/graphql";
+import {
+  fallbackMetadata,
+  DEFAULT_OPEN_GRAPH_IMAGE,
+  currentCommunityConfig,
+} from "@/lib/communities/metadata";
+
+export const generateMetadata = async ({
+  params,
+}: {
+  params: { id: string };
+}): Promise<Metadata> => {
+  const id = params.id;
+  const place = await fetchPlace(id);
+  if (!place) return fallbackMetadata;
+
+  const placeDetail = presenterPlaceDetailForMetadata(place);
+
+  return {
+    title: `${placeDetail.name} | ${currentCommunityConfig.title}`,
+    description: placeDetail.bio,
+    openGraph: {
+      title: placeDetail.name,
+      description: placeDetail.bio,
+      type: "article",
+      url: `${currentCommunityConfig.domain}/places/${id}`,
+      images: placeDetail.images.length
+        ? placeDetail.images.map((url) => ({
+            url,
+            width: 1200,
+            height: 630,
+            alt: placeDetail.name,
+          }))
+        : DEFAULT_OPEN_GRAPH_IMAGE,
+    },
+    alternates: {
+      canonical: `${currentCommunityConfig.domain}/places/${id}`,
+    },
+  };
+};
+
+async function fetchPlace(id: string): Promise<GqlPlace | null> {
+  const { data } = await apolloClient.query<GqlGetPlaceQuery, GqlGetPlaceQueryVariables>({
+    query: GetPlaceDocument,
+    variables: { id },
+  });
+
+  return data.place ?? null;
+}
+
+const presenterPlaceDetailForMetadata = (place: GqlPlace) => {
+  const opportunities = place.opportunities ?? [];
+  const publicOpportunities = opportunities.filter(
+    (o) => o.publishStatus === GqlPublishStatus.Public,
+  );
+
+  const firstArticle = place.opportunities
+    ?.flatMap((o) => o.articles ?? [])
+    ?.find((a) => !!a?.introduction); // クライアント関数を使わず article から直接取得
+
+  const opportunityImages = publicOpportunities.flatMap((o) => o.images ?? []);
+
+  const images = Array.from(
+    new Set([place.image, ...opportunityImages].filter((v): v is string => typeof v === "string")),
+  );
+
+  return {
+    name: place.name ?? "不明な場所",
+    bio: firstArticle?.introduction ?? "Coming Soon!",
+    images,
+  };
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/places/[id]/page.tsx
+++ b/src/app/places/[id]/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { FC, useEffect, useRef } from "react";
+import { usePlaceDetail } from "@/app/places/[id]/hooks/usePlaceDetail";
+import PlaceOpportunities from "@/app/places/[id]/components/PlaceOpportunities";
+import PlaceFeaturedArticle from "@/app/places/[id]/components/PlaceFeaturedArticle";
+import { ErrorState } from '@/components/shared'
+import ImagesCarousel from "@/components/ui/images-carousel";
+import PlaceOverview from "./components/PlaceOverview";
+import PlaceAddress from "./components/PlaceAddress";
+import LoadingIndicator from "@/components/shared/LoadingIndicator";
+import NavigationButtons from "@/components/shared/NavigationButtons";
+import { notFound, useParams, useSearchParams } from "next/navigation";
+
+const PlaceDetail: FC = () => {
+  const params = useParams();
+  const searchParams = useSearchParams();
+
+  const id = Array.isArray(params.id) ? params.id[0] : params.id;
+
+  const { loading, place, error, refetch } = usePlaceDetail(id ?? "");
+  const refetchRef = useRef<(() => void) | null>(null);
+  useEffect(() => {
+    refetchRef.current = refetch;
+  }, [refetch]);
+
+  if (loading) return <LoadingIndicator />;
+  if (error) return <ErrorState title="拠点を読み込めませんでした" refetchRef={refetchRef} />;
+  if (!place) return notFound();
+
+  return (
+    <>
+      <div className="relative max-w-mobile-l mx-auto w-full z-10">
+        <NavigationButtons title={place.name} />
+      </div>
+      <div className="min-h-screen">
+        <ImagesCarousel images={place.images} title={place.name} />
+        <PlaceOverview detail={place} />
+        <PlaceAddress detail={place} />
+        <PlaceOpportunities opportunities={place.currentlyHiringOpportunities} />
+        <PlaceFeaturedArticle articles={place.relatedArticles} />
+      </div>
+    </>
+  );
+};
+
+export default PlaceDetail;

--- a/src/app/places/components/Card.tsx
+++ b/src/app/places/components/Card.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { Card, CardContent, CardDescription, CardFooter, CardTitle } from "@/components/ui/card";
+import Image from "next/image";
+import { PLACEHOLDER_IMAGE } from "@/utils";
+import { MapPin, Users } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { IPlaceCard } from "@/app/places/data/type";
+import Link from "next/link";
+
+interface PlaceCardProps {
+  place: IPlaceCard;
+  selected: boolean;
+  buttonVariant?: "primary" | "tertiary";
+}
+
+const PlaceCard: React.FC<PlaceCardProps> = ({ place, selected, buttonVariant = "tertiary" }) => (
+  <Link href={`/places/${place.id}`}>
+    <Card
+      className={`w-full overflow-hidden transition-transform duration-200 ${
+        selected ? "scale-[1.02]" : "scale-100"
+      }`}
+    >
+      <div className="relative h-32 rounded-t-lg overflow-hidden">
+        <Image
+          src={place.image ?? PLACEHOLDER_IMAGE}
+          alt={place.headline}
+          className="object-cover"
+          fill
+          placeholder={`blur`}
+          blurDataURL={PLACEHOLDER_IMAGE}
+          sizes="(max-width: 768px) 100vw, 320px"
+          onError={(e) => {
+            const img = e.target as HTMLImageElement;
+            img.src = PLACEHOLDER_IMAGE;
+          }}
+        />
+      </div>
+      <CardContent className="flex flex-col px-4 py-3 w-full">
+        <div className="flex items-center justify-between mb-2 w-full">
+          <div className="mt-1 flex items-start text-foreground text-body-xs overflow-hidden">
+            <MapPin className="mr-1 h-4 w-4 flex-shrink-0 mt-0.5" />
+            <div className="flex-1 flex flex-wrap overflow-hidden min-w-0 max-w-[248px]">
+              <span className="font-bold text-body-xs truncate min-w-0 max-w-full mr-2">
+                {place.name}
+              </span>
+              <span className="truncate text-caption text-body-xs min-w-0 max-w-full">
+                {place.address}
+              </span>
+            </div>
+          </div>
+          <div className="mt-1 flex items-center text-caption text-label-xs flex-shrink-0">
+            <Users className="mr-1 h-4 w-4 flex-shrink-0" />
+            <span className="line-clamp-1 break-words">{place.participantCount}人</span>
+          </div>
+        </div>
+
+        {place.headline && (
+          <CardTitle className="text-title-sm line-clamp-1 mb-1 overflow-hidden">
+            {place.headline}
+          </CardTitle>
+        )}
+        {place.bio && (
+          <CardDescription className="line-clamp-2 mb-2 text-body-xs text-caption overflow-hidden">
+            {place.bio}
+          </CardDescription>
+        )}
+
+        <CardFooter className="flex justify-between mt-2 p-0 mb-1 w-full">
+          {place.publicOpportunityCount > 0 ? (
+            <span className="text-body-xs text-caption truncate mr-2">
+              <strong className="text-foreground mr-0.5">{place.publicOpportunityCount}件</strong>
+              の関わり方を募集中
+            </span>
+          ) : (
+            // レイアウト保持のために render
+            <span className="text-body-xs text-caption"></span>
+          )}
+          <Button variant={buttonVariant} size={"sm"} className="flex-shrink-0">
+            もっと見る
+          </Button>
+        </CardFooter>
+      </CardContent>
+    </Card>
+  </Link>
+);
+
+export default PlaceCard;

--- a/src/app/places/components/ToggleButton.tsx
+++ b/src/app/places/components/ToggleButton.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from "react";
+import { List, MapPin } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { AuthEnvironment, detectEnvironment } from "@/lib/auth/core/environment-detector";
+
+interface PlaceToggleButtonProps {
+  isMapMode: boolean;
+  onClick: () => void;
+}
+
+const PlaceToggleButton: React.FC<PlaceToggleButtonProps> = ({ isMapMode, onClick }) => {
+  const env = detectEnvironment();
+  const isLiff = env === AuthEnvironment.LIFF;
+
+  return (
+    <div className={`fixed left-1/2 -translate-x-1/2 z-50 ${isLiff ? "bottom-28" : "bottom-24"}`}>
+      <Button onClick={onClick} variant={"secondary"} size={"md"}>
+        {isMapMode ? (
+          <>
+            <List className="h-5 w-5" />
+            一覧
+          </>
+        ) : (
+          <>
+            <MapPin className="h-5 w-5" />
+            地図
+          </>
+        )}
+      </Button>
+    </div>
+  );
+};
+
+export default PlaceToggleButton;

--- a/src/app/places/components/list/ListPage.tsx
+++ b/src/app/places/components/list/ListPage.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React from "react";
+import PlaceToggleButton from "@/app/places/components/ToggleButton";
+import PlaceCard from "@/app/places/components/Card";
+import { IPlaceCard } from "@/app/places/data/type";
+
+interface PlaceListSheetProps {
+  places: IPlaceCard[];
+  selectedPlaceId?: string | null;
+  onMapClick: () => void;
+}
+
+const PlaceListPage: React.FC<PlaceListSheetProps> = ({ places, selectedPlaceId, onMapClick }) => {
+  return (
+    <div className="min-h-screen w-full px-6 pt-6 pb-6 max-w-lg mx-auto">
+      <div className="grid gap-4">
+        {places
+          .filter((place) => !selectedPlaceId || place.id === selectedPlaceId)
+          .map((place) => (
+            <PlaceCard key={place.id} place={place} selected={place.id === selectedPlaceId} />
+          ))}
+      </div>
+      {!selectedPlaceId && <PlaceToggleButton isMapMode={false} onClick={onMapClick} />}
+    </div>
+  );
+};
+
+export default PlaceListPage;

--- a/src/app/places/components/map/CustomMarker.tsx
+++ b/src/app/places/components/map/CustomMarker.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { drawCircleWithImage } from "@/app/places/utils/marker";
+import { Marker } from "@react-google-maps/api";
+import { IPlacePin } from "@/app/places/data/type";
+import { PLACEHOLDER_IMAGE } from "@/utils";
+import { logger } from "@/lib/logging";
+
+interface CustomMarkerProps {
+  data: IPlacePin;
+  onClick: () => void;
+  isSelected: boolean;
+}
+
+const markerIconCache = new Map<string, google.maps.Icon>();
+
+const HARDCODED_COORDINATES: Record<string, google.maps.LatLngLiteral> = {
+  cmahstwr4002rs60n6map2wiu: { lat: 34.178142, lng: 133.818358 }, // 大庄屋
+};
+
+const loadImage = (src: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.onload = () => resolve(img);
+    img.onerror = (e) => {
+      logger.warn(`Failed to load image from ${src}`, {
+        error: e,
+        component: "CustomMarker"
+      });
+      // Try without crossOrigin as a fallback
+      if (img.crossOrigin) {
+        const fallbackImg = new Image();
+        fallbackImg.onload = () => resolve(fallbackImg);
+        fallbackImg.onerror = reject;
+        fallbackImg.src = src;
+      } else {
+        reject(e);
+      }
+    };
+    img.src = src;
+  });
+
+const setupCanvas = (size: number, includeShadowPadding: boolean = false) => {
+  const scale = 2;
+  const shadowPadding = includeShadowPadding ? 24 : 0;
+  const totalSize = size + shadowPadding;
+
+  const canvas = document.createElement("canvas");
+  const context = canvas.getContext("2d");
+
+  if (!context) throw new Error("Failed to get canvas context");
+
+  canvas.width = totalSize * scale;
+  canvas.height = totalSize * scale;
+
+  context.scale(scale, scale);
+
+  if (includeShadowPadding) {
+    context.translate(shadowPadding / 2, shadowPadding / 2);
+  }
+
+  return { canvas, context, totalSize, shadowPadding };
+};
+
+const createIconObject = (
+  canvas: HTMLCanvasElement,
+  size: number,
+  shadowPadding: number,
+  anchorYOffset: number = 0,
+): google.maps.Icon => {
+  const totalSize = size + shadowPadding;
+  return {
+    url: canvas.toDataURL("image/png", 1.0),
+    scaledSize: new google.maps.Size(totalSize, totalSize),
+    anchor: new google.maps.Point(totalSize / 2, totalSize / 2 + anchorYOffset),
+  };
+};
+
+const createPlaceholderIcon = async (size: number): Promise<google.maps.Icon> => {
+  try {
+    const { canvas, context, totalSize } = setupCanvas(size);
+
+    const centerX = size / 2;
+    const centerY = size / 2;
+    const radius = size / 2 - 2;
+
+    const placeholderImage = await loadImage(PLACEHOLDER_IMAGE);
+    await drawCircleWithImage(context, placeholderImage, centerX, centerY, radius, true);
+
+    return createIconObject(canvas, size, 0, 10);
+  } catch (error) {
+    logger.warn("Failed to create placeholder icon, using direct URL", {
+      error: error instanceof Error ? error.message : String(error),
+      component: "CustomMarker"
+    });
+    // Fallback to direct URL approach when Canvas fails
+    return {
+      url: PLACEHOLDER_IMAGE,
+      scaledSize: new google.maps.Size(size, size),
+      anchor: new google.maps.Point(size / 2, size / 2 + 10),
+    };
+  }
+};
+
+const CustomMarker: React.FC<CustomMarkerProps> = ({ data, onClick, isSelected }) => {
+  const [icon, setIcon] = useState<google.maps.Icon | null>(null);
+  const displaySize = 48;
+  const cacheKey = `${data.id}-normal`;
+
+  // ✅ 安定した依存値にする（nullを避ける）
+  const hostImage = useMemo(() => data.host.image ?? PLACEHOLDER_IMAGE, [data.host.image]);
+
+  const position: google.maps.LatLngLiteral = useMemo(() => {
+    return HARDCODED_COORDINATES[data.id] ?? { lat: data.latitude, lng: data.longitude };
+  }, [data.id, data.latitude, data.longitude]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    (async () => {
+      if (markerIconCache.has(cacheKey)) {
+        isMounted && setIcon(markerIconCache.get(cacheKey)!);
+        return;
+      }
+
+      try {
+        const placeholder = await createPlaceholderIcon(displaySize);
+        isMounted && setIcon(placeholder);
+      } catch (error) {
+        logger.warn("Failed to create placeholder icon", {
+          error: error instanceof Error ? error.message : String(error),
+          component: "CustomMarker"
+        });
+      }
+
+      try {
+        const { canvas, context, totalSize, shadowPadding } = setupCanvas(displaySize, true);
+
+        const centerX = displaySize / 2;
+        const centerY = displaySize / 2;
+        const mainRadius = displaySize / 2 - 2;
+        const smallRadius = mainRadius * 0.4;
+        const smallX = centerX + mainRadius * 0.5;
+        const smallY = centerY + mainRadius * 0.5;
+
+        const mainImg = await loadImage(data.image);
+        await drawCircleWithImage(context, mainImg, centerX, centerY, mainRadius, true);
+
+        // ホスト画像の描画がうまくいかず、一時コメントアウト
+        // const userImg = await loadImage(hostImage);
+        // await drawCircleWithImage(context, userImg, smallX, smallY, smallRadius, false);
+
+        const markerIcon = createIconObject(canvas, displaySize, shadowPadding, 0);
+
+        markerIconCache.set(cacheKey, markerIcon);
+        isMounted && setIcon(markerIcon);
+      } catch (error) {
+        logger.warn("Failed to create marker icon with Canvas, falling back to direct URL", {
+          error: error instanceof Error ? error.message : String(error),
+          component: "CustomMarker"
+        });
+
+        // Fallback to direct URL approach when Canvas fails
+        const fallbackIcon = {
+          url: data.image || PLACEHOLDER_IMAGE,
+          scaledSize: new google.maps.Size(displaySize, displaySize),
+          anchor: new google.maps.Point(displaySize / 2, displaySize / 2),
+        };
+
+        markerIconCache.set(cacheKey, fallbackIcon);
+        isMounted && setIcon(fallbackIcon);
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [data.id, data.image, hostImage, displaySize, cacheKey]);
+
+  if (!icon) return null;
+
+  return (
+    <Marker
+      position={position}
+      icon={icon}
+      onClick={(e) => {
+        if (e && e.domEvent) e.domEvent.stopPropagation();
+        onClick();
+      }}
+      zIndex={isSelected ? 2 : 1}
+      title={data.host.name}
+    />
+  );
+};
+
+export default CustomMarker;

--- a/src/app/places/components/map/MapComponent.tsx
+++ b/src/app/places/components/map/MapComponent.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { GoogleMap, useJsApiLoader } from "@react-google-maps/api";
+import { useMapState } from "@/app/places/hooks/useMapState";
+import LoadingIndicator from "@/components/shared/LoadingIndicator";
+import { usePreloadImages } from "@/app/places/hooks/usePreloadImages";
+import { IPlacePin } from "@/app/places/data/type";
+import CustomMarker from "./CustomMarker";
+
+const containerStyle = {
+  width: "100%",
+  height: "100%",
+};
+
+interface MapComponentProps {
+  placePins: IPlacePin[];
+  selectedPlaceId: string | null;
+  onPlaceSelect: (placeId: string | null) => void;
+  onRecenterReady?: (fn: () => void) => void;
+}
+
+export default function MapComponent({
+  placePins,
+  selectedPlaceId,
+  onPlaceSelect,
+  onRecenterReady,
+}: MapComponentProps) {
+  const { isLoaded } = useJsApiLoader({
+    id: "google-map-script",
+    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || "",
+    language: "ja",
+    region: "JP",
+  });
+
+  const allImageUrls = Array.from(
+    new Set(
+      [...placePins.map((pin) => pin.image), ...placePins.map((pin) => pin.host?.image)].filter(
+        (url): url is string => url != null,
+      ),
+    ),
+  );
+  const imagesReady = usePreloadImages(allImageUrls);
+
+  const { markers, center, zoom, onLoad, onUnmount, recenterToSelectedMarker } = useMapState({
+    placePins,
+    selectedPlaceId,
+  });
+
+  React.useEffect(() => {
+    if (onRecenterReady) {
+      onRecenterReady(recenterToSelectedMarker);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recenterToSelectedMarker]);
+
+  if (!isLoaded || !imagesReady) {
+    return <LoadingIndicator fullScreen />;
+  }
+
+  return (
+    <GoogleMap
+      mapContainerStyle={containerStyle}
+      center={center}
+      zoom={zoom}
+      onLoad={onLoad}
+      onUnmount={onUnmount}
+      options={{
+        gestureHandling: "greedy",
+        disableDefaultUI: true,
+        scrollwheel: true,
+        zoomControl: true,
+      }}
+      onClick={() => onPlaceSelect(null)}
+    >
+      {markers.map((marker: IPlacePin) => (
+        <CustomMarker
+          key={marker.id}
+          data={marker}
+          onClick={() => {
+            console.debug(`マーカークリック - ID: ${marker.id}, 現在の選択ID: ${selectedPlaceId}`);
+            console.debug(`マーカーデータ:`, marker);
+            onPlaceSelect(marker.id);
+          }}
+          isSelected={marker.id === selectedPlaceId}
+        />
+      ))}
+    </GoogleMap>
+  );
+}

--- a/src/app/places/components/map/PlaceCardsSheet.tsx
+++ b/src/app/places/components/map/PlaceCardsSheet.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import React, { FC, useEffect, useMemo, useRef } from "react";
+import { IPlaceCard } from "@/app/places/data/type";
+import useEmblaCarousel from "embla-carousel-react";
+import PlaceCard from "@/app/places/components/Card";
+
+interface PlaceCardsSheetProps {
+  places: IPlaceCard[];
+  selectedPlaceId: string | null;
+  onPlaceSelect: (placeId: string) => void;
+}
+
+const PlaceCardsSheet: FC<PlaceCardsSheetProps> = ({ places, selectedPlaceId, onPlaceSelect }) => {
+  const isProgrammaticScrollRef = useRef(false);
+
+  const selectedIndex = useMemo(() => {
+    if (!selectedPlaceId) return 0;
+    const index = places.findIndex((place) => place.id === selectedPlaceId);
+    return index >= 0 ? index : 0;
+  }, [places, selectedPlaceId]);
+
+  // カルーセルの初期化
+  const [emblaRef, emblaApi] = useEmblaCarousel({
+    align: "center",
+    containScroll: "trimSnaps",
+    loop: false,
+    startIndex: selectedIndex,
+  });
+
+  useEffect(() => {
+    if (!emblaApi) return;
+
+    if (selectedPlaceId) {
+      isProgrammaticScrollRef.current = true;
+      emblaApi.scrollTo(selectedIndex, false);
+
+      const timer = setTimeout(() => {
+        isProgrammaticScrollRef.current = false;
+      }, 100);
+
+      return () => clearTimeout(timer);
+    }
+  }, [emblaApi, selectedPlaceId, selectedIndex]);
+
+  useEffect(() => {
+    if (!emblaApi) return;
+
+    const onSelect = () => {
+      if (isProgrammaticScrollRef.current) {
+        console.debug("プログラムによるスクロール中のため選択イベントをスキップ");
+        return;
+      }
+      const index = emblaApi.selectedScrollSnap();
+      const place = places[index];
+      console.debug(
+        `カード選択 - インデックス: ${index}, ID: ${place?.id}, 現在の選択ID: ${selectedPlaceId}`,
+      );
+      console.debug(`選択されたカードデータ:`, place);
+      if (place && place.id !== selectedPlaceId) {
+        onPlaceSelect(place.id);
+      }
+    };
+
+    emblaApi.on("select", onSelect);
+
+    return () => {
+      emblaApi.off("select", onSelect);
+    };
+  }, [emblaApi, places, selectedPlaceId, onPlaceSelect]);
+
+  if (!places.length) return null;
+
+  return (
+    <div ref={emblaRef} className="overflow-hidden w-full">
+      <div className="flex">
+        {places.map((place) => (
+          <div
+            key={place.id}
+            className="flex-[0_0_100%] max-w-[340px] px-2"
+            data-place-id={place.id}
+          >
+            <PlaceCard
+              place={place}
+              selected={place.id === selectedPlaceId}
+              buttonVariant={place.id === selectedPlaceId ? "primary" : "tertiary"}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PlaceCardsSheet;

--- a/src/app/places/components/map/PlaceMapView.tsx
+++ b/src/app/places/components/map/PlaceMapView.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import React, { useRef } from "react";
+import PlaceToggleButton from "../ToggleButton";
+import PlaceCardsSheet from "./PlaceCardsSheet";
+import MapComponent from "./MapComponent";
+import { AnimatePresence, motion } from "framer-motion";
+import { IPlaceCard, IPlacePin } from "@/app/places/data/type";
+
+interface PlaceMapViewProps {
+  selectedPlaceId: string | null;
+  onPlaceSelect: (placeId: string | null) => void;
+  toggleMode: () => void;
+  placePins: IPlacePin[];
+  places: IPlaceCard[];
+}
+
+const PlaceMapView: React.FC<PlaceMapViewProps> = ({
+  selectedPlaceId,
+  onPlaceSelect,
+  toggleMode,
+  placePins,
+  places,
+}) => {
+  const recenterRef = useRef<() => void>();
+  const handleRecenterReady = (fn: () => void) => {
+    recenterRef.current = fn;
+  };
+  React.useEffect(() => {
+    recenterRef.current = undefined;
+  }, [selectedPlaceId]);
+
+  return (
+    <div className="relative h-full w-full">
+      <MapComponent
+        placePins={placePins}
+        selectedPlaceId={selectedPlaceId}
+        onPlaceSelect={onPlaceSelect}
+        onRecenterReady={handleRecenterReady}
+      />
+      <AnimatePresence mode="wait">
+        {selectedPlaceId ? (
+          <motion.div
+            key="place-cards"
+            layout
+            initial={{ y: "100%" }}
+            animate={{ y: 0 }}
+            exit={{ y: "100%" }}
+            transition={{ type: "spring", damping: 25, stiffness: 200 }}
+            className="fixed bottom-[32px] inset-x-0 left-0 right-0 z-50 w-full flex items-center px-4 justify-center mx-auto"
+            onAnimationComplete={() => {
+              if (recenterRef.current) recenterRef.current();
+            }}
+          >
+            <div className="relative w-full max-w-lg overflow-hidden mx-auto">
+              <PlaceCardsSheet
+                places={places}
+                selectedPlaceId={selectedPlaceId}
+                onPlaceSelect={onPlaceSelect}
+              />
+            </div>
+          </motion.div>
+        ) : (
+          <PlaceToggleButton isMapMode={true} onClick={toggleMode} />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default PlaceMapView;

--- a/src/app/places/hooks/useMapState.ts
+++ b/src/app/places/hooks/useMapState.ts
@@ -1,0 +1,162 @@
+"use client";
+
+import { useCallback, useEffect, useReducer } from "react";
+import { IPlacePin } from "@/app/places/data/type";
+import { logger } from "@/lib/logging";
+
+const INITIAL_CENTER_COORDINATE = { lat: 33.0, lng: 133.5 };
+
+/* --------------------------------------------
+ * Reducer + 型定義
+ * ------------------------------------------ */
+
+interface MapState {
+  markers: IPlacePin[];
+  places: IPlacePin[];
+  center: google.maps.LatLngLiteral;
+  map: google.maps.Map | null;
+  isLoaded: boolean;
+  error: string | null;
+  zoom: number;
+}
+
+type MapAction =
+  | { type: "SET_MARKERS"; payload: { markers: IPlacePin[]; places: IPlacePin[] } }
+  | { type: "SET_CENTER"; payload: google.maps.LatLngLiteral }
+  | { type: "SET_MAP"; payload: google.maps.Map | null }
+  | { type: "SET_LOADED"; payload: boolean }
+  | { type: "SET_ERROR"; payload: string | null }
+  | { type: "SET_ZOOM"; payload: number };
+
+const initialState: MapState = {
+  markers: [],
+  places: [],
+  center: INITIAL_CENTER_COORDINATE,
+  map: null,
+  isLoaded: false,
+  error: null,
+  zoom: 8,
+};
+
+const mapReducer = (state: MapState, action: MapAction): MapState => {
+  switch (action.type) {
+    case "SET_MARKERS":
+      return { ...state, markers: action.payload.markers, places: action.payload.places };
+    case "SET_CENTER":
+      return { ...state, center: action.payload };
+    case "SET_MAP":
+      return { ...state, map: action.payload };
+    case "SET_LOADED":
+      return { ...state, isLoaded: action.payload };
+    case "SET_ERROR":
+      return { ...state, error: action.payload };
+    case "SET_ZOOM":
+      return { ...state, zoom: action.payload };
+    default:
+      return state;
+  }
+};
+
+/* --------------------------------------------
+ * 外部 API 型
+ * ------------------------------------------ */
+
+interface MapComponentProps {
+  placePins: IPlacePin[];
+  selectedPlaceId: string | null;
+}
+
+/* --------------------------------------------
+ * 分離された副作用関数
+ * ------------------------------------------ */
+
+const initializeMarkers = (places: IPlacePin[], dispatch: React.Dispatch<MapAction>) => {
+  try {
+    dispatch({ type: "SET_MARKERS", payload: { markers: places, places } });
+  } catch (error) {
+    logger.error("Error processing map data", {
+      error: error instanceof Error ? error.message : String(error),
+      component: "useMapState"
+    });
+    dispatch({ type: "SET_ERROR", payload: "マップデータの処理中にエラーが発生しました" });
+  }
+};
+
+const panToSelectedMarker = (
+  selectedPlaceId: string | null,
+  map: google.maps.Map | null,
+  markers: IPlacePin[],
+  dispatch?: React.Dispatch<MapAction>,
+) => {
+  if (!map || !selectedPlaceId) return;
+
+  const marker = markers.find((m) => m.id === selectedPlaceId);
+  if (!marker) return;
+
+  // ヘッダー・カード・下部余白を合計した分だけ地図中心を上にずらす（カード高さは固定値）
+  const HEADER_HEIGHT = 64; // px
+  const CARD_HEIGHT = 324; // px
+  const CARD_BOTTOM_MARGIN = 32; // px
+  const cardAndMarginHeight = CARD_HEIGHT + CARD_BOTTOM_MARGIN;
+  const mapDiv = map.getDiv();
+  const mapHeight = mapDiv.clientHeight;
+  const bounds = map.getBounds();
+  if (!bounds) return;
+  const latSpan = bounds.getNorthEast().lat() - bounds.getSouthWest().lat();
+  // 画面全体の高さに対するオフセット比率
+  const offsetPx = HEADER_HEIGHT + cardAndMarginHeight / 2;
+  const offsetRatio = offsetPx / mapHeight;
+  const latOffset = latSpan * offsetRatio;
+
+  if (dispatch) {
+    dispatch({ type: "SET_ZOOM", payload: 10 });
+  }
+
+  // マーカーの位置からオフセット分だけ上にずらした新しい中心位置を設定
+  const newCenter = new google.maps.LatLng(marker.latitude - latOffset, marker.longitude);
+  map.panTo(newCenter);
+  if (dispatch) {
+    dispatch({ type: "SET_CENTER", payload: { lat: newCenter.lat(), lng: newCenter.lng() } });
+  }
+};
+
+/* --------------------------------------------
+ * メインフック
+ * ------------------------------------------ */
+
+export const useMapState = ({ placePins, selectedPlaceId }: MapComponentProps) => {
+  const [state, dispatch] = useReducer(mapReducer, initialState);
+
+  useEffect(() => {
+    initializeMarkers(placePins, dispatch);
+  }, [placePins]);
+
+  useEffect(() => {
+    panToSelectedMarker(selectedPlaceId, state.map, state.markers, dispatch);
+  }, [selectedPlaceId, state.map, state.markers]);
+
+  const onLoad = useCallback((map: google.maps.Map) => {
+    dispatch({ type: "SET_MAP", payload: map });
+  }, []);
+
+  const onUnmount = useCallback(() => {
+    dispatch({ type: "SET_MAP", payload: null });
+  }, []);
+
+  const setLoaded = useCallback((isLoaded: boolean) => {
+    dispatch({ type: "SET_LOADED", payload: isLoaded });
+  }, []);
+
+  // imperativeに中心を再調整する関数
+  const recenterToSelectedMarker = () => {
+    panToSelectedMarker(selectedPlaceId, state.map, state.markers, dispatch);
+  };
+
+  return {
+    ...state,
+    onLoad,
+    onUnmount,
+    setLoaded,
+    recenterToSelectedMarker,
+  };
+};

--- a/src/app/places/hooks/usePlaceCards.ts
+++ b/src/app/places/hooks/usePlaceCards.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import usePlacesData from "./usePlacesData";
+
+export default function usePlaceCards() {
+  const { cards, loading, error, refetch } = usePlacesData();
+
+  return {
+    baseCards: cards,
+    loading,
+    error,
+    refetch,
+  };
+}

--- a/src/app/places/hooks/usePlacePins.ts
+++ b/src/app/places/hooks/usePlacePins.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import usePlacesData from "./usePlacesData";
+
+export default function usePlacePins() {
+  const { pins, loading, error, refetch } = usePlacesData();
+
+  return {
+    placePins: pins,
+    loading,
+    error,
+    refetch,
+  };
+}

--- a/src/app/places/hooks/usePlaceQueryActions.ts
+++ b/src/app/places/hooks/usePlaceQueryActions.ts
@@ -1,0 +1,29 @@
+import { useRouter, useSearchParams } from "next/navigation";
+
+export function usePlaceQueryActions() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const updateParams = (updater: (params: URLSearchParams) => void) => {
+    const params = new URLSearchParams(searchParams.toString());
+    updater(params);
+    router.push(`/places?${params.toString()}`);
+  };
+
+  const handlePlaceSelect = (placeId: string | null) => {
+    if (placeId) {
+      updateParams((p) => p.set("placeId", placeId));
+    } else {
+      updateParams((p) => p.delete("placeId"));
+    }
+  };
+
+  const toggleMode = () =>
+    updateParams((p) => {
+      const mode = searchParams.get("mode") || "map";
+      p.set("mode", mode === "map" ? "list" : "map");
+      p.delete("placeId");
+    });
+
+  return { handlePlaceSelect, toggleMode };
+}

--- a/src/app/places/hooks/usePlaceQueryValues.ts
+++ b/src/app/places/hooks/usePlaceQueryValues.ts
@@ -1,0 +1,9 @@
+import { useSearchParams } from "next/navigation";
+
+export function usePlaceQueryValues() {
+  const searchParams = useSearchParams();
+  const selectedPlaceId = searchParams.get("placeId");
+  const mode = searchParams.get("mode") || "map";
+
+  return { selectedPlaceId, mode };
+}

--- a/src/app/places/hooks/usePlaceSelection.ts
+++ b/src/app/places/hooks/usePlaceSelection.ts
@@ -1,0 +1,11 @@
+import { useCallback, useState } from "react";
+
+export const usePlaceSelection = () => {
+  const [selectedPlaceId, setSelectedPlaceId] = useState<string | null>(null);
+
+  const onPlaceSelect = useCallback((placeId: string) => {
+    setSelectedPlaceId(placeId);
+  }, []);
+
+  return { selectedPlaceId, onPlaceSelect };
+};

--- a/src/app/places/hooks/usePlacesData.ts
+++ b/src/app/places/hooks/usePlacesData.ts
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { GqlPlaceEdge, useGetPlacesQuery } from "@/types/graphql";
+import { presenterPlaceCard, presenterPlacePins } from "@/app/places/data/presenter";
+import {
+  getCoordinatesFromAddress,
+  PRIORITIZE_LAT_LNG_PLACE_IDS,
+} from "@/app/places/utils/geocoding";
+import { IPlacePin } from "@/app/places/data/type";
+import { useJsApiLoader } from "@react-google-maps/api";
+import { logger } from "@/lib/logging";
+
+/**
+ * 共通のデータソースからマーカーとカードのデータを提供するフック
+ * usePlaceCards と usePlacePins の機能を統合
+ */
+export default function usePlacesData() {
+  // 共通のデータ取得
+  const { data, loading, error, refetch } = useGetPlacesQuery({
+    variables: {
+      filter: {},
+      first: 100,
+      IsCard: true, // カード表示に必要な追加データを取得
+    },
+    fetchPolicy: "cache-and-network",
+    nextFetchPolicy: "cache-first",
+  });
+
+  // Google Maps API のロード状態
+  const { isLoaded } = useJsApiLoader({
+    id: "google-map-script",
+    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || "",
+    language: "ja",
+    region: "JP",
+  });
+
+  // データの整形
+  const placeEdges: GqlPlaceEdge[] = (data?.places?.edges ?? []).filter(
+    (e): e is GqlPlaceEdge => e != null && e.node != null,
+  );
+
+  // カードデータの生成
+  const baseCards = useMemo(() => presenterPlaceCard(placeEdges), [placeEdges]);
+
+  // マーカーデータの生成
+  const basePlacePins = useMemo(() => presenterPlacePins(placeEdges), [placeEdges]);
+
+  // ジオコーディング関連の状態
+  const prevPinIdsRef = useRef<string[]>([]);
+  const [geocodedPlacePins, setGeocodedPlacePins] = useState<IPlacePin[]>([]);
+  const [isGeocoding, setIsGeocoding] = useState(false);
+
+  // ピンが変更されたかどうかを確認
+  const pinsChanged = useMemo(() => {
+    const currentPinIds = basePlacePins
+      .map((pin) => pin.id)
+      .sort()
+      .join(",");
+    const prevPinIds = prevPinIdsRef.current.sort().join(",");
+    return currentPinIds !== prevPinIds;
+  }, [basePlacePins]);
+
+  // 住所から緯度経度を取得して更新する
+  useEffect(() => {
+    if (!isLoaded || !basePlacePins.length || isGeocoding || !pinsChanged) return;
+
+    const geocodePins = async () => {
+      setIsGeocoding(true);
+
+      // 現在のピンIDを保存
+      prevPinIdsRef.current = basePlacePins.map((pin) => pin.id);
+
+      const updatedPins = await Promise.all(
+        basePlacePins.map(async (pin) => {
+          if (!pin.address) return pin;
+
+          const prioritizeLatLng = PRIORITIZE_LAT_LNG_PLACE_IDS.includes(pin.id);
+
+          if (prioritizeLatLng) {
+            return pin;
+          }
+
+          const coordinates = await getCoordinatesFromAddress(pin.address, pin.id);
+
+          if (coordinates) {
+            return {
+              ...pin,
+              latitude: coordinates.lat,
+              longitude: coordinates.lng,
+            };
+          }
+
+          return pin;
+        }),
+      );
+
+      setGeocodedPlacePins(updatedPins);
+      setIsGeocoding(false);
+    };
+
+    geocodePins();
+  }, [basePlacePins, isLoaded, isGeocoding, pinsChanged]);
+
+  // 最終的なピンデータ
+  const placePins = useMemo(
+    () => (geocodedPlacePins.length > 0 ? geocodedPlacePins : basePlacePins),
+    [geocodedPlacePins, basePlacePins],
+  );
+
+  // IDの一致確認（デバッグ用）
+  useEffect(() => {
+    // マーカーとカードのIDマッピングを確認
+    const markerIds = placePins.map((pin) => pin.id).sort();
+    const cardIds = baseCards.map((card) => card.id).sort();
+
+    const missingInMarkers = cardIds.filter((id) => !markerIds.includes(id));
+    const missingInCards = markerIds.filter((id) => !cardIds.includes(id));
+
+    if (missingInMarkers.length > 0) {
+      logger.warn("カードにあってマーカーにないID", {
+        missingInMarkers,
+        component: "usePlacesData"
+      });
+    }
+
+    if (missingInCards.length > 0) {
+      logger.warn("マーカーにあってカードにないID", {
+        missingInCards,
+        component: "usePlacesData"
+      });
+    }
+  }, [placePins, baseCards]);
+
+  return {
+    cards: baseCards,
+    pins: placePins,
+    loading: loading || isGeocoding,
+    error: error ?? null,
+    refetch,
+  };
+}

--- a/src/app/places/hooks/usePreloadImages.ts
+++ b/src/app/places/hooks/usePreloadImages.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+
+export function usePreloadImages(urls: string[]): boolean {
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let completed = 0;
+    const total = urls.length;
+    if (total === 0) {
+      setLoaded(true);
+      return;
+    }
+
+    urls.forEach((url) => {
+      const img = new Image();
+      img.crossOrigin = "anonymous"; // Add crossOrigin attribute
+      img.onload = () => {
+        completed += 1;
+        if (completed === total) setLoaded(true);
+      };
+      img.onerror = () => {
+        completed += 1;
+        if (completed === total) setLoaded(true); // ignore error
+      };
+      img.src = url;
+    });
+  }, [urls]);
+
+  return loaded;
+}

--- a/src/app/places/layout.tsx
+++ b/src/app/places/layout.tsx
@@ -1,0 +1,7 @@
+import { metadata } from "./metadata";
+
+export { metadata };
+
+export default function PlacesLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/places/metadata.ts
+++ b/src/app/places/metadata.ts
@@ -1,0 +1,25 @@
+import { Metadata } from "next";
+import { DEFAULT_OPEN_GRAPH_IMAGE, currentCommunityConfig } from "@/lib/communities/metadata";
+
+export const metadata: Metadata = {
+  title: `${currentCommunityConfig.title} - 拠点一覧`,
+  description: `どこで、誰と、どんな時間を過ごすか。${currentCommunityConfig.title}の体験が生まれる土地には、それぞれの風景と営みがあります。気になる場所に、出会ってみませんか。`,
+  openGraph: {
+    title: `${currentCommunityConfig.title} - 拠点一覧`,
+    description:
+      "体験が生まれる土地には、それぞれの風景と営みがあります。気になる場所に、出会ってみませんか。",
+    url: `${currentCommunityConfig.domain}/places`,
+    type: "website",
+    locale: "ja_JP",
+    images: DEFAULT_OPEN_GRAPH_IMAGE,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${currentCommunityConfig.title} - 拠点一覧`,
+    description: "どこで、誰と、どんな時間を過ごすか。気になる場所に、出会ってみませんか。",
+    images: DEFAULT_OPEN_GRAPH_IMAGE,
+  },
+  alternates: {
+    canonical: `${currentCommunityConfig.domain}/places`,
+  },
+};

--- a/src/app/places/page.tsx
+++ b/src/app/places/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import PlaceMapView from "@/app/places/components/map/PlaceMapView";
+import usePlacePins from "@/app/places/hooks/usePlacePins";
+import usePlaceCards from "@/app/places/hooks/usePlaceCards";
+import LoadingIndicator from "@/components/shared/LoadingIndicator";
+import { useEffect, useRef } from "react";
+import { usePlaceQueryValues } from "@/app/places/hooks/usePlaceQueryValues";
+import { usePlaceQueryActions } from "@/app/places/hooks/usePlaceQueryActions";
+import PlaceListPage from "@/app/places/components/list/ListPage";
+import EmptyState from "@/components/shared/EmptyState";
+import { ErrorState } from '@/components/shared'
+
+export default function PlacesPage() {
+  const { selectedPlaceId, mode } = usePlaceQueryValues();
+  const { toggleMode, handlePlaceSelect } = usePlaceQueryActions();
+
+  const {
+    placePins,
+    loading: pinsLoading,
+    error: pinsError,
+    refetch: refetchPins,
+  } = usePlacePins();
+
+  const {
+    baseCards,
+    loading: cardsLoading,
+    error: cardsError,
+    refetch: refetchCards,
+  } = usePlaceCards();
+
+  const loading = mode === "map" ? pinsLoading : cardsLoading;
+  const error = mode === "map" ? pinsError : cardsError;
+
+  const refetchRef = useRef<(() => void) | null>(null);
+  useEffect(() => {
+    refetchRef.current = mode === "map" ? refetchPins : refetchCards;
+  }, [mode, refetchPins, refetchCards]);
+
+  if (loading) return <LoadingIndicator fullScreen />;
+
+  if (error) {
+    return <ErrorState title="拠点を読み込めませんでした" refetchRef={refetchRef} />;
+  }
+
+  if (!loading && placePins.length === 0) {
+    return <EmptyState title={"拠点"} />;
+  }
+
+  return (
+    <div className="h-screen w-full">
+      {mode === "list" ? (
+        <PlaceListPage
+          places={baseCards}
+          selectedPlaceId={selectedPlaceId}
+          onMapClick={toggleMode}
+        />
+      ) : (
+        <PlaceMapView
+          selectedPlaceId={selectedPlaceId}
+          onPlaceSelect={handlePlaceSelect}
+          toggleMode={toggleMode}
+          placePins={placePins}
+          places={baseCards}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/places/utils/marker.ts
+++ b/src/app/places/utils/marker.ts
@@ -1,0 +1,118 @@
+export const defaultImageUrl = "https://via.placeholder.com/200";
+
+// 影の設定を行う共通関数
+const setShadow = (ctx: CanvasRenderingContext2D, enabled: boolean = true) => {
+  if (enabled) {
+    ctx.shadowColor = "rgba(0, 0, 0, 0.5)";
+    ctx.shadowBlur = 12;
+    ctx.shadowOffsetX = 0;
+    ctx.shadowOffsetY = 2;
+  } else {
+    ctx.shadowColor = "transparent";
+    ctx.shadowBlur = 0;
+    ctx.shadowOffsetX = 0;
+    ctx.shadowOffsetY = 0;
+  }
+};
+
+// 円を描画する共通関数
+const drawCircle = (
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  radius: number,
+  color: string,
+) => {
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, 2 * Math.PI);
+  ctx.fillStyle = color;
+  ctx.fill();
+};
+
+export const drawCircleWithImage = async (
+  ctx: CanvasRenderingContext2D,
+  img: HTMLImageElement,
+  cx: number,
+  cy: number,
+  radius: number,
+  isMainImage: boolean,
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const loadImage = (src: string) => {
+      img.crossOrigin = "anonymous";
+      img.src = src;
+    };
+
+    img.onload = () => {
+      try {
+        // 影付きの白い外枠を描画
+        setShadow(ctx, true);
+        drawCircle(ctx, cx, cy, radius + 4, "#FFFFFF");
+
+        // 影をクリア
+        setShadow(ctx, false);
+
+        // 画像を描画
+        ctx.save();
+        ctx.beginPath();
+        ctx.arc(cx, cy, radius, 0, 2 * Math.PI);
+        ctx.clip();
+
+        const imgSize = radius * 2;
+        const imgAspect = img.width / img.height;
+        let sourceX = 0;
+        let sourceY = 0;
+        let sourceWidth = img.width;
+        let sourceHeight = img.height;
+
+        if (imgAspect > 1) {
+          sourceWidth = sourceHeight;
+          sourceX = (img.width - sourceWidth) / 2;
+        } else if (imgAspect < 1) {
+          sourceHeight = sourceWidth;
+          sourceY = (img.height - sourceHeight) / 2;
+        }
+
+        ctx.drawImage(
+          img,
+          sourceX,
+          sourceY,
+          sourceWidth,
+          sourceHeight,
+          cx - imgSize / 2,
+          cy - imgSize / 2,
+          imgSize,
+          imgSize,
+        );
+
+        ctx.restore();
+        resolve();
+      } catch (error) {
+        reject(error);
+      }
+    };
+
+    img.onerror = () => {
+      if (img.src !== defaultImageUrl) {
+        loadImage(defaultImageUrl);
+      } else {
+        try {
+          // 影付きの白い外枠を描画
+          setShadow(ctx, true);
+          drawCircle(ctx, cx, cy, radius + 4, "#FFFFFF");
+
+          // 影をクリア
+          setShadow(ctx, false);
+
+          // プレースホルダー円を描画
+          drawCircle(ctx, cx, cy, radius, isMainImage ? "#F0F0F0" : "#E0E0E0");
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      }
+    };
+
+    loadImage(img.src);
+  });
+};

--- a/src/lib/communities/metadata.ts
+++ b/src/lib/communities/metadata.ts
@@ -109,7 +109,7 @@ const COMMUNITY_BASE_CONFIG: Record<string, CommunityBaseConfig> = {
     logoPath: "/communities/neo88/logo.jpg",
     squareLogoPath: "/communities/neo88/logo-square.jpg",
     ogImagePath: "https://storage.googleapis.com/prod-civicship-storage-public/asset/neo88/ogp.jpg",
-    enableFeatures: ["opportunities", "points", "articles", "tickets", "prefectures", "quests"],
+    enableFeatures: ["opportunities", "places", "points", "articles", "tickets", "prefectures", "quests"],
     rootPath: "/opportunities",
     adminRootPath: "/admin/reservations",
   },


### PR DESCRIPTION
# feat: Restore /places feature and enable for neo88 community

## Summary

This PR restores the `/places` feature that was previously removed in PR #736. The places feature provides a map-based and list-based view of community locations/venues where activities take place.

**Changes:**
- Restored `src/app/places/` directory (28 files) from commit `bb2c0c77` (pre-deletion state)
- Added `"places"` to neo88's `enableFeatures` array in `metadata.ts`

The restored code uses the `Place` GraphQL query directly (not the membership participation views that were removed in API PR #472), so no API changes are required.

## Review & Testing Checklist for Human

This is a code restoration from ~2 months ago, so careful verification is needed:

- [ ] **Verify places page loads**: Navigate to `/places` on neo88 environment and confirm the page renders without errors
- [ ] **Test map view**: Verify Google Maps loads correctly with place markers
- [ ] **Test list view**: Toggle to list view and verify place cards display properly
- [ ] **Test place detail page**: Click on a place and verify `/places/[id]` page loads with correct data
- [ ] **Verify GraphQL queries**: Check browser network tab to confirm `GetPlaces` and `GetPlace` queries return expected data
- [ ] **Check BottomBar navigation**: Verify the "拠点" (places) link appears in the bottom navigation bar for neo88

**Recommended test plan:**
1. Deploy to dev environment for neo88 community
2. Navigate to the places page via BottomBar
3. Interact with map markers and switch between map/list views
4. Open a place detail page and verify all sections render

### Notes

- The restored code contains some neo88-specific hardcoded ordering logic (marked with TODO comments) - this is pre-existing behavior
- Lint passes with only pre-existing warnings (no new issues introduced)
- The `src/app/places/data/` directory already existed and was not part of the restoration

**Link to Devin run:** https://app.devin.ai/sessions/e8cec96dffbc4ec5b6429f0b2ad8626b
**Requested by:** Naoki Sakata (@709sakata)