### PR TITLE
Fix null capacity in repeated opportunity slots

### DIFF
--- a/src/app/admin/opportunities/features/editor/components/OpportunityFormEditor.tsx
+++ b/src/app/admin/opportunities/features/editor/components/OpportunityFormEditor.tsx
@@ -38,7 +38,6 @@ export const OpportunityFormEditor = ({
   // 開催枠専用保存フック（常に呼び出し、updateモード時のみ使用）
   const slotsBulkSave = useSlotsBulkSave({
     opportunityId: opportunityId || "",
-    capacity: editor.capacity,
   });
 
   // ヘッダー設定（formモード時のみ）
@@ -85,7 +84,7 @@ export const OpportunityFormEditor = ({
   const handleSlotsSave = useCallback(async () => {
     // 更新モード：開催枠のみサーバーに保存
     if (mode === "update" && opportunityId) {
-      const success = await slotsBulkSave.handleSave(editor.slots);
+      const success = await slotsBulkSave.handleSave(editor.slots, editor.capacity);
       if (success) {
         editor.resetSlotChanges();
         exitSlotsMode();

--- a/src/app/admin/opportunities/features/slots/hooks/useSlotsBulkSave.ts
+++ b/src/app/admin/opportunities/features/slots/hooks/useSlotsBulkSave.ts
@@ -7,7 +7,6 @@ import { convertSlotToDates } from "../../shared/utils/dateFormat";
 
 interface UseSlotsBulkSaveOptions {
   opportunityId: string;
-  capacity: number;
 }
 
 /**
@@ -16,12 +15,11 @@ interface UseSlotsBulkSaveOptions {
  */
 export const useSlotsBulkSave = ({
   opportunityId,
-  capacity,
 }: UseSlotsBulkSaveOptions) => {
   const [updateSlots, { loading }] = useUpdateOpportunitySlotsBulkMutation();
 
   const handleSave = useCallback(
-    async (slots: SlotData[]) => {
+    async (slots: SlotData[], capacity: number) => {
       // 新規作成スロット（idなし）
       const slotsToCreate = slots
         .filter((slot) => !slot.id)
@@ -61,7 +59,7 @@ export const useSlotsBulkSave = ({
         return false;
       }
     },
-    [opportunityId, capacity, updateSlots]
+    [opportunityId, updateSlots]
   );
 
   return {


### PR DESCRIPTION
## 問題
開催枠を繰り返し設定で作成すると、定員(capacity)がnullで保存される場合がありました。

## 原因
useSlotsBulkSaveフックが初期化時にcapacityの値を取得し、その後capacityが変更されても 古い値を使い続けていました。これは、capacityがフックの初期化時にクロージャーに
キャプチャされるため、後で親コンポーネントのcapacity状態が更新されても反映されない
ためです。

## 修正内容
1. useSlotsBulkSave: capacityをコンストラクタパラメータから削除し、handleSaveの 引数として受け取るように変更
2. OpportunityFormEditor: handleSlotsSave内でeditor.capacityを直接handleSaveに 渡すように変更

これにより、開催枠保存時に常に最新のcapacity値が使用されるようになりました。