### PR TITLE
Rebrand activity metrics from "稼働率" to "MAU%" terminology

### DIFF
--- a/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
+++ b/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
@@ -6,17 +6,22 @@ export type MetricDefinition = {
 };
 
 export const METRIC_DEFINITIONS: Record<string, MetricDefinition> = {
+  mau: {
+    title: "MAU",
+    formula: "直近月にDONATIONを送ったユニークユーザー数",
+    note: "本ツールでの Active = DONATION 送付者。MAU% の分子。",
+  },
   communityActivityRate: {
-    title: "コミュニティ稼働率",
+    title: "MAU%",
     formula:
       "直近月にDONATIONを送ったユニークユーザー数 ÷ 月末時点の総メンバー数",
-    note: "個人の送付率 (user_send_rate) とは別の指標。その月コミュニティがどれだけ動いたかを表す。",
+    note: "コミュニティ単位の月次稼働率。個人の送付率 (user_send_rate) とは別指標。本ツールでの Active = DONATION 送付者。",
     range: "0〜100%",
   },
   growthRateActivity: {
-    title: "前月比 (稼働率)",
-    formula: "(今月の稼働率 − 先月の稼働率) ÷ 先月の稼働率",
-    note: "負値は稼働率が前月より低下。先月の稼働率が 0 のときは null。",
+    title: "MAU% 前月比",
+    formula: "(今月の MAU% − 先月の MAU%) ÷ 先月の MAU%",
+    note: "負値は MAU% が前月より低下。先月の MAU% が 0 のときは null。",
   },
   userSendRate: {
     title: "送付率 (個人)",
@@ -31,18 +36,23 @@ export const METRIC_DEFINITIONS: Record<string, MetricDefinition> = {
     note: "分母はその月に入会した全メンバー (活動有無問わず)。M+0は全員100%スタート。",
     range: "0〜100%",
   },
+  wau: {
+    title: "WAU",
+    formula: "今週DONATIONを送ったユニークユーザー数",
+    note: "継続 / 離脱 / 復帰の3カテゴリに分解される。本ツールでの Active = DONATION 送付者。",
+  },
   retainedSenders: {
-    title: "継続送付者",
+    title: "継続 (WAU 構成)",
     formula: "今週DONATIONを送った ∧ 先週もDONATIONを送ったユーザー数",
     note: "新規メンバーは先週の活動がないため含まれない。",
   },
   churnedSenders: {
-    title: "離脱予兆",
+    title: "離脱 (WAU 構成)",
     formula: "先週DONATIONを送った ∧ 今週送っていないユーザー数",
     note: "churned > retained が続く場合は介入シグナル。",
   },
   returnedSenders: {
-    title: "復帰送付者",
+    title: "復帰 (WAU 構成)",
     formula:
       "今週DONATIONを送った ∧ 先週は送っていない ∧ 過去12週の間に送ったことがある ユーザー数",
     note: "休眠から復帰したメンバーのシグナル。",
@@ -89,15 +99,17 @@ export const METRIC_DEFINITIONS: Record<string, MetricDefinition> = {
     title: "集計日",
     formula: "指定日時点の状態を計算対象にする",
     note:
-      "画面上の稼働率・ステージ分布・コホート retention 等、すべての指標は この日時点のスナップショット。未指定時は今日 (実行時) を使う。",
+      "画面上の MAU% ・ステージ分布・コホート retention 等、すべての指標は この日時点のスナップショット。未指定時は今日 (実行時) を使う。",
   },
 };
 
 export type MetricKey =
+  | "mau"
   | "communityActivityRate"
   | "growthRateActivity"
   | "userSendRate"
   | "cohortRetention"
+  | "wau"
   | "retainedSenders"
   | "churnedSenders"
   | "returnedSenders"

--- a/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
+++ b/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
@@ -13,9 +13,8 @@ export const METRIC_DEFINITIONS: Record<string, MetricDefinition> = {
   },
   communityActivityRate: {
     title: "MAU%",
-    formula:
-      "直近月にDONATIONを送ったユニークユーザー数 ÷ 月末時点の総メンバー数",
-    note: "コミュニティ単位の月次稼働率。個人の送付率 (user_send_rate) とは別指標。本ツールでの Active = DONATION 送付者。",
+    formula: "MAU ÷ 月末時点の総メンバー数",
+    note: "コミュニティ単位の MAU%。個人の送付率 (user_send_rate) とは別指標。本ツールでの Active = DONATION 送付者。",
     range: "0〜100%",
   },
   growthRateActivity: {
@@ -39,7 +38,7 @@ export const METRIC_DEFINITIONS: Record<string, MetricDefinition> = {
   wau: {
     title: "WAU",
     formula: "今週DONATIONを送ったユニークユーザー数",
-    note: "継続 / 離脱 / 復帰の3カテゴリに分解される。本ツールでの Active = DONATION 送付者。",
+    note: "継続 / 離脱 / 復帰の3カテゴリで分析される。本ツールでの Active = DONATION 送付者。",
   },
   retainedSenders: {
     title: "継続 (WAU 構成)",

--- a/src/app/sysAdmin/_shared/components/MetricGlossary.tsx
+++ b/src/app/sysAdmin/_shared/components/MetricGlossary.tsx
@@ -22,12 +22,12 @@ type Section = {
  * 主指標 → ステージ → コホート → 週次 → メンバー → コミュニティ → 設定。
  */
 const SECTIONS: Section[] = [
-  { heading: "主指標", keys: ["communityActivityRate", "growthRateActivity"] },
+  { heading: "主指標", keys: ["mau", "communityActivityRate", "growthRateActivity"] },
   { heading: "ステージ分類", keys: ["stages", "userSendRate"] },
   { heading: "コホート", keys: ["cohortRetention"] },
   {
-    heading: "週次リテンション",
-    keys: ["retainedSenders", "churnedSenders", "returnedSenders"],
+    heading: "WAU 構成 (週次)",
+    keys: ["wau", "retainedSenders", "churnedSenders", "returnedSenders"],
   },
   {
     heading: "メンバー指標",

--- a/src/app/sysAdmin/_shared/i18n/ja.ts
+++ b/src/app/sysAdmin/_shared/i18n/ja.ts
@@ -22,21 +22,10 @@ export const sysAdminDashboardJa = {
     filterSection: "メンバー絞り込み",
     activeBadge: "(変更あり)",
   },
-  overview: {
-    latestRetentionM1: "M+1定着率",
-    sort: {
-      placeholder: "並び順",
-      activityRate: "稼働率順",
-      growth: "前月比順",
-      tier1Count: "習慣化人数順",
-      latestRetentionM1: "M+1定着率順",
-    },
-  },
   alerts: {
-    activeDrop: "稼働低下",
+    activeDrop: "MAU% 低下",
     churnSpike: "離脱加速",
     noNewMembers: "新規停止",
-    allClear: "アラートなし",
   },
   detail: {
     title: "コミュニティ詳細",
@@ -50,16 +39,6 @@ export const sysAdminDashboardJa = {
       donationSuffix: "pt",
       chainPrefix: "最大chain",
       chainSuffix: "段",
-      growth: "前月比",
-      threeMonthAvg: "3ヶ月平均",
-    },
-    summary: {
-      activityRate: "活動率",
-      activityRate3m: "活動率 (3ヶ月平均)",
-      growth: "前月比",
-      totalMembers: "総メンバー",
-      tier2Pct: "Tier2 比率",
-      totalDonation: "累計贈与ポイント",
     },
     stages: {
       title: "ステージ分布",
@@ -71,28 +50,19 @@ export const sysAdminDashboardJa = {
       avgMonthsIn: "在籍 avg",
     },
     monthly: {
-      title: "月次アクティビティ推移",
-      senderCount: "送り手数",
+      title: "MAU 推移",
+      senderCount: "MAU",
       newMembers: "新規加入",
-      activityRate: "活動率",
+      activityRate: "MAU%",
     },
     retention: {
-      title: "週次リテンション",
+      title: "WAU",
       retained: "継続",
       churned: "離脱",
       returned: "復帰",
     },
     cohort: {
       title: "コホートretention",
-      axisX: { m0: "M+0", m1: "M+1", m3: "M+3", m6: "M+6" },
-      empty: "データなし",
-      period: {
-        label: "コホート表示期間",
-        m3: "直近3ヶ月",
-        m6: "直近6ヶ月",
-        m12: "直近12ヶ月",
-        all: "全期間",
-      },
     },
     member: {
       title: "メンバー一覧",

--- a/src/app/sysAdmin/features/communityDetail/components/CommunityDetailHeader.tsx
+++ b/src/app/sysAdmin/features/communityDetail/components/CommunityDetailHeader.tsx
@@ -13,7 +13,7 @@ type Props = {
   alerts: GqlSysAdminCommunityAlerts;
   /** アラート行の右に配置する補助コントロール (用語 Button など) */
   controls?: ReactNode;
-  /** 稼働率行の右端に配置する期間セレクト */
+  /** MAU% 行の右端に配置する期間セレクト */
   periodControl?: ReactNode;
 };
 
@@ -25,7 +25,7 @@ type SubMetric = {
 /**
  * Header layout (size を抑えた落ち着き優先):
  * - Row 1: alert (左) / controls (右)
- * - Row 2: [text-3xl semibold 稼働率] [sm delta]  ·  [periodControl] (右寄せ)
+ * - Row 2: [text-3xl semibold MAU%] [sm delta]  ·  [periodControl] (右寄せ)
  * - Row 3: sub-metrics (label xs / 値 base) を label上/値下 pair で整列
  */
 export function CommunityDetailHeader({
@@ -62,14 +62,14 @@ export function CommunityDetailHeader({
         </div>
       )}
 
-      {/* Row 2: 主指標 + 前月比 + periodControl (右) */}
+      {/* Row 2: MAU% + 前月比 + periodControl (右) */}
       <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-2">
         <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
           <span className="text-3xl font-semibold tabular-nums leading-tight">
             {toPct(summary.communityActivityRate)}
           </span>
           {summary.growthRateActivity != null && (
-            <span className="text-sm" aria-label="前月比">
+            <span className="text-sm" aria-label="MAU% 前月比">
               (
               <PercentDelta
                 value={summary.growthRateActivity}


### PR DESCRIPTION
## Summary
This PR updates the System Admin dashboard terminology to use "MAU%" (Monthly Active Users percentage) instead of "稼働率" (activity rate) as the primary metric name, along with related metric definitions and UI labels. This aligns the dashboard language with standard industry terminology for measuring community engagement.

## Key Changes

- **Metric Naming**: Renamed primary metric from "コミュニティ稼働率" (Community Activity Rate) to "MAU%" throughout the dashboard
- **Related Metrics**: Updated dependent metrics:
  - "前月比 (稼働率)" → "MAU% 前月比" (Month-over-month growth)
  - "稼働低下" alert → "MAU% 低下" alert
  - "月次アクティビティ推移" chart → "MAU 推移"
  - "活動率" column → "MAU%" column

- **New Metric Definitions**: Added explicit definitions for:
  - `mau`: Monthly Active Users (unique users who sent donations in the past month)
  - `wau`: Weekly Active Users (unique users who sent donations this week)

- **Weekly Retention Rebranding**: Renamed "週次リテンション" section to "WAU 構成 (週次)" and updated component labels:
  - "継続送付者" → "継続 (WAU 構成)"
  - "離脱予兆" → "離脱 (WAU 構成)"
  - "復帰送付者" → "復帰 (WAU 構成)"

- **Removed Obsolete Translations**: Cleaned up unused i18n entries for overview section, cohort period selector, and summary metrics that are no longer displayed

- **Updated Documentation**: Enhanced metric definition notes to clarify that "Active" in this tool specifically means "DONATION sender" and updated snapshot references from "稼働率" to "MAU%"

## Implementation Details

- Changes are primarily in Japanese localization strings and metric definitions
- UI component comments updated to reflect new terminology
- No functional logic changes; this is a terminology/labeling update
- Maintains backward compatibility with existing data structures

https://claude.ai/code/session_0199Q3cbgYduMvWMPciEGyPK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
