### PR TITLE
ミニアプリへの移行

### DIFF
--- a/src/app/community/[communityId]/layout.tsx
+++ b/src/app/community/[communityId]/layout.tsx
@@ -104,8 +104,6 @@ const CommunityLayout = async ({ children, params }: CommunityLayoutProps) => {
       hasConfig: !!communityConfig,
       isFromDatabase,
       configCommunityId: communityConfig?.communityId,
-      hasLiffId: !!communityConfig?.liffId,
-      hasLiffAppId: !!communityConfig?.liffAppId,
       component: "CommunityLayout",
     });
   } catch (error) {

--- a/src/graphql/account/community/query.ts
+++ b/src/graphql/account/community/query.ts
@@ -96,8 +96,6 @@ export const GET_COMMUNITY_PORTAL_CONFIG = gql`
       }
       regionName
       regionKey
-      liffId
-      liffBaseUrl
     }
   }
 `;

--- a/src/hooks/auth/init/useAuthDependencies.ts
+++ b/src/hooks/auth/init/useAuthDependencies.ts
@@ -6,20 +6,20 @@ import { CommunityPortalConfig } from "@/lib/communities/config";
 import { logger } from "@/lib/logging";
 
 export function useAuthDependencies(communityConfig: CommunityPortalConfig | null) {
-  const liffAppId = communityConfig?.liffAppId ?? undefined;
+  const miniAppLiffId = process.env.NEXT_PUBLIC_MINI_APP_LIFF_ID;
 
   useEffect(() => {
     logger.info("[useAuthDependencies] Resolving auth dependencies", {
       configIsNull: communityConfig === null,
       communityId: communityConfig?.communityId,
-      liffAppId,
+      miniAppLiffId,
       component: "useAuthDependencies",
     });
-  }, [communityConfig, liffAppId]);
+  }, [communityConfig, miniAppLiffId]);
 
   const liffService = useMemo(() => {
-    return LiffService.getInstance(liffAppId);
-  }, [liffAppId]);
+    return LiffService.getInstance(miniAppLiffId);
+  }, [miniAppLiffId]);
 
   const phoneAuthService = useMemo(() => PhoneAuthService.getInstance(), []);
 

--- a/src/hooks/auth/init/useAuthDependencies.ts
+++ b/src/hooks/auth/init/useAuthDependencies.ts
@@ -9,6 +9,12 @@ export function useAuthDependencies(communityConfig: CommunityPortalConfig | nul
   const miniAppLiffId = process.env.NEXT_PUBLIC_MINI_APP_LIFF_ID;
 
   useEffect(() => {
+    if (!miniAppLiffId) {
+      logger.error(
+        "[useAuthDependencies] NEXT_PUBLIC_MINI_APP_LIFF_ID is not configured. LIFF/Mini App features will be unavailable.",
+        { component: "useAuthDependencies" },
+      );
+    }
     logger.info("[useAuthDependencies] Resolving auth dependencies", {
       configIsNull: communityConfig === null,
       communityId: communityConfig?.communityId,

--- a/src/lib/auth/service/liff-service.ts
+++ b/src/lib/auth/service/liff-service.ts
@@ -44,7 +44,7 @@ export class LiffService {
   }
 
   public getLiffUrl(redirectPath?: string): string {
-    const baseUrl = `https://liff.line.me/${this.liffId}`;
+    const baseUrl = `https://miniapp.line.me/${this.liffId}`;
     if (!redirectPath) return baseUrl;
 
     const encodedNext = encodeURIComponent(redirectPath);

--- a/src/lib/communities/config.ts
+++ b/src/lib/communities/config.ts
@@ -24,9 +24,6 @@ export interface CommunityPortalConfig {
   commonDocumentOverrides: CommonDocumentOverridesConfig | null;
   regionName: string | null;
   regionKey: string | null;
-  liffId: string | null;
-  liffAppId: string | null;
-  liffBaseUrl: string | null;
 }
 
 export interface CommunityDocumentConfig {
@@ -83,9 +80,6 @@ const COMMUNITY_PORTAL_CONFIG_QUERY = `
       }
       regionName
       regionKey
-      liffId
-      liffAppId
-      liffBaseUrl
     }
   }
 `;
@@ -124,14 +118,12 @@ export const getCommunityConfig = cache(
         });
       } else {
         const nullFields = (
-          ["liffId", "liffAppId", "liffBaseUrl", "regionName", "regionKey"] as const
+          ["regionName", "regionKey"] as const
         ).filter((field) => config[field] == null);
 
         logger.info("[getCommunityConfig] Config fetched from DB", {
           communityId,
           configCommunityId: config.communityId,
-          liffId: config.liffId,
-          liffAppId: config.liffAppId,
           nullFields: nullFields.length > 0 ? nullFields : undefined,
           component: "getCommunityConfig",
         });

--- a/src/lib/communities/constants.ts
+++ b/src/lib/communities/constants.ts
@@ -45,8 +45,4 @@ export const COMMUNITY_LOCAL_CONFIGS: CommunityPortalConfig = {
 
   regionName: null,
   regionKey: null,
-
-  liffId: "2007838818",
-  liffAppId: "2007838818-VR4yRvgL",
-  liffBaseUrl: "https://liff.line.me/2007838818-VR4yRvgL",
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -267,6 +267,7 @@ function setSecurityHeaders(res: NextResponse, nonce: string) {
     "https://identitytoolkit.googleapis.com",
     "https://securetoken.googleapis.com",
     "https://liffsdk.line-scdn.net",
+    "https://miniapp.line-scdn.net",
     "https://www.google.com",
     "https://maps.googleapis.com",
     "https://firebase.googleapis.com",


### PR DESCRIPTION
## Summary

- コミュニティごとに分散していた LIFF ID を廃止し、1 つの LINE Mini App チャンネル（環境変数 `NEXT_PUBLIC_MINI_APP_LIFF_ID`）に統一
- `CommunityPortalConfig` から LIFF 関連フィールド（`liffId` / `liffAppId` / `liffBaseUrl`）を削除
- `getLiffUrl()` の URL スキームを `liff.line.me` → `miniapp.line.me` に更新
- CSP `connect-src` に Mini App SDK ドメイン（`miniapp.line-scdn.net`）を追加

## 変更しないもの

- `liff.login()` のリダイレクトロジック（Web ブラウザアクセス用として維持）
- `liff.state` ディープリンク処理（Mini App でも同じ仕組みで動く）
- バックエンド認証エンドポイント（`/line/liff-login` を流用）

## 事前作業（別途必要）

- LINE Developers Console で Mini App チャンネルを作成
- 各環境に `NEXT_PUBLIC_MINI_APP_LIFF_ID` を設定
- Mini App チャンネルと Messaging API チャンネル（LINE OA）をリンク

## Test plan

- [ ] `NEXT_PUBLIC_MINI_APP_LIFF_ID` を設定して `pnpm dev` 起動、LIFF 初期化が成功することを確認
- [ ] LINE アプリ内で認証フローが通ることを確認
- [ ] Web ブラウザからアクセス時に LINE Login リダイレクトが正しく動くことを確認
- [ ] Deep link で正しいページに遷移することを確認
- [ ] `pnpm test` でユニットテスト通過確認
