### PR TITLE
fix: SSR timeout differentiation + graceful fallback for membership list (Steps 8-2, 8-3)

### DIFF
--- a/src/lib/auth/init/getUserServer.ts
+++ b/src/lib/auth/init/getUserServer.ts
@@ -31,7 +31,7 @@ export async function getUserServer(): Promise<{
     const res = await executeServerGraphQLQuery<
       GqlCurrentUserServerQuery,
       GqlCurrentUserServerQueryVariables
-    >(GET_CURRENT_USER_SERVER_QUERY, {});
+    >(GET_CURRENT_USER_SERVER_QUERY, {}, {}, 8000); // Critical query: extended timeout (8s)
 
     const user: GqlUser | null = res.currentUser?.user ?? null;
     const hasPhoneIdentity = !!user?.identities?.some((i) => i.platform?.toUpperCase() === "PHONE");

--- a/src/lib/communities/config.ts
+++ b/src/lib/communities/config.ts
@@ -111,13 +111,30 @@ export const getCommunityConfig = cache(
       console.log(`[LOCAL] Response Local Config for ${communityId}, using static config.`);
       return COMMUNITY_LOCAL_CONFIGS;
     }
-    try {
+    const fetchConfig = async (): Promise<CommunityPortalConfig | null> => {
       const data = await executeServerGraphQLQuery<CommunityPortalConfigResponse>(
         COMMUNITY_PORTAL_CONFIG_QUERY,
         { communityId },
+        {},
+        8000, // Critical query: extended timeout (8s)
       );
+      return data.communityPortalConfig;
+    };
 
-      const config = data.communityPortalConfig;
+    try {
+      let config: CommunityPortalConfig | null;
+      try {
+        config = await fetchConfig();
+      } catch (firstError) {
+        // Retry once after 1s for transient failures (timeout, network errors)
+        logger.warn("[getCommunityConfig] First attempt failed, retrying after 1s", {
+          communityId,
+          error: firstError instanceof Error ? firstError.message : String(firstError),
+          component: "getCommunityConfig",
+        });
+        await new Promise((r) => setTimeout(r, 1000));
+        config = await fetchConfig();
+      }
 
       if (!config) {
         logger.warn("[getCommunityConfig] DB returned null for communityPortalConfig", {
@@ -142,7 +159,7 @@ export const getCommunityConfig = cache(
 
       return config;
     } catch (error) {
-      logger.error("[getCommunityConfig] Failed to fetch config from DB", {
+      logger.error("[getCommunityConfig] Failed to fetch config from DB (after retry)", {
         communityId,
         error: error instanceof Error ? error.message : String(error),
         errorType: error instanceof Error ? error.constructor.name : typeof error,

--- a/src/lib/graphql/getMembershipListServer.ts
+++ b/src/lib/graphql/getMembershipListServer.ts
@@ -45,10 +45,13 @@ export async function getMembershipListServer(
       connection: res.memberships,
     };
   } catch (error) {
-    logger.warn("⚠️ Failed to fetch membership list on server:", {
+    logger.warn("[getMembershipListServer] Failed to fetch membership list on server", {
       message: (error as Error).message,
-      stack: (error as Error).stack,
+      component: "getMembershipListServer",
     });
-    throw error;
+    // Graceful fallback: return null instead of throwing to avoid page errors
+    return {
+      connection: null,
+    };
   }
 }


### PR DESCRIPTION
## Summary

Addresses production GraphQL request timeout errors (22 occurrences in logs) by:

1. **Extended timeout for critical SSR queries** (5s → 8s):
   - `getCommunityConfig` (`CommunityPortalConfig` query) — required for page rendering; was the #1 timeout source (6 of 22)
   - `getUserServer` (`currentUserServer` query) — required for auth state hydration

2. **Retry logic for `getCommunityConfig`**: On failure, retries once after a 1s delay before returning `null`. This helps with transient API overload (logs showed 5 timeouts clustering within a 5-second window from a single page load).

3. **Graceful fallback for `getMembershipListServer`**: Previously re-threw errors, which could cause SSR page failures. Now returns `{ connection: null }` on error (the return type already permits `null`), allowing the page to render with an empty member list instead of erroring out.

Non-critical SSR queries (`GetMyWalletWithTransactions`, transaction queries) already had graceful fallback and keep the default 5s timeout.

## Review & Testing Checklist for Human

- [ ] **Verify all callers of `getMembershipListServer`** handle `connection: null` gracefully (renders empty list, not a crash). This is a **behavioral change** — previously errors propagated, now they're swallowed.
- [ ] **Evaluate worst-case latency**: `getCommunityConfig` can now take up to **17s** in the worst case (8s timeout + 1s delay + 8s retry) before returning `null`. Confirm this is acceptable vs. a faster fail.
- [ ] **Staging test**: Load a community page (e.g. `/community/izu/`) with API artificially slowed or under load. Verify the page eventually renders (possibly with partial data) rather than showing an error.

### Notes
- The retry in `getCommunityConfig` calls `fetchConfig()` directly (not `getCommunityConfig` itself), so it correctly bypasses React `cache` deduplication and makes a fresh API request on retry.
- Log messages updated to include `component` field consistently and to distinguish "after retry" failures.

Link to Devin session: https://app.devin.ai/sessions/734a15a5627041458db8812571d01202
Requested by: @709sakata
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
