### PR TITLE
fix: Handle null community config in /users/me page

### DIFF
--- a/src/app/users/me/page.tsx
+++ b/src/app/users/me/page.tsx
@@ -15,7 +15,8 @@ import { ArrowLeftRight } from "lucide-react";
 export default function MyProfilePage() {
   const { gqlUser, isOwner, portfolios } = useUserProfileContext();
   const { user: currentUser } = useAuth();
-  const { communityId } = useCommunityConfig();
+  const communityConfig = useCommunityConfig();
+  const communityId = communityConfig?.communityId;
   const t = useTranslations();
 
   // 管理者権限チェック


### PR DESCRIPTION
## Summary

Fixes a runtime error that occurs when users with unsaved Identity access `/users/me`. The `useCommunityConfig()` hook can return `null`, and directly destructuring `communityId` from it throws "Cannot destructure property 'communityId' of 'null'".

This change uses optional chaining to safely handle the null case.

## Review & Testing Checklist for Human

- [ ] **Test the fix**: Access `/users/me` while logged in with LINE but without a saved Identity (no user record in database). Verify the error "ページでエラーが発生しました" no longer appears.
- [ ] **Verify downstream behavior**: Confirm that `communityId` being `undefined` (instead of a string) doesn't break the admin role check logic in `hasAdminRole`.
- [ ] **Consider broader fix**: There are ~40 other files using the same unsafe destructuring pattern (`const { communityId } = useCommunityConfig()`). Evaluate if those need similar fixes.

### Notes

- Link to Devin run: https://app.devin.ai/sessions/fea350ccdfdd4ac48fee99dbd08b1dfb
- Requested by: @sigma-xing2 (Shinji NAKASHIMA)