### PR TITLE
fix: Always wrap children in UserProfileProvider in /users/me layout

### DIFF
--- a/src/app/users/me/layout.tsx
+++ b/src/app/users/me/layout.tsx
@@ -18,26 +18,20 @@ export default async function MyPageLayout({ children }: { children: React.React
     component: "MyPageLayout",
   });
 
-  if (gqlUser) {
-    const portfolios = (gqlUser.portfolios ?? []).map(mapGqlPortfolio);
+  const portfolios = gqlUser ? (gqlUser.portfolios ?? []).map(mapGqlPortfolio) : [];
 
-    return (
-      <UserProfileProvider
-        value={{
-          userId: gqlUser.id,
-          isOwner: true,
-          gqlUser,
-          portfolios,
-        }}
-      >
-        <ClientLayout ssrUser={gqlUser}>{children}</ClientLayout>
-      </UserProfileProvider>
-    );
-  }
-
-  logger.debug("[AUTH] /users/me layout: no SSR user, using ClientLayout with null", {
-    component: "MyPageLayout",
-  });
-
-  return <ClientLayout ssrUser={null}>{children}</ClientLayout>;
+  // Always wrap children in UserProfileProvider to prevent useUserProfileContext from throwing during SSR
+  // When gqlUser is null, ClientLayout will handle fetching the user client-side
+  return (
+    <UserProfileProvider
+      value={{
+        userId: gqlUser?.id,
+        isOwner: true,
+        gqlUser: gqlUser,
+        portfolios,
+      }}
+    >
+      <ClientLayout ssrUser={gqlUser}>{children}</ClientLayout>
+    </UserProfileProvider>
+  );
 }


### PR DESCRIPTION
## Summary

Fixes a Server Components render error that occurs when users with unsaved Identity (LINE authenticated but no user record in database) access `/users/me`. The error message was "ページでエラーが発生しました".

**Root cause**: When `gqlUser` is null, the layout was passing children directly to `ClientLayout` without wrapping them in `UserProfileProvider`. During SSR, `page.tsx` is evaluated and calls `useUserProfileContext()`, which throws because there's no provider.

**Fix**: Always wrap children in `UserProfileProvider`, even when `gqlUser` is null. When the user is fetched client-side by `ClientLayout`, it will create a nested `UserProfileProvider` that overrides the outer one with the actual user data.

## Review & Testing Checklist for Human

- [ ] **Critical: Test the actual scenario** - Access `/users/me` while LINE authenticated but without a saved Identity (no user record). Verify the error no longer appears and the user is properly redirected to phone verification.
- [ ] **Verify null handling** - Check that `page.tsx` and child components handle `gqlUser: null` and `userId: undefined` from context without crashing.
- [ ] **Verify nested provider behavior** - When `ClientLayout` fetches the user client-side and wraps children in another `UserProfileProvider`, confirm the inner provider correctly overrides the outer one.

### Notes

- This is a follow-up to PR #907 which fixed a related `useCommunityConfig()` destructuring issue but didn't fully resolve the problem.
- Link to Devin run: https://app.devin.ai/sessions/fea350ccdfdd4ac48fee99dbd08b1dfb
- Requested by: @sigma-xing2 (Shinji NAKASHIMA)