### PR TITLE
fix: Preserve pageInfo for infinite scroll in donate member tab

### DIFF
--- a/src/app/wallets/donate/DonatePointPageClient.tsx
+++ b/src/app/wallets/donate/DonatePointPageClient.tsx
@@ -26,11 +26,10 @@ export default function DonatePointPageClient() {
   const [activeTab, setActiveTab] = useState<Tabs>(Tabs.History);
 
   // Grant と同じパターン: Client Component でデータ取得
-  const { members, loading, error, refetch, loadMoreRef, isLoadingMore } = useDonateMembers(
-    user?.id,
-  );
+  const { members, loading, error, refetch, loadMoreRef, isLoadingMore, walletsConnection } =
+    useDonateMembers(user?.id);
 
-  // members から initialConnection を作成
+  // members から initialConnection を作成（元のpageInfoを保持）
   const initialConnection = useMemo<GqlMembershipsConnection | null>(() => {
     if (members.length === 0) return null;
 
@@ -46,15 +45,15 @@ export default function DonatePointPageClient() {
 
     return {
       edges,
-      pageInfo: {
+      pageInfo: walletsConnection?.pageInfo ?? {
         hasNextPage: false,
         hasPreviousPage: false,
         startCursor: null,
         endCursor: null,
       },
-      totalCount: members.length,
+      totalCount: walletsConnection?.totalCount ?? members.length,
     };
-  }, [members]);
+  }, [members, walletsConnection]);
 
   const refetchRef = useRef<(() => void) | null>(null);
   useEffect(() => {

--- a/src/app/wallets/features/donate/hooks/useDonateMembers.ts
+++ b/src/app/wallets/features/donate/hooks/useDonateMembers.ts
@@ -13,9 +13,9 @@ export function useDonateMembers(currentUserId?: string) {
         const wallet = edge?.node;
         const user = wallet?.user;
         const pointStr = wallet?.currentPointView?.currentPoint;
-        
+
         if (!user || user.id === currentUserId) return null;
-        
+
         const currentPoint = pointStr ? BigInt(pointStr) : BigInt(0);
 
         return {
@@ -38,5 +38,6 @@ export function useDonateMembers(currentUserId?: string) {
     loadMoreRef,
     hasNextPage,
     isLoadingMore,
+    walletsConnection: data?.wallets, // 元のconnection情報を返す
   };
 }


### PR DESCRIPTION
- Return walletsConnection from useDonateMembers
- Use original pageInfo when creating initialConnection
- Fixes infinite scroll disappearing issue