### PR TITLE
Fix hydration mismatch in AppLink by using context instead of client-side utility

### DIFF
--- a/src/contexts/CommunityConfigContext.tsx
+++ b/src/contexts/CommunityConfigContext.tsx
@@ -25,6 +25,15 @@ export function useCommunityConfig(): CommunityPortalConfig | null {
   return config;
 }
 
+/**
+ * CommunityConfigContext が存在しない場合も null を返す安全なバージョン
+ * AppLink など Provider 外でも使われる可能性があるコンポーネント向け
+ */
+export function useCommunityConfigOptional(): CommunityPortalConfig | null {
+  const context = useContext(CommunityConfigContext);
+  return context?.config ?? null;
+}
+
 export function useIsConfigFromDatabase(): boolean {
   const { isFromDatabase } = useCommunityConfigContext();
   return isFromDatabase;

--- a/src/lib/navigation/AppLink.tsx
+++ b/src/lib/navigation/AppLink.tsx
@@ -10,7 +10,7 @@
 import Link, { LinkProps } from "next/link";
 import { forwardRef, ReactNode, useMemo } from "react";
 
-import { getCommunityIdClient } from "@/lib/community";
+import { useCommunityConfigOptional } from "@/contexts/CommunityConfigContext";
 import { resolvePath } from "./path-resolver";
 
 type AppLinkProps = Omit<LinkProps, "href"> & {
@@ -55,14 +55,19 @@ export const AppLink = forwardRef<HTMLAnchorElement, AppLinkProps>(
     },
     ref
   ) {
+    // Context から取得した communityId は SSR と hydration の両方で一貫している。
+    // getCommunityIdClient() は typeof window !== "undefined" チェックを持つため、
+    // SSR では null を返すが hydration 時には cookie から値を読むため不一致が生じる。
+    const communityConfig = useCommunityConfigOptional();
+
     const resolvedHref = useMemo(() => {
       if (skipPathResolution) {
         return href;
       }
 
-      const communityId = explicitCommunityId ?? getCommunityIdClient();
+      const communityId = explicitCommunityId ?? communityConfig?.communityId ?? null;
       return resolvePath(href, communityId);
-    }, [href, skipPathResolution, explicitCommunityId]);
+    }, [href, skipPathResolution, explicitCommunityId, communityConfig?.communityId]);
 
     return (
       <Link ref={ref} href={resolvedHref} {...props}>


### PR DESCRIPTION
## Summary
Fixes a hydration mismatch in the `AppLink` component by replacing the client-side `getCommunityIdClient()` utility with the `useCommunityConfigOptional()` context hook. This ensures consistent `communityId` resolution between server-side rendering and client-side hydration.

## Key Changes
- **AppLink.tsx**: Replaced `getCommunityIdClient()` with `useCommunityConfigOptional()` hook to resolve community ID from context instead of client-side checks
- **CommunityConfigContext.tsx**: Added new `useCommunityConfigOptional()` hook that safely returns the community config or `null` when the context is unavailable, making it suitable for use in components that may exist outside the provider

## Implementation Details
The previous implementation used `getCommunityIdClient()` which performs a `typeof window !== "undefined"` check. This caused a mismatch because:
- During SSR: the check fails and returns `null`
- During hydration: the check passes and reads from cookies, returning an actual value

By switching to the context-based approach, the `communityId` is now consistently resolved from the same source (CommunityConfigContext) in both SSR and hydration phases, eliminating the mismatch. The new `useCommunityConfigOptional()` hook safely handles cases where the context might not be available by returning `null` instead of throwing an error.

https://claude.ai/code/session_01Aqy3hYua2M2byTY7839FFy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
