### PR TITLE
fix: handle query-only navigation in useCommunityRouter

### DIFF
--- a/src/hooks/useCommunityRouter.ts
+++ b/src/hooks/useCommunityRouter.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter, useParams } from "next/navigation";
+import { useRouter, useParams, usePathname } from "next/navigation";
 import { useCallback, useMemo } from "react";
 
 /**
@@ -10,12 +10,19 @@ import { useCallback, useMemo } from "react";
 export function useCommunityRouter() {
   const router = useRouter();
   const params = useParams();
+  const pathname = usePathname();
   const communityId = params?.communityId as string | undefined;
 
   const buildHref = useCallback(
     (href: string) => {
       if (!communityId) {
         return href;
+      }
+
+      // Handle query-only navigation (e.g., "?tab=member")
+      // In this case, preserve the current pathname and just update the query params
+      if (href.startsWith("?")) {
+        return `${pathname}${href}`;
       }
 
       // Skip if already has communityId prefix or is external/absolute URL
@@ -32,7 +39,7 @@ export function useCommunityRouter() {
       const path = href.startsWith("/") ? href : `/${href}`;
       return `/${communityId}${path}`;
     },
-    [communityId]
+    [communityId, pathname]
   );
 
   return useMemo(


### PR DESCRIPTION
## Summary

Fixes a bug where `useCommunityRouter` incorrectly handled query-only navigation strings like `?tab=member`. Previously, calling `router.push("?tab=member")` would navigate to `/${communityId}/?tab=member` (the root path) instead of staying on the current page with updated query params.

This was causing the "メンバー" (member) tab on `/admin/wallet/grant` to redirect users to the top page when clicked.

The fix adds detection for query-only hrefs (strings starting with `?`) and preserves the current pathname in those cases.

## Review & Testing Checklist for Human

- [ ] **Test the member tab on `/admin/wallet/grant`**: Navigate to the grant page, click the "メンバー" tab, and verify it switches tabs without redirecting to the top page
- [ ] **Test other affected pages**: The same pattern is used in `/admin/credentials` (CredentialIssuanceWizard) and `/users/me/portfolios` (PortfolioTabs) - verify tab switching works on these pages
- [ ] **Verify normal navigation still works**: Test that `router.push("/admin/wallet")` and similar path-based navigation still correctly prepends the communityId

### Notes

- Link to Devin run: https://app.devin.ai/sessions/f798051fb31547388cac9d8ea2f303fb
- Requested by: Shinji NAKASHIMA (@sigma-xing2)