### PR TITLE
Migrate LIFF to LINE Mini App and use environment variable

### DIFF
--- a/src/app/community/[communityId]/layout.tsx
+++ b/src/app/community/[communityId]/layout.tsx
@@ -105,8 +105,6 @@ const CommunityLayout = async ({ children, params }: CommunityLayoutProps) => {
       isFromDatabase,
       configCommunityId: communityConfig?.communityId,
       hasFirebaseTenantId: !!communityConfig?.firebaseTenantId,
-      hasLiffId: !!communityConfig?.liffId,
-      hasLiffAppId: !!communityConfig?.liffAppId,
       component: "CommunityLayout",
     });
   } catch (error) {

--- a/src/graphql/account/community/query.ts
+++ b/src/graphql/account/community/query.ts
@@ -96,8 +96,6 @@ export const GET_COMMUNITY_PORTAL_CONFIG = gql`
       }
       regionName
       regionKey
-      liffId
-      liffBaseUrl
       firebaseTenantId
     }
   }

--- a/src/hooks/auth/init/useAuthDependencies.ts
+++ b/src/hooks/auth/init/useAuthDependencies.ts
@@ -7,7 +7,7 @@ import { CommunityPortalConfig } from "@/lib/communities/config";
 import { logger } from "@/lib/logging";
 
 export function useAuthDependencies(communityConfig: CommunityPortalConfig | null) {
-  const liffAppId = communityConfig?.liffAppId ?? undefined;
+  const miniAppLiffId = process.env.NEXT_PUBLIC_MINI_APP_LIFF_ID;
   const firebaseTenantId = communityConfig?.firebaseTenantId ?? null;
 
   useEffect(() => {
@@ -15,15 +15,15 @@ export function useAuthDependencies(communityConfig: CommunityPortalConfig | nul
       configIsNull: communityConfig === null,
       communityId: communityConfig?.communityId,
       firebaseTenantId,
-      liffAppId,
+      miniAppLiffId,
       component: "useAuthDependencies",
     });
-  }, [communityConfig, firebaseTenantId, liffAppId]);
+  }, [communityConfig, firebaseTenantId, miniAppLiffId]);
 
   const liffService = useMemo(() => {
     setLineAuthTenantId(firebaseTenantId);
-    return LiffService.getInstance(liffAppId);
-  }, [liffAppId, firebaseTenantId]);
+    return LiffService.getInstance(miniAppLiffId);
+  }, [miniAppLiffId, firebaseTenantId]);
 
   const phoneAuthService = useMemo(() => PhoneAuthService.getInstance(), []);
 

--- a/src/lib/auth/service/liff-service.ts
+++ b/src/lib/auth/service/liff-service.ts
@@ -45,7 +45,7 @@ export class LiffService {
   }
 
   public getLiffUrl(redirectPath?: string): string {
-    const baseUrl = `https://liff.line.me/${this.liffId}`;
+    const baseUrl = `https://miniapp.line.me/${this.liffId}`;
     if (!redirectPath) return baseUrl;
 
     const encodedNext = encodeURIComponent(redirectPath);

--- a/src/lib/communities/config.ts
+++ b/src/lib/communities/config.ts
@@ -24,9 +24,6 @@ export interface CommunityPortalConfig {
   commonDocumentOverrides: CommonDocumentOverridesConfig | null;
   regionName: string | null;
   regionKey: string | null;
-  liffId: string | null;
-  liffAppId: string | null;
-  liffBaseUrl: string | null;
   firebaseTenantId: string | null;
 }
 
@@ -84,9 +81,6 @@ const COMMUNITY_PORTAL_CONFIG_QUERY = `
       }
       regionName
       regionKey
-      liffId
-      liffAppId
-      liffBaseUrl
       firebaseTenantId
     }
   }
@@ -126,15 +120,13 @@ export const getCommunityConfig = cache(
         });
       } else {
         const nullFields = (
-          ["firebaseTenantId", "liffId", "liffAppId", "liffBaseUrl", "regionName", "regionKey"] as const
+          ["firebaseTenantId", "regionName", "regionKey"] as const
         ).filter((field) => config[field] == null);
 
         logger.info("[getCommunityConfig] Config fetched from DB", {
           communityId,
           configCommunityId: config.communityId,
           firebaseTenantId: config.firebaseTenantId,
-          liffId: config.liffId,
-          liffAppId: config.liffAppId,
           nullFields: nullFields.length > 0 ? nullFields : undefined,
           component: "getCommunityConfig",
         });

--- a/src/lib/communities/constants.ts
+++ b/src/lib/communities/constants.ts
@@ -47,7 +47,4 @@ export const COMMUNITY_LOCAL_CONFIGS: CommunityPortalConfig = {
   regionKey: null,
 
   firebaseTenantId: "himeji-ymca-5pdjx",
-  liffId: "2007838818",
-  liffAppId: "2007838818-VR4yRvgL",
-  liffBaseUrl: "https://liff.line.me/2007838818-VR4yRvgL",
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -267,6 +267,7 @@ function setSecurityHeaders(res: NextResponse, nonce: string) {
     "https://identitytoolkit.googleapis.com",
     "https://securetoken.googleapis.com",
     "https://liffsdk.line-scdn.net",
+    "https://miniapp.line-scdn.net",
     "https://www.google.com",
     "https://maps.googleapis.com",
     "https://firebase.googleapis.com",


### PR DESCRIPTION
## Summary
This PR migrates the LINE LIFF integration to the new LINE Mini App platform and updates the LIFF ID configuration to use an environment variable instead of database/config values.

## Key Changes
- **Environment-based configuration**: Changed `liffAppId` to use `process.env.NEXT_PUBLIC_MINI_APP_LIFF_ID` instead of reading from community config
- **Removed database fields**: Removed `liffId`, `liffAppId`, and `liffBaseUrl` from:
  - `CommunityPortalConfig` interface
  - GraphQL query definitions
  - Local config constants
  - Database query fields
- **Updated LIFF URL generation**: Changed base URL from `https://liff.line.me/` to `https://miniapp.line.me/` in LiffService
- **Updated security headers**: Added `https://miniapp.line-scdn.net` to CSP directives in middleware
- **Cleaned up logging**: Removed references to `liffId` and `liffAppId` from config logging

## Implementation Details
- The LIFF ID is now sourced from the `NEXT_PUBLIC_MINI_APP_LIFF_ID` environment variable, making it consistent across all communities
- This simplifies the configuration management by removing community-specific LIFF settings
- The Mini App SDK domain is now included in security headers to support the new platform

https://claude.ai/code/session_0111DwCGRE9HJF85pcJ5g9UX