### PR TITLE
Add logo preview support to WalletCard component

### DIFF
--- a/src/app/community/[communityId]/admin/setting/components/CommunitySettingForm.tsx
+++ b/src/app/community/[communityId]/admin/setting/components/CommunitySettingForm.tsx
@@ -256,7 +256,12 @@ export function CommunitySettingForm({ editor, onSubmit }: CommunitySettingFormP
           <DialogHeader>
             <DialogTitle className="text-sm font-medium">ウォレットカードでの表示イメージ</DialogTitle>
           </DialogHeader>
-          <WalletCard currentPoint={0} isLoading={false} showRefreshButton={false} />
+          <WalletCard
+            currentPoint={0}
+            isLoading={false}
+            showRefreshButton={false}
+            logoOverride={logoPreviewUrl}
+          />
         </DialogContent>
       </Dialog>
 

--- a/src/components/shared/WalletCard.tsx
+++ b/src/components/shared/WalletCard.tsx
@@ -25,7 +25,8 @@ const WalletCard: React.FC<WalletCardProps> = ({
 }) => {
   const t = useTranslations();
   const communityConfig = useCommunityConfig();
-  const logoSrc = logoOverride ?? communityConfig?.logoPath;
+  // undefined（未指定）のときのみ context にフォールバック。null はプレビューで「未設定」を明示するため尊重する
+  const logoSrc = logoOverride !== undefined ? logoOverride : communityConfig?.logoPath;
 
   return (
     <div className="bg-background rounded-[32px] px-12 py-8 shadow-[0_2px_20px_rgba(0,0,0,0.08)] mt-8 mb-8">

--- a/src/components/shared/WalletCard.tsx
+++ b/src/components/shared/WalletCard.tsx
@@ -12,6 +12,8 @@ interface WalletCardProps {
   isLoading: boolean;
   onRefetch?: () => void | Promise<void>;
   showRefreshButton?: boolean;
+  // プレビュー用途などで logoPath を外部から差し替える
+  logoOverride?: string | null;
 }
 
 const WalletCard: React.FC<WalletCardProps> = ({
@@ -19,10 +21,12 @@ const WalletCard: React.FC<WalletCardProps> = ({
   isLoading,
   onRefetch,
   showRefreshButton = true,
+  logoOverride,
 }) => {
   const t = useTranslations();
   const communityConfig = useCommunityConfig();
-  
+  const logoSrc = logoOverride ?? communityConfig?.logoPath;
+
   return (
     <div className="bg-background rounded-[32px] px-12 py-8 shadow-[0_2px_20px_rgba(0,0,0,0.08)] mt-8 mb-8">
       <div className="flex flex-col items-center mb-12">
@@ -40,13 +44,15 @@ const WalletCard: React.FC<WalletCardProps> = ({
       </div>
 
       <div className="flex justify-between items-center">
-        {communityConfig?.logoPath && (
+        {logoSrc && (
           <Image
-            src={communityConfig.logoPath}
+            src={logoSrc}
             alt="Logo"
             width={80}
             height={24}
             className="opacity-60"
+            // blob: URL（プレビュー）は next/image の最適化を通せないため unoptimized にする
+            unoptimized={logoSrc.startsWith("blob:")}
           />
         )}
         {onRefetch && showRefreshButton && (


### PR DESCRIPTION
## Summary
Added the ability to override the community logo in the WalletCard component, enabling real-time preview of logo changes in the community settings form before saving.

## Key Changes
- **WalletCard component**: Added `logoOverride` prop to allow external logo replacement for preview purposes
- **Logo source logic**: Implemented fallback logic where `logoOverride` takes precedence over the default `communityConfig.logoPath`
- **Image optimization handling**: Added conditional `unoptimized` prop to handle blob URLs (used for previews) which cannot be processed through Next.js image optimization
- **CommunitySettingForm**: Updated the WalletCard preview dialog to pass the `logoPreviewUrl` via the new `logoOverride` prop

## Implementation Details
- The `logoOverride` prop is optional and defaults to `null`, maintaining backward compatibility
- Blob URLs are detected via `startsWith("blob:")` check to conditionally disable Next.js image optimization
- This allows users to see how their logo will appear on the wallet card in real-time while editing community settings

https://claude.ai/code/session_0116cdpwvPfKSP8Ytw2vjps1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
