### PR TITLE
fix: sync pnpm-lock.yaml overrides with package.json

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   jws: '>=4.0.1'
   lodash: '>=4.17.23'
   mdast-util-to-hast: '>=13.2.1'
-  axios: '>=1.13.5'
+  axios: '>=1.13.6'
 
 importers:
 


### PR DESCRIPTION
pnpm-lock.yaml still had axios override as >=1.13.5 while package.json was updated to >=1.13.6, causing ERR_PNPM_LOCKFILE_CONFIG_MISMATCH in CI.

https://claude.ai/code/session_01QpDTT34zARfjmcUsyRTFXr