### PR TITLE
fix: handle signInWithLiffToken failure to prevent infinite loading

### DIFF
--- a/src/hooks/auth/actions/useLogin.ts
+++ b/src/hooks/auth/actions/useLogin.ts
@@ -22,7 +22,16 @@ export const useLogin = (liffService: LiffService, authStateManager: AuthStateMa
 
         const loggedIn = await liffService.login(redirectPath as any);
         if (loggedIn) {
-          await liffService.signInWithLiffToken();
+          const signedIn = await liffService.signInWithLiffToken();
+          if (!signedIn) {
+            logger.warn("LIFF signInWithLiffToken returned false", {
+              component: "useLogin",
+            });
+            if (authStateManager) {
+              authStateManager.updateState("unauthenticated", "signInWithLiffToken failed");
+            }
+            return;
+          }
         }
       } catch (error) {
         logger.warn("LIFF login failed", {

--- a/src/hooks/auth/sideEffects/useLineAuthProcessing.ts
+++ b/src/hooks/auth/sideEffects/useLineAuthProcessing.ts
@@ -55,7 +55,13 @@ export const useLineAuthProcessing = ({
             authType: "liff",
             component: "useLineAuthProcessing",
           });
-          return; // 🟠 stop: cannot init LIFF
+          // Update auth state to unauthenticated to prevent infinite loading
+          setState({
+            authenticationState: "unauthenticated",
+            isAuthenticating: false,
+          });
+          authStateManager.updateState("unauthenticated", "useLineAuthProcessing (LIFF init failed)");
+          return;
         }
 
         const { isLoggedIn } = liffService.getState();
@@ -73,7 +79,13 @@ export const useLineAuthProcessing = ({
               authType: "liff",
               component: "useLineAuthProcessing",
             });
-            return; // 🟠 stop: login token exchange failed
+            // Update auth state to unauthenticated to prevent infinite loading
+            setState({
+              authenticationState: "unauthenticated",
+              isAuthenticating: false,
+            });
+            authStateManager.updateState("unauthenticated", "useLineAuthProcessing (signInWithLiffToken failed)");
+            return;
           }
         }
 


### PR DESCRIPTION
## Summary

Fixes an issue where LINE mini-app users experience infinite loading when LIFF authentication fails. The root cause was that `signInWithLiffToken()` returning `false` was not being handled, leaving the auth state stuck in "authenticating" mode.

**Changes:**
- `useLogin.ts`: Check return value of `signInWithLiffToken()` and update auth state to "unauthenticated" on failure
- `useLineAuthProcessing.ts`: Update auth state to "unauthenticated" when LIFF initialization or token sign-in fails (previously just returned early without updating state)

## Review & Testing Checklist for Human

- [ ] **Test in LINE mini-app on staging**: Open https://miniapp.line.me/2008860770-jbw69xpu/neo88/users/me and verify auto-login works correctly
- [ ] **Test login button flow**: If auto-login fails, verify clicking the login button shows appropriate error state instead of infinite loading
- [ ] **Verify successful auth flow**: Ensure the fix doesn't break the happy path when authentication succeeds
- [ ] **Check for race conditions**: The auth state management is complex - verify no flickering or unexpected redirects occur

### Recommended Test Plan
1. Open the LINE mini-app URL on staging
2. If auto-login works, verify you're redirected to the correct page
3. If auto-login fails (e.g., due to backend config issues), verify you see the login page instead of infinite loading
4. Click the login button and verify the flow completes or shows an error (not infinite loading)

### Notes
- The underlying cause of `signInWithLiffToken()` failing may still need investigation (could be backend LINE config mismatch)
- This fix ensures graceful degradation when auth fails, rather than leaving users stuck

Link to Devin run: https://app.devin.ai/sessions/ffd96d77cff54e16b51441a3ebc5048c
Requested by: Shinji NAKASHIMA (@sigma-xing2)