### PR TITLE
fix: ミドルウェアのmatcherに/communities/を追加

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -341,5 +341,5 @@ function getCommunityIdFromHost(host: string | null): string | null {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|robots.txt|images/|icons/).*)"],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|robots.txt|images/|icons/|communities/).*)"],
 };


### PR DESCRIPTION
/_next/imageがローカル静的ファイル取得のため内部自己リクエストを送る際、
/communities/izu/nfts/*.jpgがミドルウェアに引っかかっていた。

ミドルウェア内でhostがlocalhostのためcommunityIdが'neo88'に解決され、 fetchCommunityConfigForEdge('neo88')がIzuのDB上で存在しないため404を返し、 /_next/imageが400を返していた。

communities/をmatcherの除外リストに追加することでミドルウェアをスキップし、
静的ファイルを直接サーブできるようにする。

https://claude.ai/code/session_013jb9fnZHJPG4AYjQLCvF7Q
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
