### PR TITLE
Add NFT token management and voting topic update features

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -4242,6 +4242,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "NftTokenEdge",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "OpportunityEdge",
             "ofType": null
           },
@@ -4555,6 +4560,12 @@
           },
           {
             "name": "VALIDATION_ERROR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "VOTE_TOPIC_NOT_EDITABLE",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -10225,7 +10236,7 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
+                "kind": "UNION",
                 "name": "VoteCastPayload",
                 "ofType": null
               }
@@ -10235,7 +10246,7 @@
           },
           {
             "name": "voteTopicCreate",
-            "description": "管理者: 投票テーマ・ゲート・ポリシー・選択肢を 1 トランザクションで一括作成。\nGate と PowerPolicy のクロス検証（NFT トークンの一致等）は行わない。",
+            "description": "管理者: 投票テーマ・ゲート・ポリシー・選択肢を 1 トランザクションで一括作成。\nGate.type=NFT かつ PowerPolicy.type=NFT_COUNT の場合、両者の nftTokenId は\n一致していなければならない（バックエンドで検証、違反時は `VALIDATION_ERROR`）。\n詳細は VoteGate 型の説明を参照。",
             "args": [
               {
                 "name": "input",
@@ -10274,7 +10285,7 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
+                "kind": "UNION",
                 "name": "VoteTopicCreatePayload",
                 "ofType": null
               }
@@ -10284,7 +10295,7 @@
           },
           {
             "name": "voteTopicDelete",
-            "description": "管理者: 投票テーマ削除。\ngate / powerPolicy / options / ballots は onDelete: Cascade で自動削除される。",
+            "description": "管理者: 投票テーマ削除。UPCOMING フェーズ（投票開始前）のみ許可。\nOPEN / CLOSED フェーズでは `VOTE_TOPIC_NOT_EDITABLE` エラーが返る。\ngate / powerPolicy / options は onDelete: Cascade で自動削除される（UPCOMING 限定なので ballots は存在しない）。",
             "args": [
               {
                 "name": "id",
@@ -10323,8 +10334,73 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
+                "kind": "UNION",
                 "name": "VoteTopicDeletePayload",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "voteTopicUpdate",
+            "description": "管理者: 投票テーマを更新する。UPCOMING フェーズ（投票開始前）のみ許可。\nOPEN / CLOSED フェーズでは `VOTE_TOPIC_NOT_EDITABLE` エラーが返る。\noptions は全量置換される（UPCOMING なので投票0件が保証されており安全）。\ngate / powerPolicy も同時に再設定可能。",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "VoteTopicUpdateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "permission",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CheckCommunityPermissionInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "UNION",
+                "name": "VoteTopicUpdatePayload",
                 "ofType": null
               }
             },
@@ -11202,6 +11278,18 @@
             "deprecationReason": null
           },
           {
+            "name": "community",
+            "description": "トークンを所有するコミュニティ。複数コミュニティで共用する場合や運用都合で未設定の場合は null。\nportal 側の「このコミュニティに属する NftToken」一覧取得で参照される。",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Community",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createdAt",
             "description": null,
             "args": [],
@@ -11293,6 +11381,288 @@
               "kind": "SCALAR",
               "name": "Datetime",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "NftTokenEdge",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "NftToken",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Edge",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "NftTokenFilterInput",
+        "description": null,
+        "isOneOf": false,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "address",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "NftTokenFilterInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "communityId",
+            "description": "指定したコミュニティに直接紐付く NftToken に絞る（NftToken.community_id を直接参照）。\nNftToken.communityId が NULL のトークンは除外される。",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "NftTokenFilterInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "NftTokenFilterInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "NftTokenSortInput",
+        "description": null,
+        "isOneOf": false,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "address",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortDirection",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "NftTokensConnection",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "NftTokenEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -17421,6 +17791,100 @@
             "deprecationReason": null
           },
           {
+            "name": "nftToken",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "NftToken",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nftTokens",
+            "description": null,
+            "args": [
+              {
+                "name": "cursor",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "NftTokenFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "NftTokenSortInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "NftTokensConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "opportunities",
             "description": null,
             "args": [
@@ -22763,7 +23227,7 @@
       {
         "kind": "OBJECT",
         "name": "TransactionChain",
-        "description": null,
+        "description": "ポイントの旅（chain）の全体像。\ndepth はチェーンの長さ（ステップ数）、steps は古い順（起点→現在）に並ぶ。",
         "isOneOf": null,
         "fields": [
           {
@@ -22814,33 +23278,17 @@
       },
       {
         "kind": "OBJECT",
-        "name": "TransactionChainStep",
-        "description": null,
+        "name": "TransactionChainCommunity",
+        "description": "参加者がコミュニティ（COMMUNITY wallet の所有者）である場合の表現。\nid は Community.id。GRANT / ONBOARDING のような、community wallet から\n発行される transaction の起点ステップで登場する。",
         "isOneOf": null,
         "fields": [
           {
-            "name": "createdAt",
+            "name": "bio",
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Datetime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "fromUser",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "TransactionChainUser",
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,
@@ -22863,7 +23311,19 @@
             "deprecationReason": null
           },
           {
-            "name": "points",
+            "name": "image",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
             "description": null,
             "args": [],
             "type": {
@@ -22871,51 +23331,29 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "String",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "reason",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "TransactionReason",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "toUser",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "TransactionChainUser",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           }
         ],
         "inputFields": null,
-        "interfaces": [],
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "TransactionChainParticipant",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "TransactionChainUser",
-        "description": null,
+        "kind": "INTERFACE",
+        "name": "TransactionChainParticipant",
+        "description": "chain の 1 ステップに登場する参加者（User または Community）。\n共通フィールドを束ねた interface。実体の判別は __typename で行う。",
         "isOneOf": null,
         "fields": [
           {
@@ -22977,6 +23415,191 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "TransactionChainCommunity",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "TransactionChainUser",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "TransactionChainStep",
+        "description": "chain の1ステップ。ある transaction（ポイントの移動 1回分）に対応する。\nfrom が送信元、to が送信先。どちらも User または Community を表す\nTransactionChainParticipant interface で、__typename で判別できる。",
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "from",
+            "description": "送信元の参加者。\n- GRANT / ONBOARDING の起点ステップでは TransactionChainCommunity（community wallet 発）\n- それ以外のステップは TransactionChainUser\n- ウォレットが削除済み（退会済みユーザー等）の場合は null",
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "TransactionChainParticipant",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "points",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reason",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "TransactionReason",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "to",
+            "description": "送信先の参加者。\n現状の業務ロジックでは常に TransactionChainUser（MEMBER wallet 宛）。\nウォレットが削除済みの場合は null。",
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "TransactionChainParticipant",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "TransactionChainUser",
+        "description": "参加者がユーザー（MEMBER wallet の所有者）である場合の表現。\nid は User.id。",
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "bio",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "image",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "TransactionChainParticipant",
+            "ofType": null
+          }
+        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -26614,7 +27237,7 @@
           },
           {
             "name": "updatedAt",
-            "description": null,
+            "description": "再投票（upsert）時に現在時刻で更新される。初回投票時は null。",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26675,8 +27298,25 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
+        "kind": "UNION",
         "name": "VoteCastPayload",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "VoteCastSuccess",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "VoteCastSuccess",
         "description": null,
         "isOneOf": null,
         "fields": [
@@ -26705,7 +27345,7 @@
       {
         "kind": "OBJECT",
         "name": "VoteGate",
-        "description": "誰が投票できるか（資格ゲート）。\nVotePowerPolicy（何票持つか）とは**独立に設定される**。\nスキーマレベルでのクロス検証は行わないため、Gate=NFT(tokenA) + PowerPolicy=NFT_COUNT(tokenB)\nのような食い違いも作成可能。この場合 A のみ保有するユーザーは eligible=true / currentPower=0 になる。\n組み合わせの妥当性は呼び出し側（管理 UI 等）で担保すること。",
+        "description": "誰が投票できるか（資格ゲート）。\nVotePowerPolicy（何票持つか）とは**独立に設定される**が、両方が NFT 系\n（Gate.type=NFT かつ PowerPolicy.type=NFT_COUNT）の場合に限り、参照する\n**nftTokenId は一致していなければならない**（バックエンドで検証、違反時は\n`VALIDATION_ERROR`）。異なる token を指定した場合、A 保有者のうち B 非保有者が\neligible=true / currentPower=0 になる「投票しても効かない」状態が生じる設定ミスを防ぐため。\n\n許容される組み合わせ:\n- Gate=NFT(A) + Policy=NFT_COUNT(A)  典型的\n- Gate=MEMBERSHIP + Policy=NFT_COUNT(A)  メンバー内で NFT ホルダーのみ重み付け（非ホルダーは power=0）\n- Gate=NFT(A) + Policy=FLAT  A 保有者は一律 1 票\n- Gate=MEMBERSHIP + Policy=FLAT  全員 1 票",
         "isOneOf": null,
         "fields": [
           {
@@ -26886,7 +27526,7 @@
           },
           {
             "name": "orderIndex",
-            "description": null,
+            "description": "作成時（VoteOptionInput）に指定した値がそのまま保持される。\nVoteTopic.options は本フィールドの昇順で返るため、UI 側で追加のソートは不要。",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27218,7 +27858,7 @@
           },
           {
             "name": "options",
-            "description": null,
+            "description": "投票選択肢。orderIndex 昇順で返る（UI 側でのソートは不要）。",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27242,7 +27882,7 @@
           },
           {
             "name": "phase",
-            "description": null,
+            "description": "現在フェーズ。**レスポンス時点でサーバ時刻から計算される値**であり DB カラムではない。\n詳細は VoteTopicPhase の説明を参照。",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27467,8 +28107,25 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
+        "kind": "UNION",
         "name": "VoteTopicCreatePayload",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "VoteTopicCreateSuccess",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "VoteTopicCreateSuccess",
         "description": null,
         "isOneOf": null,
         "fields": [
@@ -27495,13 +28152,30 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
+        "kind": "UNION",
         "name": "VoteTopicDeletePayload",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "VoteTopicDeleteSuccess",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "VoteTopicDeleteSuccess",
         "description": null,
         "isOneOf": null,
         "fields": [
           {
-            "name": "id",
+            "name": "voteTopicId",
             "description": null,
             "args": [],
             "type": {
@@ -27594,6 +28268,179 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "VoteTopicUpdateInput",
+        "description": "voteTopicUpdate 用の入力。**既存の全フィールドを置き換える**（部分更新は未サポート）。\noptions は delete → create で全量置換される。gate / powerPolicy も同様に再生成されるため、\n既存の id 値は保持されない点に注意。UPCOMING フェーズ限定で呼ばれるため、投票は存在しない前提。",
+        "isOneOf": false,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "description",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endsAt",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "gate",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "VoteGateInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "options",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "VoteOptionInput",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "powerPolicy",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "VotePowerPolicyInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startsAt",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Datetime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "UNION",
+        "name": "VoteTopicUpdatePayload",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "VoteTopicUpdateSuccess",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "VoteTopicUpdateSuccess",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "voteTopic",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "VoteTopic",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {

--- a/src/app/community/[communityId]/transactions/components/TransactionChainTrail.stories.tsx
+++ b/src/app/community/[communityId]/transactions/components/TransactionChainTrail.stories.tsx
@@ -4,12 +4,12 @@ import { GqlGetTransactionDetailQuery, GqlTransactionReason } from "@/types/grap
 
 type Chain = NonNullable<NonNullable<GqlGetTransactionDetailQuery["transaction"]>["chain"]>;
 type Step = Chain["steps"][number];
-type ChainUser = NonNullable<Step["fromUser"] | Step["toUser"]>;
+type ChainParticipant = NonNullable<Step["from"] | Step["to"]>;
 
 const makeUser = (
   n: number,
   opts: { name?: string; bio?: string | null; image?: string | null } = {},
-): ChainUser => ({
+): ChainParticipant => ({
   __typename: "TransactionChainUser",
   id: `user-${n}`,
   name: opts.name ?? `ユーザー${n}`,
@@ -17,14 +17,18 @@ const makeUser = (
   bio: opts.bio === undefined ? `コミュニティで活動しているユーザー${n}の自己紹介。` : opts.bio,
 });
 
-const makeStep = (n: number, from: ChainUser | null, to: ChainUser | null): Step => ({
+const makeStep = (
+  n: number,
+  from: ChainParticipant | null,
+  to: ChainParticipant | null,
+): Step => ({
   __typename: "TransactionChainStep",
   id: `step-${n}`,
   points: 100,
   reason: GqlTransactionReason.Donation,
   createdAt: new Date(`2026-04-${String(n + 1).padStart(2, "0")}T09:00:00Z`),
-  fromUser: from,
-  toUser: to,
+  from,
+  to,
 });
 
 /**

--- a/src/app/community/[communityId]/transactions/components/TransactionChainTrail.tsx
+++ b/src/app/community/[communityId]/transactions/components/TransactionChainTrail.tsx
@@ -11,7 +11,7 @@ import { GqlGetTransactionDetailQuery } from "@/types/graphql";
 
 type Chain = NonNullable<NonNullable<GqlGetTransactionDetailQuery["transaction"]>["chain"]>;
 type Step = Chain["steps"][number];
-type ChainUser = NonNullable<Step["fromUser"] | Step["toUser"]>;
+type ChainParticipant = NonNullable<Step["from"] | Step["to"]>;
 
 interface TransactionChainTrailProps {
   chain?: Chain | null;
@@ -74,17 +74,17 @@ export const TransactionChainTrail = ({ chain }: TransactionChainTrailProps) => 
  * chain.steps からユーザーの時系列列を作る（古い → 新しい）。
  * null のユーザー（退会済み等）は位置を保つため null のまま残し、描画側でプレースホルダ表示する。
  */
-const buildTrailNodes = (chain: Chain | null | undefined): (ChainUser | null)[] => {
+const buildTrailNodes = (chain: Chain | null | undefined): (ChainParticipant | null)[] => {
   if (!chain || chain.depth < 2 || chain.steps.length === 0) return [];
 
   return [
-    chain.steps[0]?.fromUser ?? null,
-    ...chain.steps.map((step) => step.toUser ?? null),
+    chain.steps[0]?.from ?? null,
+    ...chain.steps.map((step) => step.to ?? null),
   ];
 };
 
 interface ChainNodeItemProps {
-  node: ChainUser | null;
+  node: ChainParticipant | null;
   isFirst: boolean;
   isLast: boolean;
 }
@@ -122,9 +122,14 @@ const ChainNodeItem = ({ node, isFirst, isLast }: ChainNodeItemProps) => {
     );
   }
 
+  const href =
+    node.__typename === "TransactionChainCommunity"
+      ? `/community/${node.id}`
+      : `/users/${node.id}`;
+
   return (
     <AppLink
-      href={`/users/${node.id}`}
+      href={href}
       className={cn(
         "relative flex gap-3 timeline-item",
         !isLast && "pb-10",

--- a/src/app/community/[communityId]/transactions/components/TransactionChainTrail.tsx
+++ b/src/app/community/[communityId]/transactions/components/TransactionChainTrail.tsx
@@ -71,8 +71,8 @@ export const TransactionChainTrail = ({ chain }: TransactionChainTrailProps) => 
 };
 
 /**
- * chain.steps からユーザーの時系列列を作る（古い → 新しい）。
- * null のユーザー（退会済み等）は位置を保つため null のまま残し、描画側でプレースホルダ表示する。
+ * chain.steps から参加者（User / Community）の時系列列を作る（古い → 新しい）。
+ * null の参加者（wallet 削除済み等）は位置を保つため null のまま残し、描画側でプレースホルダ表示する。
  */
 const buildTrailNodes = (chain: Chain | null | undefined): (ChainParticipant | null)[] => {
   if (!chain || chain.depth < 2 || chain.steps.length === 0) return [];

--- a/src/app/community/[communityId]/transactions/components/TransactionChainTrail.tsx
+++ b/src/app/community/[communityId]/transactions/components/TransactionChainTrail.tsx
@@ -122,20 +122,8 @@ const ChainNodeItem = ({ node, isFirst, isLast }: ChainNodeItemProps) => {
     );
   }
 
-  const href =
-    node.__typename === "TransactionChainCommunity"
-      ? `/community/${node.id}`
-      : `/users/${node.id}`;
-
-  return (
-    <AppLink
-      href={href}
-      className={cn(
-        "relative flex gap-3 timeline-item",
-        !isLast && "pb-10",
-        "rounded-md -mx-1 px-1 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800/50",
-      )}
-    >
+  const inner = (
+    <>
       <div className={railClasses}>
         <Avatar className="h-10 w-10 shrink-0 border">
           <AvatarImage src={node.image ?? ""} alt={node.name} />
@@ -150,6 +138,33 @@ const ChainNodeItem = ({ node, isFirst, isLast }: ChainNodeItemProps) => {
           </p>
         )}
       </div>
+    </>
+  );
+
+  if (node.__typename === "TransactionChainCommunity") {
+    return (
+      <div
+        className={cn(
+          "relative flex gap-3 timeline-item",
+          !isLast && "pb-10",
+          "-mx-1 px-1",
+        )}
+      >
+        {inner}
+      </div>
+    );
+  }
+
+  return (
+    <AppLink
+      href={`/users/${node.id}`}
+      className={cn(
+        "relative flex gap-3 timeline-item",
+        !isLast && "pb-10",
+        "rounded-md -mx-1 px-1 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800/50",
+      )}
+    >
+      {inner}
     </AppLink>
   );
 };

--- a/src/graphql/transaction/query.ts
+++ b/src/graphql/transaction/query.ts
@@ -81,17 +81,35 @@ export const GET_TRANSACTION_DETAIL = gql`
           points
           reason
           createdAt
-          fromUser {
-            id
-            name
-            image
-            bio
+          from {
+            __typename
+            ... on TransactionChainUser {
+              id
+              name
+              image
+              bio
+            }
+            ... on TransactionChainCommunity {
+              id
+              name
+              image
+              bio
+            }
           }
-          toUser {
-            id
-            name
-            image
-            bio
+          to {
+            __typename
+            ... on TransactionChainUser {
+              id
+              name
+              image
+              bio
+            }
+            ... on TransactionChainCommunity {
+              id
+              name
+              image
+              bio
+            }
           }
         }
       }

--- a/src/graphql/transaction/query.ts
+++ b/src/graphql/transaction/query.ts
@@ -83,33 +83,17 @@ export const GET_TRANSACTION_DETAIL = gql`
           createdAt
           from {
             __typename
-            ... on TransactionChainUser {
-              id
-              name
-              image
-              bio
-            }
-            ... on TransactionChainCommunity {
-              id
-              name
-              image
-              bio
-            }
+            id
+            name
+            image
+            bio
           }
           to {
             __typename
-            ... on TransactionChainUser {
-              id
-              name
-              image
-              bio
-            }
-            ... on TransactionChainCommunity {
-              id
-              name
-              image
-              bio
-            }
+            id
+            name
+            image
+            bio
           }
         }
       }

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -512,6 +512,7 @@ export const GqlErrorCode = {
   UnsupportedGrantType: "UNSUPPORTED_GRANT_TYPE",
   UnsupportedTransactionReason: "UNSUPPORTED_TRANSACTION_REASON",
   ValidationError: "VALIDATION_ERROR",
+  VoteTopicNotEditable: "VOTE_TOPIC_NOT_EDITABLE",
 } as const;
 
 export type GqlErrorCode = (typeof GqlErrorCode)[keyof typeof GqlErrorCode];
@@ -962,14 +963,24 @@ export type GqlMutation = {
   voteCast: GqlVoteCastPayload;
   /**
    * 管理者: 投票テーマ・ゲート・ポリシー・選択肢を 1 トランザクションで一括作成。
-   * Gate と PowerPolicy のクロス検証（NFT トークンの一致等）は行わない。
+   * Gate.type=NFT かつ PowerPolicy.type=NFT_COUNT の場合、両者の nftTokenId は
+   * 一致していなければならない（バックエンドで検証、違反時は `VALIDATION_ERROR`）。
+   * 詳細は VoteGate 型の説明を参照。
    */
   voteTopicCreate: GqlVoteTopicCreatePayload;
   /**
-   * 管理者: 投票テーマ削除。
-   * gate / powerPolicy / options / ballots は onDelete: Cascade で自動削除される。
+   * 管理者: 投票テーマ削除。UPCOMING フェーズ（投票開始前）のみ許可。
+   * OPEN / CLOSED フェーズでは `VOTE_TOPIC_NOT_EDITABLE` エラーが返る。
+   * gate / powerPolicy / options は onDelete: Cascade で自動削除される（UPCOMING 限定なので ballots は存在しない）。
    */
   voteTopicDelete: GqlVoteTopicDeletePayload;
+  /**
+   * 管理者: 投票テーマを更新する。UPCOMING フェーズ（投票開始前）のみ許可。
+   * OPEN / CLOSED フェーズでは `VOTE_TOPIC_NOT_EDITABLE` エラーが返る。
+   * options は全量置換される（UPCOMING なので投票0件が保証されており安全）。
+   * gate / powerPolicy も同時に再設定可能。
+   */
+  voteTopicUpdate: GqlVoteTopicUpdatePayload;
 };
 
 export type GqlMutationArticleCreateArgs = {
@@ -1272,6 +1283,12 @@ export type GqlMutationVoteTopicDeleteArgs = {
   permission: GqlCheckCommunityPermissionInput;
 };
 
+export type GqlMutationVoteTopicUpdateArgs = {
+  id: Scalars["ID"]["input"];
+  input: GqlVoteTopicUpdateInput;
+  permission: GqlCheckCommunityPermissionInput;
+};
+
 /** ログインユーザーの投票資格と現状。再投票可能性の判定にも利用する。 */
 export type GqlMyVoteEligibility = {
   __typename?: "MyVoteEligibility";
@@ -1372,6 +1389,11 @@ export type GqlNftInstancesConnection = {
 export type GqlNftToken = {
   __typename?: "NftToken";
   address: Scalars["String"]["output"];
+  /**
+   * トークンを所有するコミュニティ。複数コミュニティで共用する場合や運用都合で未設定の場合は null。
+   * portal 側の「このコミュニティに属する NftToken」一覧取得で参照される。
+   */
+  community?: Maybe<GqlCommunity>;
   createdAt: Scalars["Datetime"]["output"];
   id: Scalars["ID"]["output"];
   json?: Maybe<Scalars["JSON"]["output"]>;
@@ -1379,6 +1401,38 @@ export type GqlNftToken = {
   symbol?: Maybe<Scalars["String"]["output"]>;
   type: Scalars["String"]["output"];
   updatedAt?: Maybe<Scalars["Datetime"]["output"]>;
+};
+
+export type GqlNftTokenEdge = GqlEdge & {
+  __typename?: "NftTokenEdge";
+  cursor: Scalars["String"]["output"];
+  node: GqlNftToken;
+};
+
+export type GqlNftTokenFilterInput = {
+  address?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  and?: InputMaybe<Array<GqlNftTokenFilterInput>>;
+  /**
+   * 指定したコミュニティに直接紐付く NftToken に絞る（NftToken.community_id を直接参照）。
+   * NftToken.communityId が NULL のトークンは除外される。
+   */
+  communityId?: InputMaybe<Scalars["ID"]["input"]>;
+  not?: InputMaybe<GqlNftTokenFilterInput>;
+  or?: InputMaybe<Array<GqlNftTokenFilterInput>>;
+  type?: InputMaybe<Array<Scalars["String"]["input"]>>;
+};
+
+export type GqlNftTokenSortInput = {
+  address?: InputMaybe<GqlSortDirection>;
+  createdAt?: InputMaybe<GqlSortDirection>;
+  name?: InputMaybe<GqlSortDirection>;
+};
+
+export type GqlNftTokensConnection = {
+  __typename?: "NftTokensConnection";
+  edges: Array<GqlNftTokenEdge>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type GqlNftWallet = {
@@ -1981,6 +2035,8 @@ export type GqlQuery = {
   myWallet?: Maybe<GqlWallet>;
   nftInstance?: Maybe<GqlNftInstance>;
   nftInstances: GqlNftInstancesConnection;
+  nftToken?: Maybe<GqlNftToken>;
+  nftTokens: GqlNftTokensConnection;
   opportunities: GqlOpportunitiesConnection;
   opportunity?: Maybe<GqlOpportunity>;
   opportunitySlot?: Maybe<GqlOpportunitySlot>;
@@ -2125,6 +2181,17 @@ export type GqlQueryNftInstancesArgs = {
   filter?: InputMaybe<GqlNftInstanceFilterInput>;
   first?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<GqlNftInstanceSortInput>;
+};
+
+export type GqlQueryNftTokenArgs = {
+  id: Scalars["ID"]["input"];
+};
+
+export type GqlQueryNftTokensArgs = {
+  cursor?: InputMaybe<Scalars["String"]["input"]>;
+  filter?: InputMaybe<GqlNftTokenFilterInput>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  sort?: InputMaybe<GqlNftTokenSortInput>;
 };
 
 export type GqlQueryOpportunitiesArgs = {
@@ -2769,23 +2836,71 @@ export type GqlTransaction = {
   updatedAt?: Maybe<Scalars["Datetime"]["output"]>;
 };
 
+/**
+ * ポイントの旅（chain）の全体像。
+ * depth はチェーンの長さ（ステップ数）、steps は古い順（起点→現在）に並ぶ。
+ */
 export type GqlTransactionChain = {
   __typename?: "TransactionChain";
   depth: Scalars["Int"]["output"];
   steps: Array<GqlTransactionChainStep>;
 };
 
+/**
+ * 参加者がコミュニティ（COMMUNITY wallet の所有者）である場合の表現。
+ * id は Community.id。GRANT / ONBOARDING のような、community wallet から
+ * 発行される transaction の起点ステップで登場する。
+ */
+export type GqlTransactionChainCommunity = GqlTransactionChainParticipant & {
+  __typename?: "TransactionChainCommunity";
+  bio?: Maybe<Scalars["String"]["output"]>;
+  id: Scalars["ID"]["output"];
+  image?: Maybe<Scalars["String"]["output"]>;
+  name: Scalars["String"]["output"];
+};
+
+/**
+ * chain の 1 ステップに登場する参加者（User または Community）。
+ * 共通フィールドを束ねた interface。実体の判別は __typename で行う。
+ */
+export type GqlTransactionChainParticipant = {
+  bio?: Maybe<Scalars["String"]["output"]>;
+  id: Scalars["ID"]["output"];
+  image?: Maybe<Scalars["String"]["output"]>;
+  name: Scalars["String"]["output"];
+};
+
+/**
+ * chain の1ステップ。ある transaction（ポイントの移動 1回分）に対応する。
+ * from が送信元、to が送信先。どちらも User または Community を表す
+ * TransactionChainParticipant interface で、__typename で判別できる。
+ */
 export type GqlTransactionChainStep = {
   __typename?: "TransactionChainStep";
   createdAt: Scalars["Datetime"]["output"];
-  fromUser?: Maybe<GqlTransactionChainUser>;
+  /**
+   * 送信元の参加者。
+   * - GRANT / ONBOARDING の起点ステップでは TransactionChainCommunity（community wallet 発）
+   * - それ以外のステップは TransactionChainUser
+   * - ウォレットが削除済み（退会済みユーザー等）の場合は null
+   */
+  from?: Maybe<GqlTransactionChainParticipant>;
   id: Scalars["ID"]["output"];
   points: Scalars["Int"]["output"];
   reason: GqlTransactionReason;
-  toUser?: Maybe<GqlTransactionChainUser>;
+  /**
+   * 送信先の参加者。
+   * 現状の業務ロジックでは常に TransactionChainUser（MEMBER wallet 宛）。
+   * ウォレットが削除済みの場合は null。
+   */
+  to?: Maybe<GqlTransactionChainParticipant>;
 };
 
-export type GqlTransactionChainUser = {
+/**
+ * 参加者がユーザー（MEMBER wallet の所有者）である場合の表現。
+ * id は User.id。
+ */
+export type GqlTransactionChainUser = GqlTransactionChainParticipant & {
   __typename?: "TransactionChainUser";
   bio?: Maybe<Scalars["String"]["output"]>;
   id: Scalars["ID"]["output"];
@@ -3196,6 +3311,7 @@ export type GqlVoteBallot = {
    * （現時点の power は MyVoteEligibility.currentPower を参照）。
    */
   power: Scalars["Int"]["output"];
+  /** 再投票（upsert）時に現在時刻で更新される。初回投票時は null。 */
   updatedAt?: Maybe<Scalars["Datetime"]["output"]>;
 };
 
@@ -3204,17 +3320,26 @@ export type GqlVoteCastInput = {
   topicId: Scalars["ID"]["input"];
 };
 
-export type GqlVoteCastPayload = {
-  __typename?: "VoteCastPayload";
+export type GqlVoteCastPayload = GqlVoteCastSuccess;
+
+export type GqlVoteCastSuccess = {
+  __typename?: "VoteCastSuccess";
   ballot: GqlVoteBallot;
 };
 
 /**
  * 誰が投票できるか（資格ゲート）。
- * VotePowerPolicy（何票持つか）とは**独立に設定される**。
- * スキーマレベルでのクロス検証は行わないため、Gate=NFT(tokenA) + PowerPolicy=NFT_COUNT(tokenB)
- * のような食い違いも作成可能。この場合 A のみ保有するユーザーは eligible=true / currentPower=0 になる。
- * 組み合わせの妥当性は呼び出し側（管理 UI 等）で担保すること。
+ * VotePowerPolicy（何票持つか）とは**独立に設定される**が、両方が NFT 系
+ * （Gate.type=NFT かつ PowerPolicy.type=NFT_COUNT）の場合に限り、参照する
+ * **nftTokenId は一致していなければならない**（バックエンドで検証、違反時は
+ * `VALIDATION_ERROR`）。異なる token を指定した場合、A 保有者のうち B 非保有者が
+ * eligible=true / currentPower=0 になる「投票しても効かない」状態が生じる設定ミスを防ぐため。
+ *
+ * 許容される組み合わせ:
+ * - Gate=NFT(A) + Policy=NFT_COUNT(A)  典型的
+ * - Gate=MEMBERSHIP + Policy=NFT_COUNT(A)  メンバー内で NFT ホルダーのみ重み付け（非ホルダーは power=0）
+ * - Gate=NFT(A) + Policy=FLAT  A 保有者は一律 1 票
+ * - Gate=MEMBERSHIP + Policy=FLAT  全員 1 票
  */
 export type GqlVoteGate = {
   __typename?: "VoteGate";
@@ -3250,6 +3375,10 @@ export type GqlVoteOption = {
   __typename?: "VoteOption";
   id: Scalars["ID"]["output"];
   label: Scalars["String"]["output"];
+  /**
+   * 作成時（VoteOptionInput）に指定した値がそのまま保持される。
+   * VoteTopic.options は本フィールドの昇順で返るため、UI 側で追加のソートは不要。
+   */
   orderIndex: Scalars["Int"]["output"];
   /** 票の重み合計（= Σ power）。endsAt 到達前は一般ユーザーに null（管理者は常に実値を参照可）。 */
   totalPower?: Maybe<Scalars["Int"]["output"]>;
@@ -3304,7 +3433,12 @@ export type GqlVoteTopic = {
   myBallot?: Maybe<GqlVoteBallot>;
   /** ログインユーザーの投票資格情報（未ログインは null）。 */
   myEligibility?: Maybe<GqlMyVoteEligibility>;
+  /** 投票選択肢。orderIndex 昇順で返る（UI 側でのソートは不要）。 */
   options: Array<GqlVoteOption>;
+  /**
+   * 現在フェーズ。**レスポンス時点でサーバ時刻から計算される値**であり DB カラムではない。
+   * 詳細は VoteTopicPhase の説明を参照。
+   */
   phase: GqlVoteTopicPhase;
   powerPolicy: GqlVotePowerPolicy;
   startsAt: Scalars["Datetime"]["output"];
@@ -3323,14 +3457,18 @@ export type GqlVoteTopicCreateInput = {
   title: Scalars["String"]["input"];
 };
 
-export type GqlVoteTopicCreatePayload = {
-  __typename?: "VoteTopicCreatePayload";
+export type GqlVoteTopicCreatePayload = GqlVoteTopicCreateSuccess;
+
+export type GqlVoteTopicCreateSuccess = {
+  __typename?: "VoteTopicCreateSuccess";
   voteTopic: GqlVoteTopic;
 };
 
-export type GqlVoteTopicDeletePayload = {
-  __typename?: "VoteTopicDeletePayload";
-  id: Scalars["ID"]["output"];
+export type GqlVoteTopicDeletePayload = GqlVoteTopicDeleteSuccess;
+
+export type GqlVoteTopicDeleteSuccess = {
+  __typename?: "VoteTopicDeleteSuccess";
+  voteTopicId: Scalars["ID"]["output"];
 };
 
 export type GqlVoteTopicEdge = {
@@ -3352,6 +3490,28 @@ export const GqlVoteTopicPhase = {
 } as const;
 
 export type GqlVoteTopicPhase = (typeof GqlVoteTopicPhase)[keyof typeof GqlVoteTopicPhase];
+/**
+ * voteTopicUpdate 用の入力。**既存の全フィールドを置き換える**（部分更新は未サポート）。
+ * options は delete → create で全量置換される。gate / powerPolicy も同様に再生成されるため、
+ * 既存の id 値は保持されない点に注意。UPCOMING フェーズ限定で呼ばれるため、投票は存在しない前提。
+ */
+export type GqlVoteTopicUpdateInput = {
+  description?: InputMaybe<Scalars["String"]["input"]>;
+  endsAt: Scalars["Datetime"]["input"];
+  gate: GqlVoteGateInput;
+  options: Array<GqlVoteOptionInput>;
+  powerPolicy: GqlVotePowerPolicyInput;
+  startsAt: Scalars["Datetime"]["input"];
+  title: Scalars["String"]["input"];
+};
+
+export type GqlVoteTopicUpdatePayload = GqlVoteTopicUpdateSuccess;
+
+export type GqlVoteTopicUpdateSuccess = {
+  __typename?: "VoteTopicUpdateSuccess";
+  voteTopic: GqlVoteTopic;
+};
+
 export type GqlVoteTopicsConnection = {
   __typename?: "VoteTopicsConnection";
   edges: Array<GqlVoteTopicEdge>;
@@ -7106,20 +7266,38 @@ export type GqlGetTransactionDetailQuery = {
         points: number;
         reason: GqlTransactionReason;
         createdAt: Date;
-        fromUser?: {
-          __typename?: "TransactionChainUser";
-          id: string;
-          name: string;
-          image?: string | null;
-          bio?: string | null;
-        } | null;
-        toUser?: {
-          __typename?: "TransactionChainUser";
-          id: string;
-          name: string;
-          image?: string | null;
-          bio?: string | null;
-        } | null;
+        from?:
+          | {
+              __typename: "TransactionChainCommunity";
+              id: string;
+              name: string;
+              image?: string | null;
+              bio?: string | null;
+            }
+          | {
+              __typename: "TransactionChainUser";
+              id: string;
+              name: string;
+              image?: string | null;
+              bio?: string | null;
+            }
+          | null;
+        to?:
+          | {
+              __typename: "TransactionChainCommunity";
+              id: string;
+              name: string;
+              image?: string | null;
+              bio?: string | null;
+            }
+          | {
+              __typename: "TransactionChainUser";
+              id: string;
+              name: string;
+              image?: string | null;
+              bio?: string | null;
+            }
+          | null;
       }>;
     } | null;
     fromWallet?: {
@@ -14174,17 +14352,35 @@ export const GetTransactionDetailDocument = gql`
           points
           reason
           createdAt
-          fromUser {
-            id
-            name
-            image
-            bio
+          from {
+            __typename
+            ... on TransactionChainUser {
+              id
+              name
+              image
+              bio
+            }
+            ... on TransactionChainCommunity {
+              id
+              name
+              image
+              bio
+            }
           }
-          toUser {
-            id
-            name
-            image
-            bio
+          to {
+            __typename
+            ... on TransactionChainUser {
+              id
+              name
+              image
+              bio
+            }
+            ... on TransactionChainCommunity {
+              id
+              name
+              image
+              bio
+            }
           }
         }
       }

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -14354,33 +14354,17 @@ export const GetTransactionDetailDocument = gql`
           createdAt
           from {
             __typename
-            ... on TransactionChainUser {
-              id
-              name
-              image
-              bio
-            }
-            ... on TransactionChainCommunity {
-              id
-              name
-              image
-              bio
-            }
+            id
+            name
+            image
+            bio
           }
           to {
             __typename
-            ... on TransactionChainUser {
-              id
-              name
-              image
-              bio
-            }
-            ... on TransactionChainCommunity {
-              id
-              name
-              image
-              bio
-            }
+            id
+            name
+            image
+            bio
           }
         }
       }


### PR DESCRIPTION
## Summary
This PR introduces NFT token querying capabilities, adds a voting topic update mutation, and refactors transaction chain participant handling to support both users and communities.

## Key Changes

### NFT Token Management
- Added `nftToken` and `nftTokens` queries to retrieve individual tokens and paginated token lists
- Introduced `NftTokenEdge`, `NftTokensConnection`, `NftTokenFilterInput`, and `NftTokenSortInput` types for cursor-based pagination and filtering
- Added `community` field to `NftToken` type to track which community owns a token
- Implemented filtering by community ID with proper null handling

### Voting Topic Updates
- Added `voteTopicUpdate` mutation to allow admins to update voting topics in UPCOMING phase only
- Introduced `VoteTopicUpdateInput` and `VoteTopicUpdatePayload` types
- Updated `voteTopicDelete` to enforce UPCOMING phase restriction with `VOTE_TOPIC_NOT_EDITABLE` error
- Enhanced `voteTopicCreate` validation: when both Gate and PowerPolicy are NFT-based, their nftTokenIds must match
- Added `VOTE_TOPIC_NOT_EDITABLE` error code to `GqlErrorCode`

### Transaction Chain Refactoring
- Refactored `TransactionChainStep` to use `from` and `to` fields (replacing `fromUser` and `toUser`)
- Introduced `TransactionChainParticipant` interface to represent both users and communities
- Added `TransactionChainCommunity` type for community wallet participants (used in GRANT/ONBOARDING transactions)
- Updated `TransactionChainUser` to implement `TransactionChainParticipant` interface
- Updated GraphQL query to use inline fragments for proper type discrimination

### Documentation Improvements
- Enhanced descriptions for voting gate validation rules and allowed combinations
- Added clarifications on vote option ordering and ballot update timestamps
- Documented transaction chain phase calculations and participant types
- Improved descriptions for NFT token community association

## Implementation Details
- All payload types for voting mutations are now unions (VoteCastPayload, VoteTopicCreatePayload, VoteTopicDeletePayload, VoteTopicUpdatePayload)
- Transaction chain participants use `__typename` for runtime type discrimination
- NFT token filtering supports logical operators (and/or/not) for complex queries
- Vote topic updates perform full replacement of options while allowing gate/policy reconfiguration

https://claude.ai/code/session_01MeP4ztuRtXPnwiuWaPJ83d
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
