### PR TITLE
Remove patches directory copy from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ WORKDIR /app
 
 # 依存関係の定義ファイルを先にコピー (キャッシュのため)
 COPY package.json pnpm-lock.yaml ./
-COPY patches/ ./patches/
 
 # 依存関係をインストール
 RUN pnpm install


### PR DESCRIPTION
## Summary
Removed the `COPY patches/ ./patches/` instruction from the Dockerfile as it is no longer needed during the build process.

## Changes
- Removed the line that copies the `patches/` directory into the Docker image during the dependency installation stage

## Details
This change simplifies the Dockerfile by eliminating an unnecessary copy operation. The patches directory is no longer required as part of the build context for dependency installation, reducing the build complexity and potentially improving build performance.

https://claude.ai/code/session_018oDxSFxAnLy5kxcpvH1z4V