### PR TITLE
Replace Next.js Image with SafeImage component and fix NFT ID range

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "retry": "^0.13.1",
+    "sharp": "^0.34.5",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "undici": "^7.22.0",
@@ -158,7 +159,8 @@
       "lodash": ">=4.17.23",
       "mdast-util-to-hast": ">=13.2.1",
       "axios": "1.14.0"
-    }
+    },
+    "onlyBuiltDependencies": ["sharp"]
   },
   "engines": {
     "node": ">=20.18.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       retry:
         specifier: ^0.13.1
         version: 0.13.1
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
@@ -10928,8 +10931,7 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
-  '@img/colour@1.0.0':
-    optional: true
+  '@img/colour@1.0.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -14573,8 +14575,7 @@ snapshots:
   detect-libc@1.0.3:
     optional: true
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
@@ -17706,7 +17707,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:

--- a/src/app/community/[communityId]/admin/nfts/components/NftItem.tsx
+++ b/src/app/community/[communityId]/admin/nfts/components/NftItem.tsx
@@ -2,7 +2,7 @@
 
 import { Item, ItemContent, ItemFooter, ItemTitle } from "@/components/ui/item";
 import { cn } from "@/lib/utils";
-import Image from "next/image";
+import { SafeImage } from "@/components/ui/safe-image";
 import { PLACEHOLDER_IMAGE } from "@/utils";
 import { getNftImageUrl } from "@/lib/nfts/image-helper";
 
@@ -62,12 +62,13 @@ export function NftItem({ nftInstance }: NftItemProps) {
 
         {/* --- RIGHT IMAGE (正方形) --- */}
         <div className="shrink-0 w-14 h-14 overflow-hidden rounded-md relative bg-muted">
-          <Image
-            src={imageUrl!}
+          <SafeImage
+            src={imageUrl}
             alt={nftInstance.name || "NFT"}
             fill
             className="object-cover"
             sizes="56px"
+            fallbackSrc={PLACEHOLDER_IMAGE}
           />
         </div>
       </a>

--- a/src/app/community/[communityId]/nfts/[id]/page.tsx
+++ b/src/app/community/[communityId]/nfts/[id]/page.tsx
@@ -4,7 +4,8 @@ import { useGetNftInstanceWithDidQuery } from "@/types/graphql";
 import { ErrorState, InfoCard } from "@/components/shared";
 import { InfoCardProps } from "@/types";
 import useHeaderConfig from "@/hooks/useHeaderConfig";
-import Image from "next/image";
+import { SafeImage } from "@/components/ui/safe-image";
+import { PLACEHOLDER_IMAGE } from "@/utils";
 import LoadingIndicator from "@/components/shared/LoadingIndicator";
 import { Button } from "@/components/ui/button";
 import { useNftDetailData } from "./lib/useNftDetailData";
@@ -87,12 +88,13 @@ export default function NftPage({ params }: { params: Promise<{ id: string }> })
     <>
       <div className="flex justify-center mt-10">
         <div>
-          <Image
+          <SafeImage
             src={getNftImageUrl(basic.imageUrl, basic.instanceId, basic.communityId)}
             alt={basic.instanceName ?? "証明書"}
             width={120}
             height={120}
             className="object-cover border-none shadow-none mx-auto rounded-sm"
+            fallbackSrc={PLACEHOLDER_IMAGE}
           />
           <h1 className="text-title-sm font-bold w-[70%] mx-auto mt-4 text-center">
             {basic.instanceName}

--- a/src/lib/nfts/image-helper.ts
+++ b/src/lib/nfts/image-helper.ts
@@ -2,11 +2,11 @@ import { PLACEHOLDER_IMAGE } from "@/utils";
 
 const IZU_COMMUNITY_ID = "izu";
 const IZU_NFT_ID_RANGE_START = 0;
-const IZU_NFT_ID_RANGE_END = 80;
+const IZU_NFT_ID_RANGE_END = 79;
 
 /**
  * NFT画像のURLを取得する
- * izuコミュニティのNFTの場合、instanceIdが0-80の範囲ならローカル画像を使用
+ * izuコミュニティのNFTの場合、instanceIdが0-79の範囲ならローカル画像を使用
  * それ以外は元のimageUrlを使用
  */
 export function getNftImageUrl(
@@ -16,7 +16,7 @@ export function getNftImageUrl(
 ): string {
   if (communityId === IZU_COMMUNITY_ID && instanceId) {
     const imageNumber = parseInt(instanceId, 10);
-    // 0-80の範囲ならローカル画像を使用 (1.jpg - 81.jpg)
+    // 0-79の範囲ならローカル画像を使用 (1.jpg - 80.jpg)
     if (!isNaN(imageNumber) && imageNumber >= IZU_NFT_ID_RANGE_START && imageNumber <= IZU_NFT_ID_RANGE_END) {
       return `/communities/${IZU_COMMUNITY_ID}/nfts/${imageNumber + 1}.jpg`;
     }


### PR DESCRIPTION
## Summary
This PR improves image handling in the NFT detail page by replacing the Next.js `Image` component with a custom `SafeImage` component that includes fallback support. Additionally, it corrects the NFT ID range validation for the Izu community.

## Key Changes
- **Image Component Migration**: Replaced `next/image` with `SafeImage` component in the NFT detail page (`src/app/community/[communityId]/nfts/[id]/page.tsx`)
  - Added `fallbackSrc` prop pointing to `PLACEHOLDER_IMAGE` for graceful degradation when images fail to load
  - Imported `PLACEHOLDER_IMAGE` utility constant

- **NFT ID Range Correction**: Fixed the Izu community NFT ID range validation in `src/lib/nfts/image-helper.ts`
  - Changed `IZU_NFT_ID_RANGE_END` from `80` to `79` to correctly represent the 0-79 range (80 total images: 1.jpg - 80.jpg)
  - Updated corresponding comments to reflect the accurate range

- **Dependencies**: Added `sharp` package as a build-only dependency in `package.json` (likely required by the `SafeImage` component for image optimization)

## Implementation Details
The `SafeImage` component provides better error handling compared to the standard Next.js Image component by allowing a fallback image to be displayed when the primary image URL fails to load. This improves the user experience when NFT images are unavailable or broken.

https://claude.ai/code/session_013jb9fnZHJPG4AYjQLCvF7Q
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
