### PR TITLE
Exclude images and icons directories from middleware matcher

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -379,5 +379,5 @@ function getCommunityIdFromHost(host: string | null): string | null {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|robots.txt).*)"],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|robots.txt|images/|icons/).*)"],
 };


### PR DESCRIPTION
## Summary
Updated the middleware matcher configuration to exclude the `images/` and `icons/` directories from middleware processing, allowing these static assets to be served directly without middleware interception.

## Key Changes
- Modified the matcher pattern in `src/middleware.ts` to add `images/` and `icons/` to the exclusion list
- This prevents the middleware from processing requests to static image and icon assets, improving performance and reducing unnecessary middleware overhead for these resources

## Implementation Details
The matcher pattern now excludes:
- `_next/static` (Next.js static files)
- `_next/image` (Next.js image optimization)
- `favicon.ico` (favicon)
- `robots.txt` (robots file)
- `images/` (image assets directory)
- `icons/` (icon assets directory)

This change allows these static assets to bypass middleware processing and be served more efficiently.

https://claude.ai/code/session_01FUFth5yh3VUNMtRZuTmbRu