### PR TITLE
chore(chromatic): Storybook デプロイ & CI 連携セットアップ

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,10 +9,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -25,15 +29,13 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: "20.18"
+          node-version: "20.18.1"
           cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Publish to Chromatic
-        uses: chromaui/action@latest
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          exitZeroOnChanges: true
-          onlyChanged: true
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        run: pnpm exec chromatic --exit-zero-on-changes --only-changed

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: "20.18.1"
+          node-version: "22"
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,39 @@
+name: Chromatic
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Set up Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "20.18"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish to Chromatic
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          exitZeroOnChanges: true
+          onlyChanged: true

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -21,7 +21,7 @@ const config: StorybookConfig = {
   viteFinal: async (viteConfig) => {
     viteConfig.define = {
       ...viteConfig.define,
-      "process.env": JSON.stringify({}),
+      "process.env": JSON.stringify({ ENV: "STORYBOOK" }),
     };
     return viteConfig;
   },

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -21,7 +21,9 @@ const config: StorybookConfig = {
   viteFinal: async (viteConfig) => {
     viteConfig.define = {
       ...viteConfig.define,
-      "process.env": JSON.stringify({ ENV: "STORYBOOK" }),
+      // src/lib/environment.ts の isStorybook 判定をビルド時に true にする。
+      // NODE_ENV など他の process.env.* は Vite のデフォルト置換に任せる。
+      "process.env.ENV": JSON.stringify("STORYBOOK"),
     };
     return viteConfig;
   },

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -18,5 +18,12 @@ const config: StorybookConfig = {
   "staticDirs": [
     "../public"
   ],
+  viteFinal: async (viteConfig) => {
+    viteConfig.define = {
+      ...viteConfig.define,
+      "process.env": JSON.stringify({}),
+    };
+    return viteConfig;
+  },
 };
 export default config;

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,7 @@
+<script>
+  // Vite ビルドのバンドルが読み込まれる前に process.env を用意する。
+  // src/lib/logging/client/index.ts 等のモジュール初期化時に
+  // process.env.NEXT_PUBLIC_LOG_LEVEL を参照しており、
+  // ブラウザでは process が未定義のため ReferenceError になる。
+  window.process = window.process || { env: {} };
+</script>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -3,5 +3,8 @@
   // src/lib/logging/client/index.ts 等のモジュール初期化時に
   // process.env.NEXT_PUBLIC_LOG_LEVEL を参照しており、
   // ブラウザでは process が未定義のため ReferenceError になる。
-  window.process = window.process || { env: {} };
+  // ENV=STORYBOOK を明示することで src/lib/environment.ts の isStorybook 判定を通し、
+  // clientLogger が /api/client-log に送信しないようにする。
+  window.process = window.process || {};
+  window.process.env = { ...(window.process.env || {}), ENV: "STORYBOOK" };
 </script>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,10 +1,7 @@
 <script>
-  // Vite ビルドのバンドルが読み込まれる前に process.env を用意する。
-  // src/lib/logging/client/index.ts 等のモジュール初期化時に
-  // process.env.NEXT_PUBLIC_LOG_LEVEL を参照しており、
-  // ブラウザでは process が未定義のため ReferenceError になる。
-  // ENV=STORYBOOK を明示することで src/lib/environment.ts の isStorybook 判定を通し、
-  // clientLogger が /api/client-log に送信しないようにする。
+  // Vite の define で置換されない動的な process.env アクセスに備えた runtime polyfill。
+  // 例えば一部ライブラリが process.env や process 自体の存在を typeof 等でチェックする場合、
+  // ブラウザでは process が未定義のため ReferenceError になるのを防ぐ。
   window.process = window.process || {};
-  window.process.env = { ...(window.process.env || {}), ENV: "STORYBOOK" };
+  window.process.env = window.process.env || {};
 </script>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:coverage": "vitest --project unit --coverage",
     "test:ui": "vitest --project unit --ui",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "chromatic": "chromatic --exit-zero-on-changes"
   },
   "dependencies": {
     "@apollo/client": "^3.13.8",
@@ -133,6 +134,7 @@
     "@types/retry": "^0.12.5",
     "@vitest/browser": "^3.2.4",
     "@vitest/coverage-v8": "^3.2.4",
+    "chromatic": "^16.3.0",
     "eslint": "^8.57.1",
     "eslint-config-next": "14.2.5",
     "eslint-config-prettier": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@types/retry": "^0.12.5",
     "@vitest/browser": "^3.2.4",
     "@vitest/coverage-v8": "^3.2.4",
-    "chromatic": "^12.2.0",
+    "chromatic": "16.3.0",
     "eslint": "^8.57.1",
     "eslint-config-next": "14.2.5",
     "eslint-config-prettier": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@types/retry": "^0.12.5",
     "@vitest/browser": "^3.2.4",
     "@vitest/coverage-v8": "^3.2.4",
-    "chromatic": "^16.3.0",
+    "chromatic": "^12.2.0",
     "eslint": "^8.57.1",
     "eslint-config-next": "14.2.5",
     "eslint-config-prettier": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,8 +338,8 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
       chromatic:
-        specifier: ^12.2.0
-        version: 12.2.0
+        specifier: 16.3.0
+        version: 16.3.0
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -4975,6 +4975,21 @@ packages:
       '@chromatic-com/cypress':
         optional: true
       '@chromatic-com/playwright':
+        optional: true
+
+  chromatic@16.3.0:
+    resolution: {integrity: sha512-PvXUpXP3l8p2NxLEYhMgo4kGNNBQgCgbslMu+O4Bb37ujiiDWk8QExX/Jk7JeHUewNgK2wg98rtw3gdfz3U+Kg==}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+      '@chromatic-com/vitest': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
+      '@chromatic-com/vitest':
         optional: true
 
   class-variance-authority@0.7.1:
@@ -14310,6 +14325,8 @@ snapshots:
       readdirp: 4.1.2
 
   chromatic@12.2.0: {}
+
+  chromatic@16.3.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,6 +337,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
+      chromatic:
+        specifier: ^16.3.0
+        version: 16.3.0
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -4972,6 +4975,21 @@ packages:
       '@chromatic-com/cypress':
         optional: true
       '@chromatic-com/playwright':
+        optional: true
+
+  chromatic@16.3.0:
+    resolution: {integrity: sha512-PvXUpXP3l8p2NxLEYhMgo4kGNNBQgCgbslMu+O4Bb37ujiiDWk8QExX/Jk7JeHUewNgK2wg98rtw3gdfz3U+Kg==}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+      '@chromatic-com/vitest': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
+      '@chromatic-com/vitest':
         optional: true
 
   class-variance-authority@0.7.1:
@@ -14307,6 +14325,8 @@ snapshots:
       readdirp: 4.1.2
 
   chromatic@12.2.0: {}
+
+  chromatic@16.3.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,8 +338,8 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
       chromatic:
-        specifier: ^16.3.0
-        version: 16.3.0
+        specifier: ^12.2.0
+        version: 12.2.0
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -4975,21 +4975,6 @@ packages:
       '@chromatic-com/cypress':
         optional: true
       '@chromatic-com/playwright':
-        optional: true
-
-  chromatic@16.3.0:
-    resolution: {integrity: sha512-PvXUpXP3l8p2NxLEYhMgo4kGNNBQgCgbslMu+O4Bb37ujiiDWk8QExX/Jk7JeHUewNgK2wg98rtw3gdfz3U+Kg==}
-    hasBin: true
-    peerDependencies:
-      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
-      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
-      '@chromatic-com/vitest': ^0.*.* || ^1.0.0
-    peerDependenciesMeta:
-      '@chromatic-com/cypress':
-        optional: true
-      '@chromatic-com/playwright':
-        optional: true
-      '@chromatic-com/vitest':
         optional: true
 
   class-variance-authority@0.7.1:
@@ -14325,8 +14310,6 @@ snapshots:
       readdirp: 4.1.2
 
   chromatic@12.2.0: {}
-
-  chromatic@16.3.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:

--- a/src/shared/transactions/components/timeline/ChainDepthBadge.tsx
+++ b/src/shared/transactions/components/timeline/ChainDepthBadge.tsx
@@ -22,9 +22,9 @@ export const ChainDepthBadge = ({ depth }: ChainDepthBadgeProps) => {
     <span
       title={label}
       aria-label={label}
-      className="shrink-0 inline-flex items-center gap-0.5 rounded-full border border-muted-foreground/30 px-1.5 py-px text-[10px] leading-none text-muted-foreground"
+      className="shrink-0 inline-flex items-center gap-0.5 rounded-full border border-muted-foreground/30 px-2 py-0.5 text-xs leading-none text-muted-foreground"
     >
-      <Link2 className="w-2.5 h-2.5" strokeWidth={2} />
+      <Link2 className="w-3 h-3" strokeWidth={2} />
       <span className="tabular-nums">{depth}</span>
     </span>
   );

--- a/src/shared/transactions/components/timeline/ChainDepthBadge.tsx
+++ b/src/shared/transactions/components/timeline/ChainDepthBadge.tsx
@@ -22,9 +22,9 @@ export const ChainDepthBadge = ({ depth }: ChainDepthBadgeProps) => {
     <span
       title={label}
       aria-label={label}
-      className="shrink-0 inline-flex items-center gap-0.5 rounded-full border border-muted-foreground/30 px-2 py-0.5 text-xs leading-none text-muted-foreground"
+      className="shrink-0 inline-flex items-center gap-0.5 rounded-full border border-muted-foreground/30 px-1.5 py-px text-[10px] leading-none text-muted-foreground"
     >
-      <Link2 className="w-3 h-3" strokeWidth={2} />
+      <Link2 className="w-2.5 h-2.5" strokeWidth={2} />
       <span className="tabular-nums">{depth}</span>
     </span>
   );


### PR DESCRIPTION
## Summary

Chromatic を使った Storybook の自動デプロイ・ビジュアル回帰テストを導入する。

- `chromatic` パッケージ追加 & `package.json` にスクリプト追加
- `.github/workflows/chromatic.yml` 追加（push to `develop` / 全 PR で発火、TurboSnap 有効化）
- `.storybook/main.ts` に `viteFinal` 追加（`process.env` 参照の逃げ道）
- `.storybook/preview-head.html` 追加（バンドル読み込み前に `window.process` を polyfill。Vite ビルドで `process is not defined` を回避）

## Chromatic 側の設定（完了済み）

- Project: `Hopin-inc/civicship-portal`
- Visual tests: Chrome で有効
- Accessibility tests: 有効
- UI Review: 有効
- Pull request comments: 有効（GitHub App インストール済み）

## CI 連携に必要な事前作業（完了済み）

- GitHub Secrets に `CHROMATIC_PROJECT_TOKEN` 登録済み

## Test plan

- [ ] この PR 作成時に `.github/workflows/chromatic.yml` が走り、Chromatic にビルドが publish されることを確認
- [ ] PR コメントに Chromatic からの結果コメントが投稿されることを確認
- [ ] PR の Checks に `UI Tests` / `UI Review` が表示されることを確認
- [ ] Chromatic 管理画面で「Finish setup by configuring CI」の警告が消えることを確認

## 注意

- `.storybook/preview-head.html` の `window.process = { env: {} }` は Storybook 表示のみに影響。実 API 値は不要なので空オブジェクトで十分。
- `chromatic` スクリプトは `--exit-zero-on-changes` 付き。差分検出時も CI を止めない（レビューは Chromatic 側で実施）。
- Storybook が増えるほど Chromatic の価値が上がるので、コンポーネント追加時に `*.stories.tsx` も合わせて追加する運用推奨。

https://claude.ai/code/session_01PXWexyNtcJ7ad1NyxG69Y3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
