### PR TITLE
🔍 LINE認証のテナントID不一致エラーのデバッグログを追加

### DIFF
--- a/src/hooks/auth/actions/useLogin.ts
+++ b/src/hooks/auth/actions/useLogin.ts
@@ -24,6 +24,12 @@ export const useLogin = (liffService: LiffService, authStateManager: AuthStateMa
         const loggedIn = await liffService.login(redirectPath);
         if (!loggedIn) return false;
 
+        // 🔍 DEBUG: テナントIDパラメータを確認
+        logger.info("[useLogin] 🔍 DEBUG: Calling signInWithLiffToken", {
+          tenantIdParam: undefined,
+          note: "No tenant ID is being passed to signInWithLiffToken",
+        });
+
         return await liffService.signInWithLiffToken();
       } catch (error) {
         logger.warn("LIFF login failed", {

--- a/src/lib/auth/service/liff-service.ts
+++ b/src/lib/auth/service/liff-service.ts
@@ -247,20 +247,69 @@ export class LiffService {
           component: "LiffService",
         });
 
+        // 🔍 DEBUG: トークンから取得したテナントIDをログ出力
+        logger.info("[LiffService] 🔍 DEBUG: Decoded token tenant ID", {
+          tokenTenantId,
+          tokenTenantIdType: typeof tokenTenantId,
+          tokenTenantIdIsNull: tokenTenantId === null,
+          tokenTenantIdIsUndefined: tokenTenantId === undefined,
+          component: "LiffService",
+        });
+
         if (tenantId !== undefined) {
           lineAuth.tenantId = tenantId;
           logger.info("[LiffService] lineAuth.tenantId explicitly updated before sign-in", {
             newTenantId: lineAuth.tenantId,
             component: "LiffService",
           });
+        } else {
+          // 🔍 DEBUG: tenantIdが未定義の場合、トークンから取得したテナントIDを使用
+          logger.info("[LiffService] 🔍 DEBUG: tenantId parameter is undefined, using tokenTenantId", {
+            tokenTenantId,
+            currentLineAuthTenantId: lineAuth.tenantId,
+            component: "LiffService",
+          });
+
+          if (tokenTenantId !== null) {
+            lineAuth.tenantId = tokenTenantId;
+            logger.info("[LiffService] 🔍 DEBUG: Updated lineAuth.tenantId from token", {
+              newTenantId: lineAuth.tenantId,
+              component: "LiffService",
+            });
+          }
         }
 
-        const userCredential = await signInWithCustomToken(lineAuth, customToken);
-        logger.info("[LiffService] signInWithCustomToken success", {
-          uid: userCredential.user.uid,
-          tenantIdOnUser: userCredential.user.tenantId,
+        // 🔍 DEBUG: signInWithCustomToken実行直前の状態を記録
+        logger.info("[LiffService] 🔍 DEBUG: About to call signInWithCustomToken", {
+          lineAuthTenantId: lineAuth.tenantId,
+          tokenTenantId,
+          tenantIdMatch: lineAuth.tenantId === tokenTenantId,
           component: "LiffService",
         });
+
+        let userCredential;
+        try {
+          userCredential = await signInWithCustomToken(lineAuth, customToken);
+          logger.info("[LiffService] ✅ signInWithCustomToken success", {
+            uid: userCredential.user.uid,
+            tenantIdOnUser: userCredential.user.tenantId,
+            lineAuthTenantId: lineAuth.tenantId,
+            component: "LiffService",
+          });
+        } catch (signInError: any) {
+          // 🔍 DEBUG: signInWithCustomTokenのエラーを詳細にログ出力
+          logger.error("[LiffService] ❌ signInWithCustomToken failed", {
+            error: signInError?.message || String(signInError),
+            errorCode: signInError?.code,
+            errorName: signInError?.name,
+            lineAuthTenantId: lineAuth.tenantId,
+            tokenTenantId,
+            tenantIdMismatch: lineAuth.tenantId !== tokenTenantId,
+            customTokenPreview: customToken?.substring(0, 50) + "...",
+            component: "LiffService",
+          });
+          throw signInError;
+        }
 
         await Promise.race([
           new Promise<void>((resolve) => {
@@ -311,11 +360,18 @@ export class LiffService {
         return true;
       } catch (error) {
         const processedError = error instanceof Error ? error : new Error(String(error));
-        logger.error("[LiffService] signInWithLiffToken attempt failed", {
+
+        // 🔍 DEBUG: エラーの詳細情報を記録
+        const errorDetails: any = error;
+        logger.error("[LiffService] ❌ signInWithLiffToken attempt failed", {
           error: processedError.message,
+          errorCode: errorDetails?.code,
+          errorName: errorDetails?.name,
+          errorStack: errorDetails?.stack?.split('\n').slice(0, 3).join('\n'),
           tenantId,
           lineAuthTenantId: lineAuth.tenantId,
           attempt,
+          isTenantIdMismatch: processedError.message.includes('TENANT_ID_MISMATCH'),
           component: "LiffService",
         });
 


### PR DESCRIPTION
## 概要
TENANT_ID_MISMATCH エラーをデバッグするための詳細なログを追加しました。

## 問題
LINE認証時に以下のエラーが発生:
```
TENANT_ID_MISMATCH : Specified tenant ID does not match the custom token.
```

## 変更内容

### 1. `liff-service.ts`
- カスタムトークンからテナントIDをデコードしてログ出力
- `tenantId`パラメータが未定義の場合、トークンから取得したテナントIDを使用するロジックを追加
- `signInWithCustomToken`実行直前の状態（lineAuth.tenantIdとtokenTenantIdの比較）をログ出力
- `signInWithCustomToken`の成功/失敗時に詳細な情報をログ出力
- エラー発生時にテナントID不一致の有無を明示的に記録

### 2. `useLogin.ts`
- `signInWithLiffToken()`呼び出し時のパラメータをログ出力

## デバッグ方法
ログインを試行すると、ブラウザコンソールに🔍マークの付いたデバッグログが表示されます。以下の情報を確認できます:

- カスタムトークンに含まれるテナントID
- Firebase Authインスタンスに設定されているテナントID
- 両者が一致しているか
- エラー発生時の詳細情報

## 期待される効果
このログ情報により、以下を特定できます:
- カスタムトークンにテナントIDが正しく含まれているか
- Firebase Authインスタンスのテナントidが正しく設定されているか
- どのタイミングでテナントIDの不一致が発生しているか

## テスト
- [ ] ローカル環境でログイン試行し、デバッグログが正しく出力されることを確認
- [ ] ログ情報から原因を特定

## 関連Issue
N/A (デバッグ用のホットフィックス)