### PR TITLE
Redirect to admin dashboard after community profile update

### DIFF
--- a/src/app/community/[communityId]/admin/setting/hooks/useCommunityProfileEditor.ts
+++ b/src/app/community/[communityId]/admin/setting/hooks/useCommunityProfileEditor.ts
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, FormEvent, ChangeEvent } from "react";
 import { useMutation } from "@apollo/client";
 import { toast } from "react-toastify";
 import { useTranslations } from "next-intl";
+import { useAppRouter } from "@/lib/navigation";
 import { UPDATE_PORTAL_CONFIG } from "@/graphql/account/community/mutation";
 import {
   useGetCommunityPortalConfigQuery,
@@ -30,6 +31,7 @@ interface FormErrors {
 
 export function useCommunityProfileEditor(communityId: string | undefined) {
   const t = useTranslations();
+  const router = useAppRouter();
 
   const { data, loading: queryLoading } = useGetCommunityPortalConfigQuery({
     variables: { communityId: communityId ?? "" },
@@ -174,6 +176,7 @@ export function useCommunityProfileEditor(communityId: string | undefined) {
         }
       }
       toast.success(t("adminSetting.form.success"));
+      router.push("/admin");
     } catch {
       toast.error(t("adminSetting.form.error.submit"));
     }


### PR DESCRIPTION
## Summary
Added automatic navigation to the admin dashboard upon successful community profile update in the community profile editor hook.

## Key Changes
- Imported `useAppRouter` hook from the navigation library
- Initialized the router instance in the `useCommunityProfileEditor` hook
- Added `router.push("/admin")` call after successful profile update to redirect users to the admin dashboard

## Implementation Details
The redirect is triggered immediately after the success toast notification is displayed, ensuring users are navigated away from the settings page once their changes have been saved successfully. This improves the user experience by providing clear navigation flow after completing the profile update action.

https://claude.ai/code/session_01WTn4FK5LH3EaZmguA6w8oo
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
