### PR TITLE
fix: initAuthFull でユーザー未取得 + stale cookie 残存時にセッションをクリア

### DIFF
--- a/src/lib/auth/init/index.ts
+++ b/src/lib/auth/init/index.ts
@@ -173,6 +173,21 @@ async function initAuthFull({
 
     const user = await restoreUserSession(communityConfig, ssrCurrentUser, firebaseUser, setState);
     if (!user) {
+      // セッションcookieが残存している場合はステールとしてクリア
+      // （バックエンドがauth/user-not-foundでfallback anonymousした可能性）
+      if (
+        typeof document !== "undefined" &&
+        document.cookie.split(";").some((c) => c.trim().startsWith("__session"))
+      ) {
+        logger.warn("[AUTH] User not found with session cookie present - clearing stale session", {
+          component: "initAuthFull",
+        });
+        try {
+          await fetch("/api/sessionLogout", { method: "POST" });
+        } catch (e) {
+          logger.warn("[AUTH] Failed to clear stale session cookie", { error: e });
+        }
+      }
       finalizeAuthState("unauthenticated", undefined, setState, authStateManager);
       return;
     }


### PR DESCRIPTION
バックエンドが verifySessionCookie で auth/user-not-found を検出して anonymous fallback (HTTP 200) を返す場合、Apollo error link では auth:token-expired イベントが発火せず stale cookie が残り続ける問題を修正。

restoreUserSession が null を返した（= バックエンドがユーザーを返さなかった） かつ __session cookie が存在する状態を stale session と判断し、
/api/sessionLogout を呼んでクリアする。

https://claude.ai/code/session_013Tw6nDmvPMAF2VZNoMCQV4