### PR TITLE
fix(chromatic): TurboSnap 有効化のため checkout ref を head.ref に変更

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,6 +22,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          # pull_request イベントでは GitHub がデフォルトで ephemeral な
+          # merge commit (refs/pull/N/merge) を checkout するため、
+          # Chromatic の TurboSnap が git 履歴を辿れず発動しない。
+          # PR の HEAD commit を直接指定することでこれを回避する。
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install pnpm
         run: npm install -g pnpm

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,11 +22,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          # pull_request イベントでは GitHub がデフォルトで ephemeral な
-          # merge commit (refs/pull/N/merge) を checkout するため、
-          # Chromatic の TurboSnap が git 履歴を辿れず発動しない。
-          # PR の HEAD commit を直接指定することでこれを回避する。
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # pull_request イベントではデフォルトで ephemeral な merge commit
+          # (refs/pull/N/merge) を checkout するため、Chromatic の TurboSnap
+          # が git 履歴を辿れず invalidChangedFiles で bail する。
+          # ブランチ名 (head.ref) で checkout してローカル ref を作ることで、
+          # Chromatic CLI が正しく履歴を解析できるようにする。
+          # 公式 troubleshooting ガイド: https://www.chromatic.com/docs/turbosnap/troubleshooting/
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: Install pnpm
         run: npm install -g pnpm


### PR DESCRIPTION
## Summary

Chromatic の TurboSnap を有効化するために、`pull_request` イベントで checkout する ref を PR ブランチ名 (`head.ref`) に変更する。

## 背景

GitHub Actions の `pull_request` イベントは、デフォルトで ephemeral な merge commit (`refs/pull/N/merge`) を checkout する。この commit はどの branch にも属さず、Chromatic CLI が git 履歴から baseline commit までの diff を計算できないため、TurboSnap が `invalidChangedFiles` で bail し全 story が full snapshot になっていた。

実際、直近の Build 詳細では:

```
26 Captured snapshots
0 TurboSnaps
A full build was triggered because the Chromatic CLI could not retrieve
the set of changed files from Git.
```

Chromatic 公式の TurboSnap troubleshooting でも、この症状の対策として **「checkout step に正しい ref を設定する」** ことが明記されている:

> Another common cause of this issue is when customers use GitHub Actions
> with the pull_request event. If this is the case, you'll want to make
> sure you set the correct ref in your checkout step.

https://www.chromatic.com/docs/turbosnap/troubleshooting/

## 変更内容

`.github/workflows/chromatic.yml` の checkout ステップに `ref` を追加:

```yaml
ref: ${{ github.event.pull_request.head.ref || github.ref }}
```

| イベント | checkout 対象 |
|---|---|
| `pull_request` | PR のブランチ名 (`head.ref`) |
| `push` (develop) | `github.ref` (例: `refs/heads/develop`) |

ブランチ名で checkout することで、ローカルに `refs/heads/<branch>` が作られ、Chromatic CLI が `git rev-list` で baseline commit までの履歴を辿れるようになる。

### なぜ `head.sha` ではダメだったか
SHA で checkout すると detached HEAD 状態になり、ローカルにブランチ ref が存在しない。Chromatic は branch 名から最新 commit を逆引きしようとするが、ローカル ref がないため見つけられず bail する（前回の試行で実証済み）。

## セキュリティ

`if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository` により、自リポジトリ発の PR のみ job が実行されるため、fork PR で head ref を参照するリスクはない。

## 期待される効果

TurboSnap が有効化されることで:

- 変更に関係ない story は baseline からスナップショットをコピー（料金は通常の **1/5**）
- CI 実行時間が短縮される
- 月間スナップショット消費量が大幅に減る（現在 425 / 5,000 → 数十〜100 台に収まる見込み）

## Test plan

- [ ] このPRのCIログに `⚠ Branch ... does not exist` や `⚠ TurboSnap disabled due to missing git history` が出ないこと
- [ ] Chromatic 管理画面の Build 詳細で **TurboSnaps の数値が 0 でなくなる** こと
- [ ] bail reason が `invalidChangedFiles` から外れていること
- [ ] 後続 PR で変更に関係ない story が skip されること

## 試行錯誤の履歴

このブランチで一度 `head.sha` を指定する形で push したが、上記理由で TurboSnap が動かなかったため、公式 troubleshooting の指示通り `head.ref` に修正した。

https://claude.ai/code/session_01PXWexyNtcJ7ad1NyxG69Y3