### PR TITLE
Exclude /sysAdmin paths from community scope routing

### DIFF
--- a/src/app/sysAdmin/page.tsx
+++ b/src/app/sysAdmin/page.tsx
@@ -23,7 +23,7 @@ export default function SysAdminPage() {
   return (
     <div className="p-4 max-w-2xl mx-auto">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-body-sm text-muted-foreground">コミュニティ一覧</h2>
+        <h2 className="text-body-sm text-muted-foreground pl-4">コミュニティ一覧</h2>
         <Button
           onClick={() => router.push("/sysAdmin/create")}
           variant="primary"

--- a/src/lib/navigation/__tests__/path-resolver.test.ts
+++ b/src/lib/navigation/__tests__/path-resolver.test.ts
@@ -90,6 +90,16 @@ describe("path-resolver", () => {
         );
         expect(resolvePath("favicon.ico", "community-a")).toBe("favicon.ico");
       });
+
+      it("should not modify /sysAdmin paths (community-scope外)", () => {
+        expect(resolvePath("/sysAdmin", "community-a")).toBe("/sysAdmin");
+        expect(resolvePath("/sysAdmin/create", "community-a")).toBe(
+          "/sysAdmin/create"
+        );
+        expect(resolvePath("/sysAdmin/create?foo=bar", "community-a")).toBe(
+          "/sysAdmin/create?foo=bar"
+        );
+      });
     });
 
     describe("community-dependent paths (now included)", () => {

--- a/src/lib/navigation/path-resolver.ts
+++ b/src/lib/navigation/path-resolver.ts
@@ -23,6 +23,10 @@ const EXCLUDED_PATH_PATTERNS = [
 
   // API ルート
   "/api/**",
+
+  // SYS_ADMIN 専用ルート（コミュニティスコープ外）
+  "/sysAdmin",
+  "/sysAdmin/**",
 ];
 
 /**


### PR DESCRIPTION
## Summary
This PR ensures that system admin routes (`/sysAdmin`) are not modified by the community-scoped path resolver, allowing them to remain accessible outside of community contexts.

## Key Changes
- **Path Resolver**: Added `/sysAdmin` and `/sysAdmin/**` to the `EXCLUDED_PATH_PATTERNS` list to prevent community scope prefixing on admin routes
- **Tests**: Added test cases to verify that `/sysAdmin` paths are not modified when a community scope is provided
- **UI**: Added left padding (`pl-4`) to the "コミュニティ一覧" heading in the SysAdmin page for improved visual alignment

## Implementation Details
The `/sysAdmin` routes are now treated similarly to API routes (`/api/**`) - they bypass the community-dependent path resolution logic entirely. This ensures that system admin pages remain accessible at their absolute paths regardless of the current community context.

https://claude.ai/code/session_01GEArgLobMFx54Qw9E2YrLF
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
