### PR TITLE
fix: 429 retry in auth exchange, HTTP status in errorLink, communityId validation in middleware

### DIFF
--- a/src/app/api/auth/exchange/route.ts
+++ b/src/app/api/auth/exchange/route.ts
@@ -120,6 +120,8 @@ export async function POST(request: NextRequest) {
           status: first.status,
           component: "auth/exchange",
         });
+        // Drain the response body to release the connection back to the pool
+        await first.text().catch(() => {});
         await new Promise((r) => setTimeout(r, 2000));
         return doFetch();
       }

--- a/src/app/api/auth/exchange/route.ts
+++ b/src/app/api/auth/exchange/route.ts
@@ -102,14 +102,31 @@ export async function POST(request: NextRequest) {
     }
     const apiBase = apiEndpoint.replace(/\/graphql\/?$/, "");
 
-    const sessionRes = await fetch(`${apiBase}/sessionLogin`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(communityId ? { "X-Community-Id": communityId } : {}),
-      },
-      body: JSON.stringify({ idToken }),
-    });
+    // Retry helper for session login (handles transient 429 / 5xx from backend)
+    const createSession = async (): Promise<Response> => {
+      const doFetch = () =>
+        fetch(`${apiBase}/sessionLogin`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(communityId ? { "X-Community-Id": communityId } : {}),
+          },
+          body: JSON.stringify({ idToken }),
+        });
+
+      const first = await doFetch();
+      if (first.status === 429 || first.status >= 500) {
+        logger.info("[auth/exchange] Session login returned retryable status, retrying after delay", {
+          status: first.status,
+          component: "auth/exchange",
+        });
+        await new Promise((r) => setTimeout(r, 2000));
+        return doFetch();
+      }
+      return first;
+    };
+
+    const sessionRes = await createSession();
 
     // Build response with tokens
     const response = NextResponse.json({
@@ -127,13 +144,19 @@ export async function POST(request: NextRequest) {
     } else {
       // Session cookie is required for subsequent GraphQL requests in session mode.
       // If session creation fails, return error to prevent silent auth failure.
+      const isRateLimited = sessionRes.status === 429;
       logger.error("[auth/exchange] Session creation failed", {
         sessionStatus: sessionRes.status,
+        isRateLimited,
         component: "auth/exchange",
       });
       return NextResponse.json(
-        { error: "Session creation failed" },
-        { status: 502 },
+        {
+          error: isRateLimited
+            ? "Too many login attempts. Please try again later."
+            : "Session creation failed",
+        },
+        { status: sessionRes.status === 429 ? 429 : 502 },
       );
     }
 

--- a/src/lib/apollo.ts
+++ b/src/lib/apollo.ts
@@ -124,10 +124,16 @@ const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) 
   }
 
   if (networkError) {
-    if ("statusCode" in networkError && networkError.statusCode === 401) {
+    const statusCode = "statusCode" in networkError ? networkError.statusCode : undefined;
+    const responseBody =
+      "result" in networkError && networkError.result
+        ? JSON.stringify(networkError.result).substring(0, 200)
+        : undefined;
+
+    if (statusCode === 401) {
       logger.warn("Network authentication error", {
         error: networkError.message || String(networkError),
-        statusCode: networkError.statusCode,
+        statusCode,
         component: "ApolloErrorLink",
         operation: operation.operationName,
       });
@@ -141,6 +147,7 @@ const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) 
       if (isTemporaryNetworkIssue) {
         logger.warn("Network connectivity issue", {
           error: errorMessage,
+          statusCode,
           component: "ApolloErrorLink",
           operation: operation.operationName,
           errorCategory: "network_temporary",
@@ -149,6 +156,8 @@ const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) 
       } else {
         logger.warn("Network system error", {
           error: errorMessage,
+          statusCode,
+          responseBody,
           component: "ApolloErrorLink",
           operation: operation.operationName,
           errorCategory: "system_error",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -29,8 +29,16 @@ export async function middleware(request: NextRequest) {
   let communityIdSource = communityId ? "path" : null;
 
   if (!communityId) {
-    communityId = getCommunityIdFromHost(host);
-    if (communityId) communityIdSource = "host";
+    const hostCommunityId = getCommunityIdFromHost(host);
+    if (hostCommunityId && isValidCommunityId(hostCommunityId)) {
+      communityId = hostCommunityId;
+      communityIdSource = "host";
+    } else if (hostCommunityId) {
+      console.warn("[Middleware] Invalid communityId format from host, rejecting", {
+        hostCommunityId,
+        host,
+      });
+    }
   }
 
   // パスとホストで解決できない場合はクッキーからフォールバック
@@ -39,7 +47,7 @@ export async function middleware(request: NextRequest) {
   // コールバックがルート "/" に来ても communityId を特定できる必要がある。
   if (!communityId) {
     const cookieValue = request.cookies.get("x-community-id")?.value ?? null;
-    if (cookieValue && /^[a-zA-Z0-9-]+$/.test(cookieValue)) {
+    if (cookieValue && isValidCommunityId(cookieValue)) {
       communityId = cookieValue;
       communityIdSource = "cookie";
       console.log("[Middleware] communityId resolved from cookie", {
@@ -190,6 +198,15 @@ export async function middleware(request: NextRequest) {
  * /community/{communityId}/... 形式の場合に communityId を返す
  * ホワイトリストチェックは行わず、DB検証に委ねる
  */
+/**
+ * Validate communityId format: alphanumeric, hyphens, and underscores only.
+ * Rejects values like ".env" or other invalid/malicious inputs.
+ * Consistent with API-side validation in extractAuthHeaders.
+ */
+function isValidCommunityId(value: string): boolean {
+  return /^[a-zA-Z0-9_-]+$/.test(value);
+}
+
 function getCommunityIdFromPath(pathname: string): string | null {
   const match = pathname.match(/^\/community\/([a-zA-Z0-9-]+)/);
   return match ? match[1] : null;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -194,11 +194,6 @@ export async function middleware(request: NextRequest) {
 }
 
 /**
- * パスから communityId を抽出
- * /community/{communityId}/... 形式の場合に communityId を返す
- * ホワイトリストチェックは行わず、DB検証に委ねる
- */
-/**
  * Validate communityId format: alphanumeric, hyphens, and underscores only.
  * Rejects values like ".env" or other invalid/malicious inputs.
  * Consistent with API-side validation in extractAuthHeaders.
@@ -207,8 +202,13 @@ function isValidCommunityId(value: string): boolean {
   return /^[a-zA-Z0-9_-]+$/.test(value);
 }
 
+/**
+ * パスから communityId を抽出
+ * /community/{communityId}/... 形式の場合に communityId を返す
+ * ホワイトリストチェックは行わず、DB検証に委ねる
+ */
 function getCommunityIdFromPath(pathname: string): string | null {
-  const match = pathname.match(/^\/community\/([a-zA-Z0-9-]+)/);
+  const match = pathname.match(/^\/community\/([a-zA-Z0-9_-]+)/);
   return match ? match[1] : null;
 }
 


### PR DESCRIPTION
## Summary

Three production log-driven fixes in one PR:

1. **429 retry in `/api/auth/exchange`** (Step 13-3): When the backend `/sessionLogin` returns 429 (rate limited) or 5xx, the route now retries once after a 2-second delay before failing. If still rate-limited after retry, returns 429 with a user-facing message (`"Too many login attempts. Please try again later."`) instead of a generic 502.

2. **HTTP status in Apollo errorLink logs** (Steps 4-1, 4-2): Extracts `statusCode` and truncated `responseBody` from `networkError` and includes them in all log branches (not just the 401 branch). Enables distinguishing 429 vs 502 vs 500 errors in production log analysis.

3. **communityId format validation in middleware** (Step 16-2): Adds `isValidCommunityId()` (`/^[a-zA-Z0-9_-]+$/`) to validate community IDs extracted from path, host, and cookie sources. Rejects malicious/invalid values like `.env` at the edge before they reach the API. Consistent with API-side validation added in PR #779.

### Updates since last revision
- Fixed `getCommunityIdFromPath` regex to include underscore (`[a-zA-Z0-9_-]+`), consistent with `isValidCommunityId` (flagged by Devin Review and Gemini)
- Fixed JSDoc placement so each doc block sits directly above its function

## Review & Testing Checklist for Human

- [ ] **Auth exchange retry behavior**: Only 1 retry with a fixed 2s delay. Confirm this is sufficient given the backend rate limit window (currently 15 min / 30 requests per IP:communityId after PR #779). Consider whether the 429 response from the retry is correctly surfaced to the LIFF client calling this endpoint.
- [ ] **End-to-end login flow**: Test the full LIFF → exchange → sessionLogin flow in staging to verify that (a) successful logins still work, (b) 429 triggers the retry path, and (c) the user-facing error message renders correctly on the client side.
- [ ] **communityId validation coverage**: The path-based extraction now validates format via regex, host-based extraction validates via `isValidCommunityId` + `ACTIVE_COMMUNITY_IDS` whitelist, and cookie-based extraction uses `isValidCommunityId`. Verify no valid community IDs are accidentally rejected.

**Recommended test plan:**
1. Deploy to staging and perform a normal LIFF login → confirm session cookie is set correctly
2. Temporarily lower rate limit on staging and trigger a 429 → confirm retry fires (check logs for `"retrying after delay"`) and user sees `"Too many login attempts"` if retry also fails
3. Send a request with `communityId: ".env"` via path/cookie → confirm it's rejected at middleware level
4. Check production logs after deploy to confirm `statusCode` appears in Apollo errorLink entries

### Notes
- No unit tests added — these changes affect server-side API routes and middleware that are difficult to unit test without mocking Firebase/fetch. Staging verification recommended.
- The `responseBody` field in errorLink logs is truncated to 200 characters to avoid log bloat.
- The first response body from `createSession` is not consumed before retrying; this is intentional since only `status` is checked for the retry decision.

Link to Devin session: https://app.devin.ai/sessions/734a15a5627041458db8812571d01202
Requested by: @709sakata
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
