### PR TITLE
fix: check membership before setting user_registered to avoid infinite redirect loop

### DIFF
--- a/src/lib/auth/init/index.ts
+++ b/src/lib/auth/init/index.ts
@@ -91,12 +91,19 @@ async function initAuthFast({
     const hasMembershipInCurrentCommunity = !!ssrCurrentUser.memberships?.some(
       (m) => m.community?.id === communityId
     );
-    const isFullyRegistered = ssrPhoneAuthenticated && hasMembershipInCurrentCommunity;
+    const hasPhoneIdentity = !!ssrCurrentUser.identities?.some(
+      (i) => i.platform?.toUpperCase() === "PHONE"
+    );
+    const isPhoneVerified =
+      !!ssrPhoneAuthenticated || hasPhoneIdentity || TokenManager.phoneVerified();
+    const isFullyRegistered = isPhoneVerified && hasMembershipInCurrentCommunity;
 
     logger.debug("[AUTH] initAuthFast: checking membership", {
       userId: ssrCurrentUser.id,
       communityId,
       ssrPhoneAuthenticated,
+      hasPhoneIdentity,
+      isPhoneVerified,
       hasMembershipInCurrentCommunity,
       isFullyRegistered,
       membershipIds: ssrCurrentUser.memberships?.map(m => m.community?.id) ?? [],


### PR DESCRIPTION
## Summary

Fixes an infinite redirect loop between `/users/me` and `/sign-up/phone-verification` that occurred when a user registered in one community (e.g., neo88) tried to access a different community (e.g., ubuyama) without membership.

**Root Cause**: `initAuthFast` and `applySsrAuthState` were setting `authenticationState` to `user_registered` based only on `ssrPhoneAuthenticated`, without checking if the user has membership in the **current** community. This caused:
1. User at `/users/me` → `handleRoleRestriction` redirects to `/sign-up/phone-verification` (no membership)
2. User at `/sign-up/phone-verification` → `handleAuthEntryFlow` with `user_registered` redirects back to `/users/me` (via `next` param)
3. Infinite loop

**Fix**: Added `hasMembershipInCurrentCommunity` and `isPhoneVerified` checks before setting `user_registered`, fully aligning with the existing logic in `evaluateUserRegistrationState` in `helper.ts`.

### Updates since last revision

Addressed Copilot review feedback: aligned phone verification logic to match `evaluateUserRegistrationState` exactly. Now `isPhoneVerified` checks all three sources:
- `ssrPhoneAuthenticated` (SSR flag)
- `hasPhoneIdentity` (user.identities with PHONE platform)
- `TokenManager.phoneVerified()` (client-side flag)

## Review & Testing Checklist for Human

- [ ] **Critical**: Test with a user who is registered in another community (e.g., neo88) but NOT in the target community (e.g., ubuyama) - verify they are directed to phone verification and can complete registration
- [ ] Verify existing users with membership in the current community can still log in normally
- [ ] Verify new users (no account anywhere) can complete the full registration flow
- [ ] Check that `TokenManager.savePhoneAuthFlag` being called only when `isFullyRegistered` doesn't break phone verification state for cross-community users
- [ ] Verify `TokenManager.phoneVerified()` behaves correctly in SSR hydration context

### Notes

- The fix adds debug logging to help trace membership and phone verification checks in production
- This change fully aligns `initAuthFast` and `applySsrAuthState` with the existing correct logic in `evaluateUserRegistrationState`

Link to Devin run: https://app.devin.ai/sessions/4c9184d413214ae78e667753fa3abece
Requested by: Shinji NAKASHIMA (@sigma-xing2)