### PR TITLE
Fix: Ensure proper community name and logo display in transactions

### DIFF
--- a/src/app/admin/wallet/data/presenter.ts
+++ b/src/app/admin/wallet/data/presenter.ts
@@ -1,22 +1,16 @@
 import { GqlTransaction, GqlWalletType } from "@/types/graphql";
 import { PLACEHOLDER_IMAGE } from "@/utils";
 
-export const getToWalletImage = (
-  node: GqlTransaction,
-  communitySquareLogoPath: string = ""
-): string => {
+export const getToWalletImage = (node: GqlTransaction): string => {
   if (node.toWallet?.type === GqlWalletType.Community) {
-    return communitySquareLogoPath || node.toWallet.community?.image || PLACEHOLDER_IMAGE;
+    return node.toWallet.community?.image || PLACEHOLDER_IMAGE;
   }
   return node.toWallet?.user?.image || PLACEHOLDER_IMAGE;
 };
 
-export const getFromWalletImage = (
-  node: GqlTransaction,
-  communitySquareLogoPath: string = ""
-): string => {
+export const getFromWalletImage = (node: GqlTransaction): string => {
   if (node.fromWallet?.type === GqlWalletType.Community) {
-    return communitySquareLogoPath || node.fromWallet.community?.image || PLACEHOLDER_IMAGE;
+    return node.fromWallet.community?.image || PLACEHOLDER_IMAGE;
   }
   return node.fromWallet?.user?.image || PLACEHOLDER_IMAGE;
 }

--- a/src/app/transactions/components/InfiniteTransactionList.tsx
+++ b/src/app/transactions/components/InfiniteTransactionList.tsx
@@ -6,7 +6,6 @@ import LoadingIndicator from "@/components/shared/LoadingIndicator";
 import { useInfiniteTransactions } from "@/hooks/transactions/useInfiniteTransactions";
 import { getServerCommunityTransactionsWithCursor } from "@/hooks/transactions/server-community-transactions";
 import { getFromWalletImage } from "@/app/admin/wallet/data/presenter";
-import { useCommunityConfig } from "@/contexts/CommunityConfigContext";
 
 interface InfiniteTransactionListProps {
   initialTransactions: GqlTransactionsConnection;
@@ -17,9 +16,6 @@ export const InfiniteTransactionList = ({
   initialTransactions,
   enableClickNavigation = false,
 }: InfiniteTransactionListProps) => {
-  const communityConfig = useCommunityConfig();
-  const communitySquareLogoPath = communityConfig?.squareLogoPath ?? "";
-
   const { transactions, hasNextPage, loading, loadMoreRef } = useInfiniteTransactions({
     initialTransactions,
     fetchMore: getServerCommunityTransactionsWithCursor,
@@ -28,7 +24,7 @@ export const InfiniteTransactionList = ({
   return (
     <div className="timeline-container">
       {transactions.map((transaction) => {
-        const image = getFromWalletImage(transaction, communitySquareLogoPath);
+        const image = getFromWalletImage(transaction);
         return (
           <TransactionCard
             key={transaction.id}

--- a/src/shared/transactions/components/InfiniteTransactionList.tsx
+++ b/src/shared/transactions/components/InfiniteTransactionList.tsx
@@ -7,7 +7,6 @@ import { useInfiniteTransactions } from "@/hooks/transactions/useInfiniteTransac
 import { getServerCommunityTransactionsWithCursor } from "@/hooks/transactions/server-community-transactions";
 import { getServerWalletTransactionsWithCursor } from "@/hooks/transactions/server-wallet-transactions";
 import { getCounterpartyImage, getFromWalletImage } from "@/shared/transactions/utils/images";
-import { useCommunityConfig } from "@/contexts/CommunityConfigContext";
 
 interface InfiniteTransactionListProps {
   initialTransactions: GqlTransactionsConnection;
@@ -25,9 +24,6 @@ export const InfiniteTransactionList = ({
   perspectiveWalletId,
   enableClickNavigation = false,
 }: InfiniteTransactionListProps) => {
-  const communityConfig = useCommunityConfig();
-  const communitySquareLogoPath = communityConfig?.squareLogoPath ?? "";
-
   const fetchMore = walletId
     ? (cursor?: string, first: number = 20) =>
         getServerWalletTransactionsWithCursor(walletId, cursor, first)
@@ -42,8 +38,8 @@ export const InfiniteTransactionList = ({
     <div className="timeline-container">
       {transactions.map((transaction, index) => {
         const image = perspectiveWalletId
-          ? getCounterpartyImage(transaction, perspectiveWalletId, communitySquareLogoPath)
-          : getFromWalletImage(transaction, communitySquareLogoPath);
+          ? getCounterpartyImage(transaction, perspectiveWalletId)
+          : getFromWalletImage(transaction);
         const isFirst = index === 0;
         const isLast = index === transactions.length - 1;
         return (

--- a/src/shared/transactions/utils/images.ts
+++ b/src/shared/transactions/utils/images.ts
@@ -1,22 +1,16 @@
 import { GqlTransaction, GqlWalletType } from "@/types/graphql";
 import { PLACEHOLDER_IMAGE } from "@/utils";
 
-export const getFromWalletImage = (
-  transaction: GqlTransaction,
-  communitySquareLogoPath: string = ""
-): string => {
+export const getFromWalletImage = (transaction: GqlTransaction): string => {
   if (transaction.fromWallet?.type === GqlWalletType.Community) {
-    return communitySquareLogoPath || transaction.fromWallet.community?.image || PLACEHOLDER_IMAGE;
+    return transaction.fromWallet.community?.image || PLACEHOLDER_IMAGE;
   }
   return transaction.fromWallet?.user?.image || PLACEHOLDER_IMAGE;
 };
 
-export const getToWalletImage = (
-  transaction: GqlTransaction,
-  communitySquareLogoPath: string = ""
-): string => {
+export const getToWalletImage = (transaction: GqlTransaction): string => {
   if (transaction.toWallet?.type === GqlWalletType.Community) {
-    return communitySquareLogoPath || transaction.toWallet.community?.image || PLACEHOLDER_IMAGE;
+    return transaction.toWallet.community?.image || PLACEHOLDER_IMAGE;
   }
   return transaction.toWallet?.user?.image || PLACEHOLDER_IMAGE;
 };
@@ -24,13 +18,12 @@ export const getToWalletImage = (
 export const getCounterpartyImage = (
   transaction: GqlTransaction,
   perspectiveWalletId: string,
-  communitySquareLogoPath: string = ""
 ): string => {
   const isOutgoing = transaction.fromWallet?.id === perspectiveWalletId;
   const counterpartyWallet = isOutgoing ? transaction.toWallet : transaction.fromWallet;
 
   if (counterpartyWallet?.type === GqlWalletType.Community) {
-    return communitySquareLogoPath || counterpartyWallet.community?.image || PLACEHOLDER_IMAGE;
+    return counterpartyWallet.community?.image || PLACEHOLDER_IMAGE;
   }
   return counterpartyWallet?.user?.image || PLACEHOLDER_IMAGE;
 };


### PR DESCRIPTION
### Description

This pull request addresses multiple issues related to the display of community names and logos in transaction pages, ensuring consistency and proper resolution.

**Key changes include:**
- Fixed community name display issues in the transaction detail page by correctly passing the `communityTitle` parameter to `getNameFromWallet`.
- Ensured `getTransactionInfo` now receives the required `communityTitle` for POINT_ISSUE, GRANT, and ONBOARDING transactions, enabling proper wallet name resolution.
- Reverted a prior change to the transaction avatars' logo usage for further review.
- Improved transaction avatars to display the community square logo for consistent UI.

### Checklist
- [ ] Code changes are tested and verified
- [ ] Documentation and comments are updated where applicable