### PR TITLE
fix: prevent infinite loading on LINE login failure

### DIFF
--- a/src/graphql/account/community/query.ts
+++ b/src/graphql/account/community/query.ts
@@ -63,8 +63,9 @@ export const GET_COMMUNITY_PORTAL_CONFIG = gql`
       regionName
       regionKey
       liffId
+      liffAppId
       liffBaseUrl
       firebaseTenantId
     }
   }
-`; 
+`;  

--- a/src/lib/auth/init/firebase.ts
+++ b/src/lib/auth/init/firebase.ts
@@ -4,33 +4,53 @@ import { logger } from "@/lib/logging";
 import { LiffService } from "@/lib/auth/service/liff-service";
 import { User } from "@firebase/auth";
 
+export interface InitializeFirebaseResult {
+  user: User | null;
+  signInFailed: boolean;
+}
+
 export async function initializeFirebase(
   liffService: LiffService,
   environment: AuthEnvironment,
-): Promise<User | null> {
+): Promise<InitializeFirebaseResult> {
+  let signInFailed = false;
+
   if (environment === AuthEnvironment.LIFF) {
     try {
       await liffService.initialize();
       const liffState = liffService.getState();
       if (liffState.isLoggedIn) {
         try {
-          await liffService.signInWithLiffToken();
+          const success = await liffService.signInWithLiffToken();
+          if (!success) {
+            logger.warn("LIFF sign-in with token returned false - authentication failed");
+            signInFailed = true;
+          }
         } catch (signInErr) {
           logger.warn("LIFF sign-in with token failed", { err: signInErr });
+          signInFailed = true;
         }
       }
     } catch (initErr) {
       logger.warn("LIFF initialization failed", { err: initErr });
+      signInFailed = true;
     }
   }
 
-  return (
-    lineAuth.currentUser ??
-    (await new Promise((resolve) => {
+  // If sign-in explicitly failed, return null immediately to trigger unauthenticated state
+  // This prevents infinite loading when LIFF is logged in but Firebase sign-in fails
+  if (signInFailed) {
+    logger.debug("LIFF sign-in failed, returning null to trigger unauthenticated state");
+    return { user: null, signInFailed: true };
+  }
+
+  const user = lineAuth.currentUser ??
+    (await new Promise<User | null>((resolve) => {
       const unsub = lineAuth.onAuthStateChanged((u) => {
         unsub();
         resolve(u);
       });
-    }))
-  );
+    }));
+
+  return { user, signInFailed: false };
 }


### PR DESCRIPTION
## Summary

Fixes an issue where clicking the "LINEでログイン" button from an unauthenticated state causes an infinite loading state instead of showing an error or redirecting appropriately.

**Root cause:** When `signInWithLiffToken()` fails (e.g., due to LIFF ID mismatch or backend error), the error was caught but not properly propagated. The auth state remained stuck in "authenticating" because `handleUnauthenticatedBranch()` saw `liffState.isLoggedIn` as true and assumed token processing was still in progress.

**Changes:**
1. Added `liffAppId` to `GET_COMMUNITY_PORTAL_CONFIG` GraphQL query - this field was missing, causing the frontend to fall back to environment variables instead of using the backend's integrated config
2. Modified `initializeFirebase()` to return `{ user, signInFailed }` instead of just `User | null`, allowing callers to distinguish between "no user yet" and "sign-in explicitly failed"
3. Updated `initAuthFull()` to check `signInFailed` and immediately finalize as "unauthenticated" when LIFF sign-in fails

## Review & Testing Checklist for Human

- [ ] **Verify backend returns `liffAppId`**: Confirm the `communityPortalConfig` GraphQL query returns `liffAppId` for the "integrated" LINE config in the target environment
- [ ] **Test LINE login flow end-to-end**: From an unauthenticated state, click "LINEでログイン" and verify:
  - If LIFF sign-in succeeds: user is authenticated normally
  - If LIFF sign-in fails: user sees login screen (not infinite loading)
- [ ] **Check error logging**: When sign-in fails, verify appropriate warning logs appear in the console for debugging

**Recommended test plan:**
1. Deploy to a test environment with the backend's "integrated" LINE config
2. Clear all auth cookies/tokens and access the app
3. Click "LINEでログイン" and complete LINE OAuth
4. Verify the app either authenticates successfully or shows the login screen with an appropriate state (not infinite loading)

### Notes

- This fix addresses the symptom (infinite loading) but the underlying cause may be a LIFF ID mismatch between frontend and backend. If login still fails after this fix, verify that the `liffAppId` in the database matches the LIFF app configured in LINE Developers Console.
- The `signInWithLiffToken()` method already has retry logic (up to 3 attempts) for transient errors, so this fix only triggers for persistent failures.

Link to Devin run: https://app.devin.ai/sessions/b0e604d220d247daa50e5a3b2dfa622f
Requested by: Shinji NAKASHIMA (@sigma-xing2)