### PR TITLE
Fix toast notification centering on mobile devices

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -485,18 +485,17 @@ li {
   }
 }
 
-/* Keep top-center toasts horizontally centered on mobile.
-   react-toastify's default mobile CSS sets left: 0 / width: 100vw / translateX(0),
-   which breaks top-center alignment. */
-@media only screen and (max-width: 480px) {
-  .Toastify__toast-container--top-center {
-    top: 1em;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 90vw;
-    max-width: 425px;
-    padding: 4px;
-  }
+/* top-center コンテナの中央寄せ（モバイルファースト）。
+   react-toastify のデフォルト CSS は max-width: 480px のメディアクエリで
+   left: 0 / width: 100vw / translateX(0) に上書きしてしまうため、
+   これをベース（モバイル）側で打ち消す。 */
+.Toastify__toast-container--top-center {
+  top: 1em;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 90vw;
+  max-width: 425px;
+  padding: 4px;
 }
 
 .Toastify__toast--success {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -485,17 +485,18 @@ li {
   }
 }
 
-/* top-center コンテナの中央寄せ（モバイルファースト）。
-   react-toastify のデフォルト CSS は max-width: 480px のメディアクエリで
-   left: 0 / width: 100vw / translateX(0) に上書きしてしまうため、
-   これをベース（モバイル）側で打ち消す。 */
+/* top-center コンテナの中央寄せ（モバイルファースト・最小 override）。
+   react-toastify は max-width: 480px のメディアクエリで
+   top: 0 / left: 0 / translateX(0) に強制上書きしてしまうので、
+   ベースルールで再度中央寄せに戻す。
+   width / padding は上書きしないため、デスクトップ（320px コンテナ）の
+   見た目には影響しない。モバイル側は width: 100vw のままだが
+   max-width: 425px で上限をかける。 */
 .Toastify__toast-container--top-center {
   top: 1em;
   left: 50%;
   transform: translateX(-50%);
-  width: 90vw;
   max-width: 425px;
-  padding: 4px;
 }
 
 .Toastify__toast--success {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -485,6 +485,20 @@ li {
   }
 }
 
+/* Keep top-center toasts horizontally centered on mobile.
+   react-toastify's default mobile CSS sets left: 0 / width: 100vw / translateX(0),
+   which breaks top-center alignment. */
+@media only screen and (max-width: 480px) {
+  .Toastify__toast-container--top-center {
+    top: 1em;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 90vw;
+    max-width: 425px;
+    padding: 4px;
+  }
+}
+
 .Toastify__toast--success {
   border-left-color: hsl(var(--success));
 }

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -19,7 +19,6 @@ export function Toaster() {
       draggable
       pauseOnHover
       theme={resolvedTheme === "dark" ? "dark" : "light"}
-      style={{ maxWidth: "90vw" }}
       toastStyle={{ fontSize: "12px", minHeight: "auto" }}
     />
   );


### PR DESCRIPTION
## Summary
Fixed an issue where top-center toast notifications were not properly centered on mobile devices due to react-toastify's default mobile CSS overrides.

## Changes
- Added mobile-specific CSS rules for `.Toastify__toast-container--top-center` that override react-toastify's default mobile behavior
- Applied proper centering using `left: 50%` and `transform: translateX(-50%)` instead of the library's `left: 0 / width: 100vw` approach
- Set responsive width constraints (`90vw` with `max-width: 425px`) to ensure toasts don't stretch edge-to-edge on mobile
- Added appropriate padding and top spacing for better visual presentation on small screens

## Implementation Details
The fix targets screens with a maximum width of 480px and explicitly overrides react-toastify's default mobile CSS that was breaking the top-center alignment. The solution maintains proper centering while respecting mobile screen constraints.

https://claude.ai/code/session_01EeeT4TV4z8fvxUcmSAHNWR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
