### PR TITLE
refactor(sysAdmin): L1 を nested rolling-window schema に移行

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -23919,41 +23919,9 @@
       {
         "kind": "OBJECT",
         "name": "SysAdminCommunityOverview",
-        "description": "One row of the L1 all-community table. See the module docstring for the\ndistinction between `communityActivityRate` (this type) and\n`userSendRate` (SysAdminMemberRow).",
+        "description": "One row of the L1 all-community table. Designed for at-a-glance\nintervention judgment: each row carries the raw counts the client\nneeds to derive rates, growth, alerts, sort keys, and filter\npredicates without a second round-trip.\n\nCalendar-month metrics live on the L2 detail card\n(SysAdminCommunitySummaryCard) — L1 is rolling-window only.",
         "isOneOf": null,
         "fields": [
-          {
-            "name": "alerts",
-            "description": "Alert flags (see SysAdminCommunityAlerts).",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "SysAdminCommunityAlerts",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "communityActivityRate",
-            "description": "Community activity rate for the JST calendar month containing asOf:\nunique DONATION senders in that month / month-end total_members.\n0.0–1.0. NOT the individual-level userSendRate.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
           {
             "name": "communityId",
             "description": "Community id.",
@@ -23987,39 +23955,15 @@
             "deprecationReason": null
           },
           {
-            "name": "growthRateActivity",
-            "description": "Month-over-month % change in communityActivityRate.\nReturned as a fraction (e.g. -0.2 == -20%). null when the prior month\nhas no data to compare against.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "latestCohortRetentionM1",
-            "description": "Retention rate of the most recent completed cohort (members who joined\nin asOf's previous JST month) measured in the month after joining.\nnull when that cohort is empty.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "passiveCount",
-            "description": "Direct member count for the \"latent\" stage (never donated).\nConvenience field (== segmentCounts.passiveCount).",
+            "name": "latestCohort",
+            "description": "Latest completed monthly cohort and its M+1 activity. See\nSysAdminLatestCohort.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
+                "kind": "OBJECT",
+                "name": "SysAdminLatestCohort",
                 "ofType": null
               }
             },
@@ -24028,7 +23972,7 @@
           },
           {
             "name": "segmentCounts",
-            "description": "Stage counts under the supplied thresholds (cumulative, see type doc).",
+            "description": "Per-stage member counts (tier1 / tier2 / passive, cumulative\nper the type doc) classified against input.segmentThresholds.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24043,40 +23987,8 @@
             "deprecationReason": null
           },
           {
-            "name": "tier1Count",
-            "description": "Direct member count for the \"habitual\" stage (userSendRate >= tier1).\nConvenience field (== segmentCounts.tier1Count).",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tier2Count",
-            "description": "Direct member count for the \"regular+habitual\" stage\n(userSendRate >= tier2). Convenience field (== segmentCounts.tier2Count).",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "totalMembers",
-            "description": "Total status='JOINED' members at asOf.",
+            "description": "Total status='JOINED' members as of asOf. Members whose\ncreated_at is after asOf are excluded from the count.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24084,6 +23996,38 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "weeklyRetention",
+            "description": "Latest completed-week retention signals for client-side churn\ndetection. See SysAdminWeeklyRetention.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SysAdminWeeklyRetention",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "windowActivity",
+            "description": "Rolling-window DONATION activity. See SysAdminWindowActivity.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SysAdminWindowActivity",
                 "ofType": null
               }
             },
@@ -24289,7 +24233,7 @@
         "inputFields": [
           {
             "name": "asOf",
-            "description": "The \"as of\" timestamp. All trailing-window calculations are anchored\nhere: the \"latest month\" is the JST calendar month containing asOf,\nand \"latest week\" is the ISO-week containing asOf. Defaults to now\nwhen omitted.",
+            "description": "As-of timestamp anchor. All trailing-window calculations are\nanchored here:\n  - parametric activity window: [asOf - windowDays, asOf + 1 JST日)\n  - weekly retention: latest completed ISO week before asOf\n  - latest cohort: (asOf JST月 - 2) so its M+1 window is fully past\nDefaults to now when omitted.",
             "type": {
               "kind": "SCALAR",
               "name": "Datetime",
@@ -24301,13 +24245,25 @@
           },
           {
             "name": "segmentThresholds",
-            "description": "Stage-count thresholds (see SysAdminSegmentThresholdsInput).",
+            "description": "Stage classification thresholds (see SysAdminSegmentThresholdsInput).",
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "SysAdminSegmentThresholdsInput",
               "ofType": null
             },
             "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "windowDays",
+            "description": "Length of the rolling activity window in JST days. Effective\nrange 7-90; values outside are silently clamped on the server.\nDefaults to 28 (= 4 weeks, absorbs day-of-week variance).",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": "28",
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -24372,6 +24328,50 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "SysAdminPlatformSummary",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SysAdminLatestCohort",
+        "description": "Most recently completed monthly cohort plus its M+1 activity.\n\"M+1\" follows standard cohort-analysis convention: the calendar\nmonth immediately after the joining month.\n\nThe cohort is selected as (asOf's JST month - 2 months) so its\nM+1 window — the JST month immediately preceding asOf's month —\nis fully past. This avoids reporting an artificially low retention\nduring the in-progress month.\n\nRaw counts are returned; the client divides for the retention rate\nand decides how to handle small-N cohorts via `size`.",
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "activeAtM1",
+            "description": "Of those cohort members, how many sent at least one DONATION\nduring the M+1 month.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "size",
+            "description": "Cohort size: status='JOINED' members whose created_at falls\nwithin the cohort month. 0 when no one joined that month\n(callers should treat M+1 retention as null in that case).",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               }
             },
@@ -25270,6 +25270,126 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SysAdminWeeklyRetention",
+        "description": "DONATION sender retention against the most recently completed\nISO week (Monday 00:00 JST). Raw signals only; the client composes\nchurn alerts (e.g. churnedSenders > retainedSenders).",
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "churnedSenders",
+            "description": "Users who sent DONATION in the week-before-latest but NOT in\nthe latest completed week. \"Lost this week, was engaged last week.\"",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retainedSenders",
+            "description": "Users who sent DONATION in the latest completed week AND in\nthe week before it. \"Engaged this week, was engaged last week.\"",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SysAdminWindowActivity",
+        "description": "DONATION activity within the parametric window driven by\n`SysAdminDashboardInput.windowDays`. Both the current window and\nthe immediately preceding window of equal length are returned so\nthe client can derive growth rates without a second query.\n\n  current  = [asOf - windowDays JST日, asOf + 1 JST日)\n  previous = [asOf - 2 * windowDays, asOf - windowDays)",
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "newMemberCount",
+            "description": "New JOINED memberships (t_memberships.created_at within the\ncurrent window, status='JOINED').",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "newMemberCountPrev",
+            "description": "Same metric for the previous window.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "senderCount",
+            "description": "Unique users with at least one outgoing DONATION transaction\nduring the current window (donation_out_count > 0 in\nmv_user_transaction_daily).",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "senderCountPrev",
+            "description": "Same metric for the previous window of equal length.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -25355,6 +25355,22 @@
             "deprecationReason": null
           },
           {
+            "name": "retainedSenders",
+            "description": "Users who sent at least one DONATION in BOTH the current window\nAND the previous window (set intersection on user_id). Same\nshape as SysAdminWeeklyRetention.retainedSenders but at\nwindowDays scale, enabling client-side leaky-bucket derivation:\n\n  newlyActivatedSenders = senderCount     - retainedSenders\n  churnedSenders        = senderCountPrev - retainedSenders",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "senderCount",
             "description": "Unique users with at least one outgoing DONATION transaction\nduring the current window (donation_out_count > 0 in\nmv_user_transaction_daily).",
             "args": [],

--- a/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
+++ b/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
@@ -8,19 +8,19 @@ export type MetricDefinition = {
 export const METRIC_DEFINITIONS: Record<string, MetricDefinition> = {
   mau: {
     title: "MAU",
-    formula: "直近月にDONATIONを送ったユニークユーザー数",
-    note: "本ツールでの Active = DONATION 送付者。MAU% の分子。",
+    formula: "直近 28 日に DONATION を送ったユニークユーザー数 (windowDays default = 28)",
+    note: "本ツールでの Active = DONATION 送付者。MAU% の分子。暦月ではなく rolling 28 日窓。",
   },
   communityActivityRate: {
     title: "MAU%",
-    formula: "MAU ÷ 月末時点の総メンバー数",
+    formula: "MAU ÷ asOf 時点の総メンバー数 (rolling 28 日窓)",
     note: "コミュニティ単位の MAU%。個人の送付率 (user_send_rate) とは別指標。本ツールでの Active = DONATION 送付者。",
     range: "0〜100%",
   },
   growthRateActivity: {
     title: "MAU% 前月比",
-    formula: "(今月の MAU% − 先月の MAU%) ÷ 先月の MAU%",
-    note: "負値は MAU% が前月より低下。先月の MAU% が 0 のときは null。",
+    formula: "(直近 28 日 MAU% − その前 28 日 MAU%) ÷ その前 28 日 MAU%",
+    note: "負値は MAU% が前窓より低下。前 28 日窓の MAU% が 0 のときは null。",
   },
   userSendRate: {
     title: "送付率 (個人)",

--- a/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
+++ b/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
@@ -33,6 +33,12 @@ export const METRIC_DEFINITIONS: Record<string, MetricDefinition> = {
     formula: "直近 28 日 (windowDays default) に JOINED で加入したメンバー数",
     note: "row では総メンバー数の隣に `(+12)` の形で表示。0 のときは `(+0)` で「新規加入なし」のシグナルを兼ねる。",
   },
+  activityFlow: {
+    title: "Δ (activity flow)",
+    formula:
+      "↑newlyActivated = senderCount − retainedSenders / ↓churned = senderCountPrev − retainedSenders",
+    note: "leaky-bucket 検出。↑ は前 28d は送付してなく現 28d で送付した sender、↓ は前 28d は送付してたが現 28d で送付してない sender。MAU 数だけ見ても入退室で打ち消されるケースを表面化する。",
+  },
   userSendRate: {
     title: "送付率 (個人)",
     formula: "DONATIONを送った月数 ÷ 在籍月数",
@@ -119,6 +125,7 @@ export type MetricKey =
   | "growthRateActivity"
   | "hubUserPct"
   | "newMembers"
+  | "activityFlow"
   | "userSendRate"
   | "cohortRetention"
   | "wau"

--- a/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
+++ b/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
@@ -31,7 +31,7 @@ export const METRIC_DEFINITIONS: Record<string, MetricDefinition> = {
   newMembers: {
     title: "New",
     formula: "直近 28 日 (windowDays default) に JOINED で加入したメンバー数",
-    note: "rolling 窓内の絶対数。コミュニティ size に依らず流入の勢いを見るため % ではなく count で表示。",
+    note: "row では総メンバー数の隣に `(+12)` の形で表示。0 のときは `(+0)` で「新規加入なし」のシグナルを兼ねる。",
   },
   userSendRate: {
     title: "送付率 (個人)",

--- a/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
+++ b/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
@@ -22,6 +22,17 @@ export const METRIC_DEFINITIONS: Record<string, MetricDefinition> = {
     formula: "(直近 28 日 MAU% − その前 28 日 MAU%) ÷ その前 28 日 MAU%",
     note: "負値は MAU% が前窓より低下。前 28 日窓の MAU% が 0 のときは null。",
   },
+  hubUserPct: {
+    title: "Hub user%",
+    formula: "tier1Count ÷ totalMembers (userSendRate ≥ tier1 を満たすメンバー)",
+    note: "ステージ最上位 (習慣化層) の比率。コミュニティの DONATION 連鎖を支える hub 役のユーザー割合。",
+    range: "0〜100%",
+  },
+  newMembers: {
+    title: "New",
+    formula: "直近 28 日 (windowDays default) に JOINED で加入したメンバー数",
+    note: "rolling 窓内の絶対数。コミュニティ size に依らず流入の勢いを見るため % ではなく count で表示。",
+  },
   userSendRate: {
     title: "送付率 (個人)",
     formula: "DONATIONを送った月数 ÷ 在籍月数",
@@ -91,8 +102,8 @@ export const METRIC_DEFINITIONS: Record<string, MetricDefinition> = {
   stages: {
     title: "ステージ分類",
     formula:
-      "habitual: send_rate ≥ tier1 / regular: tier2 ≤ send_rate < tier1 / occasional: 0 < send_rate < tier2 / latent: send_rate = 0",
-    note: "デフォルト tier1=0.7, tier2=0.4。閾値はステージ分布の「分類設定」から変更可能。",
+      "hub: send_rate ≥ tier1 / regular: tier2 ≤ send_rate < tier1 / occasional: 0 < send_rate < tier2 / latent: send_rate = 0",
+    note: "デフォルト tier1=0.7, tier2=0.4。最上位 (hub) は DONATION ネットワークの連鎖を支える役割を表す。閾値はステージ分布の「分類設定」から変更可能。",
   },
   asOf: {
     title: "集計日",
@@ -106,6 +117,8 @@ export type MetricKey =
   | "mau"
   | "communityActivityRate"
   | "growthRateActivity"
+  | "hubUserPct"
+  | "newMembers"
   | "userSendRate"
   | "cohortRetention"
   | "wau"

--- a/src/app/sysAdmin/_shared/components/MetricGlossary.tsx
+++ b/src/app/sysAdmin/_shared/components/MetricGlossary.tsx
@@ -22,8 +22,11 @@ type Section = {
  * 主指標 → ステージ → コホート → 週次 → メンバー → コミュニティ → 設定。
  */
 const SECTIONS: Section[] = [
-  { heading: "主指標", keys: ["mau", "communityActivityRate", "growthRateActivity"] },
-  { heading: "ステージ分類", keys: ["stages", "userSendRate"] },
+  {
+    heading: "主指標",
+    keys: ["mau", "communityActivityRate", "growthRateActivity", "newMembers"],
+  },
+  { heading: "ステージ分類", keys: ["stages", "userSendRate", "hubUserPct"] },
   { heading: "コホート", keys: ["cohortRetention"] },
   {
     heading: "WAU 構成 (週次)",

--- a/src/app/sysAdmin/_shared/components/MetricGlossary.tsx
+++ b/src/app/sysAdmin/_shared/components/MetricGlossary.tsx
@@ -24,7 +24,7 @@ type Section = {
 const SECTIONS: Section[] = [
   {
     heading: "主指標",
-    keys: ["mau", "communityActivityRate", "growthRateActivity", "newMembers"],
+    keys: ["mau", "communityActivityRate", "growthRateActivity", "newMembers", "activityFlow"],
   },
   { heading: "ステージ分類", keys: ["stages", "userSendRate", "hubUserPct"] },
   { heading: "コホート", keys: ["cohortRetention"] },

--- a/src/app/sysAdmin/_shared/components/MetricGlossary.tsx
+++ b/src/app/sysAdmin/_shared/components/MetricGlossary.tsx
@@ -17,30 +17,15 @@ type Section = {
   keys: MetricKey[];
 };
 
-/**
- * セクション分けは「admin が読みたい順」を意識する。
- * 主指標 → ステージ → コホート → 週次 → メンバー → コミュニティ → 設定。
- */
+// L1 row に表示している指標とその直接的な前提だけに絞る。L2 詳細で必要な
+// 個人指標 / コホート / WAU 構成は別途 L2 側で glossary を持つ想定。
 const SECTIONS: Section[] = [
   {
     heading: "主指標",
     keys: ["mau", "communityActivityRate", "growthRateActivity", "newMembers", "activityFlow"],
   },
-  { heading: "ステージ分類", keys: ["stages", "userSendRate", "hubUserPct"] },
-  { heading: "コホート", keys: ["cohortRetention"] },
-  {
-    heading: "WAU 構成 (週次)",
-    keys: ["wau", "retainedSenders", "churnedSenders", "returnedSenders"],
-  },
-  {
-    heading: "メンバー指標",
-    keys: ["monthsIn", "donationOutMonths", "totalPointsOut"],
-  },
-  {
-    heading: "コミュニティ指標",
-    keys: ["totalDonationPointsAllTime", "maxChainDepthAllTime", "chainPct"],
-  },
-  { heading: "画面設定", keys: ["asOf"] },
+  { heading: "ステージ", keys: ["hubUserPct", "stages", "userSendRate"] },
+  { heading: "設定", keys: ["asOf"] },
 ];
 
 type Props = {
@@ -63,37 +48,41 @@ export function MetricGlossaryButton({ className }: Props) {
         用語
       </Button>
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-[560px]">
+        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-[520px]">
           <DialogHeader>
-            <DialogTitle>指標の定義</DialogTitle>
+            <DialogTitle className="text-sm font-medium text-muted-foreground">
+              指標の定義
+            </DialogTitle>
           </DialogHeader>
-          <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-5 text-muted-foreground">
             {SECTIONS.map((section) => (
-              <section key={section.heading} className="flex flex-col gap-3">
-                <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <section key={section.heading} className="flex flex-col gap-2">
+                <h3 className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">
                   {section.heading}
                 </h3>
-                <dl className="flex flex-col gap-4">
+                <dl className="flex flex-col gap-3">
                   {section.keys.map((key) => {
                     const def = METRIC_DEFINITIONS[key];
                     if (!def) return null;
                     return (
-                      <div key={key} className="flex flex-col gap-1">
-                        <dt className="text-sm font-semibold">{def.title}</dt>
-                        <dd className="flex flex-col gap-1 text-sm">
-                          <p className="text-muted-foreground">
-                            <span className="mr-1 text-xs text-muted-foreground/70">計算式:</span>
+                      <div key={key} className="flex flex-col gap-0.5">
+                        <dt className="text-xs font-medium text-foreground/80">
+                          {def.title}
+                        </dt>
+                        <dd className="flex flex-col gap-0.5 text-xs">
+                          <p>
+                            <span className="mr-1 text-muted-foreground/60">計算式:</span>
                             {def.formula}
                           </p>
                           {def.note && (
-                            <p className="text-muted-foreground">
-                              <span className="mr-1 text-xs text-muted-foreground/70">補足:</span>
+                            <p>
+                              <span className="mr-1 text-muted-foreground/60">補足:</span>
                               {def.note}
                             </p>
                           )}
                           {def.range && (
-                            <p className="text-muted-foreground">
-                              <span className="mr-1 text-xs text-muted-foreground/70">範囲:</span>
+                            <p>
+                              <span className="mr-1 text-muted-foreground/60">範囲:</span>
                               {def.range}
                             </p>
                           )}

--- a/src/app/sysAdmin/_shared/components/PercentDelta.tsx
+++ b/src/app/sysAdmin/_shared/components/PercentDelta.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import { toSignedPct } from "@/app/sysAdmin/_shared/format/number";
+import { toArrowPct } from "@/app/sysAdmin/_shared/format/number";
 import { sysAdminDashboardJa } from "@/app/sysAdmin/_shared/i18n/ja";
 
 type Props = {
@@ -23,7 +23,7 @@ export function PercentDelta({ value, className }: Props) {
         className,
       )}
     >
-      {toSignedPct(value)}
+      {toArrowPct(value)}
     </span>
   );
 }

--- a/src/app/sysAdmin/_shared/components/PrimaryAlertBadge.stories.tsx
+++ b/src/app/sysAdmin/_shared/components/PrimaryAlertBadge.stories.tsx
@@ -1,7 +1,13 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { PrimaryAlertBadge } from "./PrimaryAlertBadge";
-import { makeAlerts } from "../fixtures/sysAdminDashboard";
+import type { DerivedAlerts } from "@/app/sysAdmin/_shared/derive";
+
+const NONE: DerivedAlerts = {
+  churnSpike: false,
+  activeDrop: false,
+  noNewMembers: false,
+};
 
 const meta: Meta<typeof PrimaryAlertBadge> = {
   title: "SysAdmin/Shared/PrimaryAlertBadge",
@@ -19,30 +25,30 @@ export default meta;
 type Story = StoryObj<typeof PrimaryAlertBadge>;
 
 export const ChurnSpike: Story = {
-  args: { alerts: makeAlerts({ churnSpike: true }) },
+  args: { alerts: { ...NONE, churnSpike: true } },
 };
 
 export const ActiveDrop: Story = {
-  args: { alerts: makeAlerts({ activeDrop: true }) },
+  args: { alerts: { ...NONE, activeDrop: true } },
 };
 
 export const NoNewMembers: Story = {
-  args: { alerts: makeAlerts({ noNewMembers: true }) },
+  args: { alerts: { ...NONE, noNewMembers: true } },
 };
 
 // 優先度: churnSpike > activeDrop > noNewMembers
 export const PriorityChurnSpikeWins: Story = {
   args: {
-    alerts: makeAlerts({ churnSpike: true, activeDrop: true, noNewMembers: true }),
+    alerts: { churnSpike: true, activeDrop: true, noNewMembers: true },
   },
 };
 
 export const PriorityActiveDropWins: Story = {
   args: {
-    alerts: makeAlerts({ activeDrop: true, noNewMembers: true }),
+    alerts: { ...NONE, activeDrop: true, noNewMembers: true },
   },
 };
 
 export const NoAlerts: Story = {
-  args: { alerts: makeAlerts() },
+  args: { alerts: NONE },
 };

--- a/src/app/sysAdmin/_shared/components/PrimaryAlertBadge.tsx
+++ b/src/app/sysAdmin/_shared/components/PrimaryAlertBadge.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import type { GqlSysAdminCommunityAlerts } from "@/types/graphql";
+import type { DerivedAlerts } from "@/app/sysAdmin/_shared/derive";
 import { cn } from "@/lib/utils";
 import { sysAdminDashboardJa } from "@/app/sysAdmin/_shared/i18n/ja";
 
 type AlertVariant = "churnSpike" | "activeDrop" | "noNewMembers";
 
-export function selectPrimaryAlert(alerts: GqlSysAdminCommunityAlerts): AlertVariant | null {
+export function selectPrimaryAlert(alerts: DerivedAlerts): AlertVariant | null {
   if (alerts.churnSpike) return "churnSpike";
   if (alerts.activeDrop) return "activeDrop";
   if (alerts.noNewMembers) return "noNewMembers";
@@ -33,7 +33,7 @@ const STYLE: Record<AlertVariant, { container: string; dot: string; label: strin
 };
 
 type Props = {
-  alerts: GqlSysAdminCommunityAlerts;
+  alerts: DerivedAlerts;
   className?: string;
 };
 

--- a/src/app/sysAdmin/_shared/components/__tests__/PrimaryAlertBadge.test.tsx
+++ b/src/app/sysAdmin/_shared/components/__tests__/PrimaryAlertBadge.test.tsx
@@ -7,7 +7,6 @@ describe("selectPrimaryAlert", () => {
   it("returns null when no alerts active", () => {
     expect(
       selectPrimaryAlert({
-        __typename: "SysAdminCommunityAlerts",
         churnSpike: false,
         activeDrop: false,
         noNewMembers: false,
@@ -18,7 +17,6 @@ describe("selectPrimaryAlert", () => {
   it("prioritizes churnSpike over the others", () => {
     expect(
       selectPrimaryAlert({
-        __typename: "SysAdminCommunityAlerts",
         churnSpike: true,
         activeDrop: true,
         noNewMembers: true,
@@ -29,7 +27,6 @@ describe("selectPrimaryAlert", () => {
   it("falls through to activeDrop when churnSpike is off", () => {
     expect(
       selectPrimaryAlert({
-        __typename: "SysAdminCommunityAlerts",
         churnSpike: false,
         activeDrop: true,
         noNewMembers: true,
@@ -40,7 +37,6 @@ describe("selectPrimaryAlert", () => {
   it("falls through to noNewMembers when others are off", () => {
     expect(
       selectPrimaryAlert({
-        __typename: "SysAdminCommunityAlerts",
         churnSpike: false,
         activeDrop: false,
         noNewMembers: true,
@@ -54,7 +50,6 @@ describe("PrimaryAlertBadge", () => {
     render(
       <PrimaryAlertBadge
         alerts={{
-          __typename: "SysAdminCommunityAlerts",
           churnSpike: true,
           activeDrop: true,
           noNewMembers: false,
@@ -68,7 +63,6 @@ describe("PrimaryAlertBadge", () => {
     const { container } = render(
       <PrimaryAlertBadge
         alerts={{
-          __typename: "SysAdminCommunityAlerts",
           churnSpike: false,
           activeDrop: false,
           noNewMembers: false,

--- a/src/app/sysAdmin/_shared/derive.ts
+++ b/src/app/sysAdmin/_shared/derive.ts
@@ -1,0 +1,56 @@
+import type { GqlSysAdminCommunityOverview } from "@/types/graphql";
+
+// MoM (= rolling-window vs preceding window) drop threshold.
+// growthRateActivity <= ACTIVE_DROP_THRESHOLD points the alert.
+export const ACTIVE_DROP_THRESHOLD = -0.2;
+
+export function deriveActivityRate(row: GqlSysAdminCommunityOverview): number {
+  if (row.totalMembers === 0) return 0;
+  return row.windowActivity.senderCount / row.totalMembers;
+}
+
+export function deriveActivityRatePrev(
+  row: GqlSysAdminCommunityOverview,
+): number {
+  if (row.totalMembers === 0) return 0;
+  return row.windowActivity.senderCountPrev / row.totalMembers;
+}
+
+// null when there is no baseline (prev-window had zero senders or
+// totalMembers is zero); the UI renders "-" in that case.
+export function deriveGrowthRateActivity(
+  row: GqlSysAdminCommunityOverview,
+): number | null {
+  if (row.totalMembers === 0) return null;
+  if (row.windowActivity.senderCountPrev === 0) return null;
+  const curr = deriveActivityRate(row);
+  const prev = deriveActivityRatePrev(row);
+  return (curr - prev) / prev;
+}
+
+export function deriveLatestCohortRetentionM1(
+  row: GqlSysAdminCommunityOverview,
+): number | null {
+  if (row.latestCohort.size === 0) return null;
+  return row.latestCohort.activeAtM1 / row.latestCohort.size;
+}
+
+export type DerivedAlerts = {
+  churnSpike: boolean;
+  activeDrop: boolean;
+  noNewMembers: boolean;
+};
+
+export function deriveAlerts(row: GqlSysAdminCommunityOverview): DerivedAlerts {
+  const growth = deriveGrowthRateActivity(row);
+  return {
+    churnSpike:
+      row.weeklyRetention.churnedSenders > row.weeklyRetention.retainedSenders,
+    activeDrop: growth != null && growth <= ACTIVE_DROP_THRESHOLD,
+    noNewMembers: row.windowActivity.newMemberCount === 0,
+  };
+}
+
+export function hasAnyAlert(alerts: DerivedAlerts): boolean {
+  return alerts.churnSpike || alerts.activeDrop || alerts.noNewMembers;
+}

--- a/src/app/sysAdmin/_shared/derive.ts
+++ b/src/app/sysAdmin/_shared/derive.ts
@@ -35,6 +35,14 @@ export function deriveLatestCohortRetentionM1(
   return row.latestCohort.activeAtM1 / row.latestCohort.size;
 }
 
+// Hub user share: tier1 segment (userSendRate >= tier1 threshold, default 0.7).
+// "Hub" frames the highest stage as the network-role layer that anchors
+// the donation graph, distinct from generic "habitual" individual behavior.
+export function deriveHubUserPct(row: GqlSysAdminCommunityOverview): number {
+  if (row.totalMembers === 0) return 0;
+  return row.segmentCounts.tier1Count / row.totalMembers;
+}
+
 export type DerivedAlerts = {
   churnSpike: boolean;
   activeDrop: boolean;

--- a/src/app/sysAdmin/_shared/derive.ts
+++ b/src/app/sysAdmin/_shared/derive.ts
@@ -38,9 +38,26 @@ export function deriveLatestCohortRetentionM1(
 // Hub user share: tier1 segment (userSendRate >= tier1 threshold, default 0.7).
 // "Hub" frames the highest stage as the network-role layer that anchors
 // the donation graph, distinct from generic "habitual" individual behavior.
+//
+// NOTE: provisional. Pareto-based redefinition (top users covering 80%
+// of donation volume) is pending backend support; once shipped, this
+// derive switches to the Pareto count.
 export function deriveHubUserPct(row: GqlSysAdminCommunityOverview): number {
   if (row.totalMembers === 0) return 0;
   return row.segmentCounts.tier1Count / row.totalMembers;
+}
+
+// Activity-flow leaky-bucket pair derived from windowActivity raw counts.
+//   newlyActivated = senderCount     - retainedSenders   (entered active pool)
+//   churned        = senderCountPrev - retainedSenders   (left active pool)
+export function deriveNewlyActivatedSenders(
+  row: GqlSysAdminCommunityOverview,
+): number {
+  return row.windowActivity.senderCount - row.windowActivity.retainedSenders;
+}
+
+export function deriveChurnedSenders(row: GqlSysAdminCommunityOverview): number {
+  return row.windowActivity.senderCountPrev - row.windowActivity.retainedSenders;
 }
 
 export type DerivedAlerts = {

--- a/src/app/sysAdmin/_shared/fixtures/sysAdminDashboard.ts
+++ b/src/app/sysAdmin/_shared/fixtures/sysAdminDashboard.ts
@@ -59,19 +59,40 @@ export const makePlatformSummary = (
   ...overrides,
 });
 
+// Default proportions used to derive segmentCounts from totalMembers when
+// the caller doesn't pass an explicit segmentCounts override. Keeps Hub /
+// passive rates visually plausible across stories with varied totalMembers.
+const DEFAULT_TIER1_RATIO = 0.33;
+const DEFAULT_TIER2_RATIO = 0.58;
+const DEFAULT_PASSIVE_RATIO = 0.21;
+
+function defaultSegmentCountsFor(total: number): GqlSysAdminSegmentCounts {
+  return {
+    __typename: "SysAdminSegmentCounts",
+    total,
+    activeCount: Math.round(total * (1 - DEFAULT_PASSIVE_RATIO)),
+    passiveCount: Math.round(total * DEFAULT_PASSIVE_RATIO),
+    tier1Count: Math.round(total * DEFAULT_TIER1_RATIO),
+    tier2Count: Math.round(total * DEFAULT_TIER2_RATIO),
+  };
+}
+
 export const makeCommunityOverview = (
   overrides: Partial<GqlSysAdminCommunityOverview> = {},
-): GqlSysAdminCommunityOverview => ({
-  __typename: "SysAdminCommunityOverview",
-  communityId: "community-a",
-  communityName: "コミュニティA",
-  totalMembers: 120,
-  segmentCounts: makeSegmentCounts(),
-  windowActivity: makeWindowActivity(),
-  weeklyRetention: makeWeeklyRetention(),
-  latestCohort: makeLatestCohort(),
-  ...overrides,
-});
+): GqlSysAdminCommunityOverview => {
+  const totalMembers = overrides.totalMembers ?? 120;
+  return {
+    __typename: "SysAdminCommunityOverview",
+    communityId: "community-a",
+    communityName: "コミュニティA",
+    totalMembers,
+    segmentCounts: defaultSegmentCountsFor(totalMembers),
+    windowActivity: makeWindowActivity(),
+    weeklyRetention: makeWeeklyRetention(),
+    latestCohort: makeLatestCohort(),
+    ...overrides,
+  };
+};
 
 export const makeDashboardPayload = (
   overrides: {

--- a/src/app/sysAdmin/_shared/fixtures/sysAdminDashboard.ts
+++ b/src/app/sysAdmin/_shared/fixtures/sysAdminDashboard.ts
@@ -28,6 +28,7 @@ export const makeWindowActivity = (
   senderCountPrev: 46,
   newMemberCount: 8,
   newMemberCountPrev: 6,
+  retainedSenders: 38,
   ...overrides,
 });
 

--- a/src/app/sysAdmin/_shared/fixtures/sysAdminDashboard.ts
+++ b/src/app/sysAdmin/_shared/fixtures/sysAdminDashboard.ts
@@ -1,20 +1,12 @@
 import type {
   GqlGetSysAdminDashboardQuery,
-  GqlSysAdminCommunityAlerts,
   GqlSysAdminCommunityOverview,
+  GqlSysAdminLatestCohort,
   GqlSysAdminPlatformSummary,
   GqlSysAdminSegmentCounts,
+  GqlSysAdminWeeklyRetention,
+  GqlSysAdminWindowActivity,
 } from "@/types/graphql";
-
-export const makeAlerts = (
-  overrides: Partial<GqlSysAdminCommunityAlerts> = {},
-): GqlSysAdminCommunityAlerts => ({
-  __typename: "SysAdminCommunityAlerts",
-  activeDrop: false,
-  churnSpike: false,
-  noNewMembers: false,
-  ...overrides,
-});
 
 export const makeSegmentCounts = (
   overrides: Partial<GqlSysAdminSegmentCounts> = {},
@@ -25,6 +17,35 @@ export const makeSegmentCounts = (
   passiveCount: 25,
   tier1Count: 40,
   tier2Count: 70,
+  ...overrides,
+});
+
+export const makeWindowActivity = (
+  overrides: Partial<GqlSysAdminWindowActivity> = {},
+): GqlSysAdminWindowActivity => ({
+  __typename: "SysAdminWindowActivity",
+  senderCount: 50,
+  senderCountPrev: 46,
+  newMemberCount: 8,
+  newMemberCountPrev: 6,
+  ...overrides,
+});
+
+export const makeWeeklyRetention = (
+  overrides: Partial<GqlSysAdminWeeklyRetention> = {},
+): GqlSysAdminWeeklyRetention => ({
+  __typename: "SysAdminWeeklyRetention",
+  retainedSenders: 18,
+  churnedSenders: 4,
+  ...overrides,
+});
+
+export const makeLatestCohort = (
+  overrides: Partial<GqlSysAdminLatestCohort> = {},
+): GqlSysAdminLatestCohort => ({
+  __typename: "SysAdminLatestCohort",
+  size: 12,
+  activeAtM1: 8,
   ...overrides,
 });
 
@@ -44,15 +65,11 @@ export const makeCommunityOverview = (
   __typename: "SysAdminCommunityOverview",
   communityId: "community-a",
   communityName: "コミュニティA",
-  communityActivityRate: 0.42,
-  growthRateActivity: 0.08,
-  latestCohortRetentionM1: 0.63,
   totalMembers: 120,
-  passiveCount: 25,
-  tier1Count: 40,
-  tier2Count: 70,
   segmentCounts: makeSegmentCounts(),
-  alerts: makeAlerts(),
+  windowActivity: makeWindowActivity(),
+  weeklyRetention: makeWeeklyRetention(),
+  latestCohort: makeLatestCohort(),
   ...overrides,
 });
 
@@ -75,17 +92,13 @@ export const makeDashboardPayload = (
         makeCommunityOverview({
           communityId: "community-b",
           communityName: "コミュニティB",
-          communityActivityRate: 0.28,
-          growthRateActivity: -0.14,
-          alerts: makeAlerts({ activeDrop: true }),
+          windowActivity: makeWindowActivity({ senderCount: 28, senderCountPrev: 40 }),
         }),
         makeCommunityOverview({
           communityId: "community-c",
           communityName: "コミュニティC",
-          communityActivityRate: 0.55,
-          growthRateActivity: 0.03,
-          latestCohortRetentionM1: null,
-          alerts: makeAlerts({ noNewMembers: true }),
+          windowActivity: makeWindowActivity({ newMemberCount: 0, newMemberCountPrev: 5 }),
+          latestCohort: makeLatestCohort({ size: 0, activeAtM1: 0 }),
         }),
       ],
   },

--- a/src/app/sysAdmin/_shared/fixtures/sysAdminDashboard.ts
+++ b/src/app/sysAdmin/_shared/fixtures/sysAdminDashboard.ts
@@ -22,15 +22,25 @@ export const makeSegmentCounts = (
 
 export const makeWindowActivity = (
   overrides: Partial<GqlSysAdminWindowActivity> = {},
-): GqlSysAdminWindowActivity => ({
-  __typename: "SysAdminWindowActivity",
-  senderCount: 50,
-  senderCountPrev: 46,
-  newMemberCount: 8,
-  newMemberCountPrev: 6,
-  retainedSenders: 38,
-  ...overrides,
-});
+): GqlSysAdminWindowActivity => {
+  const senderCount = overrides.senderCount ?? 50;
+  const senderCountPrev = overrides.senderCountPrev ?? 46;
+  const newMemberCount = overrides.newMemberCount ?? 8;
+  const newMemberCountPrev = overrides.newMemberCountPrev ?? 6;
+  // retained ≤ min(senderCount, senderCountPrev) by definition.
+  // Clamp the default so story overrides that lower senderCount(/Prev)
+  // don't produce negative newlyActivated / churned counts.
+  const retainedSenders =
+    overrides.retainedSenders ?? Math.min(senderCount, senderCountPrev, 38);
+  return {
+    __typename: "SysAdminWindowActivity",
+    senderCount,
+    senderCountPrev,
+    newMemberCount,
+    newMemberCountPrev,
+    retainedSenders,
+  };
+};
 
 export const makeWeeklyRetention = (
   overrides: Partial<GqlSysAdminWeeklyRetention> = {},

--- a/src/app/sysAdmin/_shared/format/number.ts
+++ b/src/app/sysAdmin/_shared/format/number.ts
@@ -19,6 +19,13 @@ export function toSignedPct(value: number | null | undefined, fallback = "-"): s
   return `${sign}${PCT_FORMATTER.format(value)}`;
 }
 
+export function toArrowPct(value: number | null | undefined, fallback = "-"): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return fallback;
+  if (value === 0) return PCT_FORMATTER.format(0);
+  const arrow = value > 0 ? "↑" : "↓";
+  return `${arrow}${PCT_FORMATTER.format(Math.abs(value))}`;
+}
+
 export function toIntJa(value: number | null | undefined, fallback = "-"): string {
   if (value === null || value === undefined || !Number.isFinite(value)) return fallback;
   return INT_FORMATTER.format(Math.trunc(value));

--- a/src/app/sysAdmin/features/dashboard/components/CommunityRow.stories.tsx
+++ b/src/app/sysAdmin/features/dashboard/components/CommunityRow.stories.tsx
@@ -2,8 +2,10 @@ import React from "react";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { CommunityRow } from "./CommunityRow";
 import {
-  makeAlerts,
   makeCommunityOverview,
+  makeLatestCohort,
+  makeWeeklyRetention,
+  makeWindowActivity,
 } from "../../../_shared/fixtures/sysAdminDashboard";
 
 const meta: Meta<typeof CommunityRow> = {
@@ -27,46 +29,58 @@ export const Healthy: Story = {
   },
 };
 
+// churnSpike: weeklyRetention.churnedSenders > retainedSenders
 export const ChurnSpike: Story = {
   args: {
     row: makeCommunityOverview({
       communityName: "kibotcha",
-      communityActivityRate: 0.12,
-      growthRateActivity: -0.18,
-      alerts: makeAlerts({ churnSpike: true }),
+      totalMembers: 100,
+      windowActivity: makeWindowActivity({ senderCount: 12, senderCountPrev: 18 }),
+      weeklyRetention: makeWeeklyRetention({ retainedSenders: 4, churnedSenders: 9 }),
     }),
   },
 };
 
+// activeDrop: growthRateActivity <= -0.2 (e.g. senderCount/Prev = 28/45 → -38%)
 export const ActiveDrop: Story = {
   args: {
     row: makeCommunityOverview({
       communityName: "コミュニティB",
-      communityActivityRate: 0.28,
-      growthRateActivity: -0.14,
-      alerts: makeAlerts({ activeDrop: true }),
+      totalMembers: 200,
+      windowActivity: makeWindowActivity({ senderCount: 28, senderCountPrev: 45 }),
     }),
   },
 };
 
+// noNewMembers: windowActivity.newMemberCount === 0
 export const NoNewMembers: Story = {
   args: {
     row: makeCommunityOverview({
       communityName: "コミュニティC",
-      communityActivityRate: 0.55,
-      growthRateActivity: null,
-      alerts: makeAlerts({ noNewMembers: true }),
+      totalMembers: 80,
+      windowActivity: makeWindowActivity({
+        senderCount: 44,
+        senderCountPrev: 42,
+        newMemberCount: 0,
+        newMemberCountPrev: 5,
+      }),
     }),
   },
 };
 
+// growth = null: prev-window had zero senders
 export const NoGrowthData: Story = {
   args: {
     row: makeCommunityOverview({
       communityName: "新規コミュニティ",
-      communityActivityRate: 0.08,
-      growthRateActivity: null,
       totalMembers: 8,
+      windowActivity: makeWindowActivity({
+        senderCount: 1,
+        senderCountPrev: 0,
+        newMemberCount: 8,
+        newMemberCountPrev: 0,
+      }),
+      latestCohort: makeLatestCohort({ size: 0, activeAtM1: 0 }),
     }),
   },
 };

--- a/src/app/sysAdmin/features/dashboard/components/CommunityRow.tsx
+++ b/src/app/sysAdmin/features/dashboard/components/CommunityRow.tsx
@@ -9,8 +9,10 @@ import { cn } from "@/lib/utils";
 import {
   deriveActivityRate,
   deriveAlerts,
+  deriveChurnedSenders,
   deriveGrowthRateActivity,
   deriveHubUserPct,
+  deriveNewlyActivatedSenders,
   hasAnyAlert,
 } from "@/app/sysAdmin/_shared/derive";
 import type { GqlSysAdminCommunityOverview } from "@/types/graphql";
@@ -27,6 +29,8 @@ export function CommunityRow({ row, onClick }: Props) {
   const growthRateActivity = deriveGrowthRateActivity(row);
   const hubUserPct = deriveHubUserPct(row);
   const newMemberCount = row.windowActivity.newMemberCount;
+  const newlyActivated = deriveNewlyActivatedSenders(row);
+  const churned = deriveChurnedSenders(row);
   const hasAlert = hasAnyAlert(alerts);
 
   return (
@@ -64,10 +68,7 @@ export function CommunityRow({ row, onClick }: Props) {
         <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1.5">
           <KpiPill label="MAU" value={toPct(activityRate)} delta={growthRateActivity} />
           <KpiPill label="Hub" value={toPct(hubUserPct)} />
-          {/* TODO: [Δ] ↑newlyActivated ↓churned pill awaits backend
-              addition of windowActivity.retainedSenders. Once shipped:
-                newlyActivated = senderCount - retainedSenders
-                churned        = senderCountPrev - retainedSenders */}
+          <KpiPill label="Δ" value={`↑${toIntJa(newlyActivated)} ↓${toIntJa(churned)}`} />
         </div>
       </ItemFooter>
     </Item>

--- a/src/app/sysAdmin/features/dashboard/components/CommunityRow.tsx
+++ b/src/app/sysAdmin/features/dashboard/components/CommunityRow.tsx
@@ -53,9 +53,10 @@ export function CommunityRow({ row, onClick }: Props) {
           <ItemTitle className="min-w-0 flex-1 truncate text-base font-semibold">
             {row.communityName}
           </ItemTitle>
-          <span className="shrink-0 text-base font-medium tabular-nums text-muted-foreground">
-            {toIntJa(row.totalMembers)}
-          </span>
+          <div className="flex shrink-0 items-baseline gap-1 tabular-nums text-muted-foreground">
+            <span className="text-base font-medium">{toIntJa(row.totalMembers)}</span>
+            <span className="text-xs">(+{toIntJa(newMemberCount)})</span>
+          </div>
         </div>
       </ItemContent>
 
@@ -63,7 +64,10 @@ export function CommunityRow({ row, onClick }: Props) {
         <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1.5">
           <KpiPill label="MAU" value={toPct(activityRate)} delta={growthRateActivity} />
           <KpiPill label="Hub" value={toPct(hubUserPct)} />
-          <KpiPill label="New" value={toIntJa(newMemberCount)} />
+          {/* TODO: [Δ] ↑newlyActivated ↓churned pill awaits backend
+              addition of windowActivity.retainedSenders. Once shipped:
+                newlyActivated = senderCount - retainedSenders
+                churned        = senderCountPrev - retainedSenders */}
         </div>
       </ItemFooter>
     </Item>

--- a/src/app/sysAdmin/features/dashboard/components/CommunityRow.tsx
+++ b/src/app/sysAdmin/features/dashboard/components/CommunityRow.tsx
@@ -6,6 +6,12 @@ import { PercentDelta } from "@/app/sysAdmin/_shared/components/PercentDelta";
 import { PrimaryAlertBadge } from "@/app/sysAdmin/_shared/components/PrimaryAlertBadge";
 import { toIntJa, toPct } from "@/app/sysAdmin/_shared/format/number";
 import { cn } from "@/lib/utils";
+import {
+  deriveActivityRate,
+  deriveAlerts,
+  deriveGrowthRateActivity,
+  hasAnyAlert,
+} from "@/app/sysAdmin/_shared/derive";
 import type { GqlSysAdminCommunityOverview } from "@/types/graphql";
 
 type Props = {
@@ -22,8 +28,10 @@ type Props = {
  */
 export function CommunityRow({ row, onClick }: Props) {
   const handleClick = () => onClick?.(row.communityId);
-  const hasAlert =
-    row.alerts.activeDrop || row.alerts.churnSpike || row.alerts.noNewMembers;
+  const alerts = deriveAlerts(row);
+  const activityRate = deriveActivityRate(row);
+  const growthRateActivity = deriveGrowthRateActivity(row);
+  const hasAlert = hasAnyAlert(alerts);
 
   return (
     <Item
@@ -42,7 +50,7 @@ export function CommunityRow({ row, onClick }: Props) {
         }
       }}
     >
-      {hasAlert && <PrimaryAlertBadge alerts={row.alerts} />}
+      {hasAlert && <PrimaryAlertBadge alerts={alerts} />}
 
       <ItemContent>
         <ItemTitle className="text-base font-semibold">
@@ -53,12 +61,12 @@ export function CommunityRow({ row, onClick }: Props) {
       <ItemFooter className="mt-0">
         <div className="flex flex-wrap items-baseline gap-x-2 text-xs text-muted-foreground">
           <span className="inline-flex items-baseline gap-1">
-            <span>MAU% {toPct(row.communityActivityRate)}</span>
-            {row.growthRateActivity != null && (
+            <span>MAU% {toPct(activityRate)}</span>
+            {growthRateActivity != null && (
               <span aria-label="前月比">
                 (
                 <PercentDelta
-                  value={row.growthRateActivity}
+                  value={growthRateActivity}
                   className="text-xs"
                 />
                 )

--- a/src/app/sysAdmin/features/dashboard/components/CommunityRow.tsx
+++ b/src/app/sysAdmin/features/dashboard/components/CommunityRow.tsx
@@ -3,17 +3,14 @@
 import React from "react";
 import { Item, ItemContent, ItemFooter, ItemTitle } from "@/components/ui/item";
 import { PercentDelta } from "@/app/sysAdmin/_shared/components/PercentDelta";
-import { PrimaryAlertBadge } from "@/app/sysAdmin/_shared/components/PrimaryAlertBadge";
 import { toIntJa, toPct } from "@/app/sysAdmin/_shared/format/number";
 import { cn } from "@/lib/utils";
 import {
   deriveActivityRate,
-  deriveAlerts,
   deriveChurnedSenders,
   deriveGrowthRateActivity,
   deriveHubUserPct,
   deriveNewlyActivatedSenders,
-  hasAnyAlert,
 } from "@/app/sysAdmin/_shared/derive";
 import type { GqlSysAdminCommunityOverview } from "@/types/graphql";
 
@@ -24,14 +21,12 @@ type Props = {
 
 export function CommunityRow({ row, onClick }: Props) {
   const handleClick = () => onClick?.(row.communityId);
-  const alerts = deriveAlerts(row);
   const activityRate = deriveActivityRate(row);
   const growthRateActivity = deriveGrowthRateActivity(row);
   const hubUserPct = deriveHubUserPct(row);
   const newMemberCount = row.windowActivity.newMemberCount;
   const newlyActivated = deriveNewlyActivatedSenders(row);
   const churned = deriveChurnedSenders(row);
-  const hasAlert = hasAnyAlert(alerts);
 
   return (
     <Item
@@ -50,8 +45,6 @@ export function CommunityRow({ row, onClick }: Props) {
         }
       }}
     >
-      {hasAlert && <PrimaryAlertBadge alerts={alerts} />}
-
       <ItemContent>
         <div className="flex w-full items-baseline justify-between gap-2">
           <ItemTitle className="min-w-0 flex-1 truncate text-base font-semibold">

--- a/src/app/sysAdmin/features/dashboard/components/CommunityRow.tsx
+++ b/src/app/sysAdmin/features/dashboard/components/CommunityRow.tsx
@@ -10,6 +10,7 @@ import {
   deriveActivityRate,
   deriveAlerts,
   deriveGrowthRateActivity,
+  deriveHubUserPct,
   hasAnyAlert,
 } from "@/app/sysAdmin/_shared/derive";
 import type { GqlSysAdminCommunityOverview } from "@/types/graphql";
@@ -19,18 +20,13 @@ type Props = {
   onClick?: (communityId: string) => void;
 };
 
-/**
- * opportunities の OpportunityItem を参考にした compact な 1 行表示。
- * 構造:
- * - status (アラートがある場合のみ、タイトル上に小さく)
- * - community name (bold base)
- * - footer: MAU%・前月比・人数 (xs muted)
- */
 export function CommunityRow({ row, onClick }: Props) {
   const handleClick = () => onClick?.(row.communityId);
   const alerts = deriveAlerts(row);
   const activityRate = deriveActivityRate(row);
   const growthRateActivity = deriveGrowthRateActivity(row);
+  const hubUserPct = deriveHubUserPct(row);
+  const newMemberCount = row.windowActivity.newMemberCount;
   const hasAlert = hasAnyAlert(alerts);
 
   return (
@@ -53,30 +49,45 @@ export function CommunityRow({ row, onClick }: Props) {
       {hasAlert && <PrimaryAlertBadge alerts={alerts} />}
 
       <ItemContent>
-        <ItemTitle className="text-base font-semibold">
-          {row.communityName}
-        </ItemTitle>
+        <div className="flex w-full items-baseline justify-between gap-2">
+          <ItemTitle className="min-w-0 flex-1 truncate text-base font-semibold">
+            {row.communityName}
+          </ItemTitle>
+          <span className="shrink-0 text-base font-medium tabular-nums text-muted-foreground">
+            {toIntJa(row.totalMembers)}
+          </span>
+        </div>
       </ItemContent>
 
       <ItemFooter className="mt-0">
-        <div className="flex flex-wrap items-baseline gap-x-2 text-xs text-muted-foreground">
-          <span className="inline-flex items-baseline gap-1">
-            <span>MAU% {toPct(activityRate)}</span>
-            {growthRateActivity != null && (
-              <span aria-label="前月比">
-                (
-                <PercentDelta
-                  value={growthRateActivity}
-                  className="text-xs"
-                />
-                )
-              </span>
-            )}
-          </span>
-          <span aria-hidden>·</span>
-          <span>{toIntJa(row.totalMembers)}人</span>
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1.5">
+          <KpiPill label="MAU" value={toPct(activityRate)} delta={growthRateActivity} />
+          <KpiPill label="Hub" value={toPct(hubUserPct)} />
+          <KpiPill label="New" value={toIntJa(newMemberCount)} />
         </div>
       </ItemFooter>
     </Item>
+  );
+}
+
+type KpiPillProps = {
+  label: string;
+  value: string;
+  delta?: number | null;
+};
+
+function KpiPill({ label, value, delta }: KpiPillProps) {
+  return (
+    <span className="inline-flex items-baseline gap-1">
+      <span className="rounded-md border border-border px-1.5 py-px text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <span className="text-sm font-medium tabular-nums">{value}</span>
+      {delta !== undefined && delta !== null && (
+        <span className="text-xs text-muted-foreground">
+          (<PercentDelta value={delta} className="text-xs" />)
+        </span>
+      )}
+    </span>
   );
 }

--- a/src/app/sysAdmin/features/dashboard/hooks/useDashboardOverview.ts
+++ b/src/app/sysAdmin/features/dashboard/hooks/useDashboardOverview.ts
@@ -9,6 +9,7 @@ import {
   useGetSysAdminDashboardQuery,
 } from "@/types/graphql";
 import type { DashboardControlsState } from "./useDashboardControls";
+import { DASHBOARD_CONTROLS_DEFAULTS } from "./useDashboardControls";
 import {
   DEFAULT_PERIOD,
   resolvePeriodToInput,
@@ -22,8 +23,8 @@ export type DashboardOverviewResult = {
   asOf: Date | null;
 };
 
-const DEFAULT_TIER1 = 0.7;
-const DEFAULT_TIER2 = 0.4;
+const DEFAULT_TIER1 = DASHBOARD_CONTROLS_DEFAULTS.tier1;
+const DEFAULT_TIER2 = DASHBOARD_CONTROLS_DEFAULTS.tier2;
 
 /**
  * SSR で取得した初期データと、クライアント側のコントロール変化時のみ発火する

--- a/src/app/sysAdmin/page.stories.tsx
+++ b/src/app/sysAdmin/page.stories.tsx
@@ -3,9 +3,10 @@ import { GetSysAdminDashboardDocument } from "@/types/graphql";
 import { withApollo, withPageShell } from "../../../.storybook/decorators";
 import { SysAdminPageClient } from "./SysAdminPageClient";
 import {
-  makeAlerts,
   makeCommunityOverview,
   makeDashboardPayload,
+  makeWeeklyRetention,
+  makeWindowActivity,
 } from "./_shared/fixtures/sysAdminDashboard";
 
 // page.tsx は async RSC なので Storybook から直接 render できない。
@@ -41,40 +42,56 @@ export const WithItems: Story = {
                 makeCommunityOverview({
                   communityId: "kibotcha",
                   communityName: "kibotcha",
-                  communityActivityRate: 0.423,
-                  growthRateActivity: 0.083,
                   totalMembers: 566,
+                  windowActivity: makeWindowActivity({
+                    senderCount: 240,
+                    senderCountPrev: 222,
+                  }),
                 }),
+                // churnSpike
                 makeCommunityOverview({
                   communityId: "community-b",
                   communityName: "コミュニティB",
-                  communityActivityRate: 0.12,
-                  growthRateActivity: -0.18,
                   totalMembers: 240,
-                  alerts: makeAlerts({ churnSpike: true }),
+                  windowActivity: makeWindowActivity({
+                    senderCount: 30,
+                    senderCountPrev: 36,
+                  }),
+                  weeklyRetention: makeWeeklyRetention({
+                    retainedSenders: 6,
+                    churnedSenders: 14,
+                  }),
                 }),
+                // activeDrop (~-38% growth)
                 makeCommunityOverview({
                   communityId: "community-c",
                   communityName: "コミュニティC",
-                  communityActivityRate: 0.28,
-                  growthRateActivity: -0.14,
                   totalMembers: 180,
-                  alerts: makeAlerts({ activeDrop: true }),
+                  windowActivity: makeWindowActivity({
+                    senderCount: 50,
+                    senderCountPrev: 81,
+                  }),
                 }),
+                // noNewMembers
                 makeCommunityOverview({
                   communityId: "community-d",
                   communityName: "コミュニティD",
-                  communityActivityRate: 0.55,
-                  growthRateActivity: null,
                   totalMembers: 48,
-                  alerts: makeAlerts({ noNewMembers: true }),
+                  windowActivity: makeWindowActivity({
+                    senderCount: 26,
+                    senderCountPrev: 25,
+                    newMemberCount: 0,
+                    newMemberCountPrev: 4,
+                  }),
                 }),
                 makeCommunityOverview({
                   communityId: "community-e",
                   communityName: "未来こども塾",
-                  communityActivityRate: 0.065,
-                  growthRateActivity: -0.03,
                   totalMembers: 566,
+                  windowActivity: makeWindowActivity({
+                    senderCount: 37,
+                    senderCountPrev: 38,
+                  }),
                 }),
               ],
             }),

--- a/src/graphql/account/sysAdmin/fragment.ts
+++ b/src/graphql/account/sysAdmin/fragment.ts
@@ -16,6 +16,7 @@ export const SYS_ADMIN_WINDOW_ACTIVITY_FRAGMENT = gql`
     senderCountPrev
     newMemberCount
     newMemberCountPrev
+    retainedSenders
   }
 `;
 

--- a/src/graphql/account/sysAdmin/fragment.ts
+++ b/src/graphql/account/sysAdmin/fragment.ts
@@ -1,13 +1,5 @@
 import { gql } from "@apollo/client";
 
-export const SYS_ADMIN_ALERT_FRAGMENT = gql`
-  fragment SysAdminAlertFields on SysAdminCommunityAlerts {
-    activeDrop
-    churnSpike
-    noNewMembers
-  }
-`;
-
 export const SYS_ADMIN_SEGMENT_COUNTS_FRAGMENT = gql`
   fragment SysAdminSegmentCountsFields on SysAdminSegmentCounts {
     total
@@ -15,6 +7,29 @@ export const SYS_ADMIN_SEGMENT_COUNTS_FRAGMENT = gql`
     passiveCount
     tier1Count
     tier2Count
+  }
+`;
+
+export const SYS_ADMIN_WINDOW_ACTIVITY_FRAGMENT = gql`
+  fragment SysAdminWindowActivityFields on SysAdminWindowActivity {
+    senderCount
+    senderCountPrev
+    newMemberCount
+    newMemberCountPrev
+  }
+`;
+
+export const SYS_ADMIN_WEEKLY_RETENTION_FRAGMENT = gql`
+  fragment SysAdminWeeklyRetentionFields on SysAdminWeeklyRetention {
+    retainedSenders
+    churnedSenders
+  }
+`;
+
+export const SYS_ADMIN_LATEST_COHORT_FRAGMENT = gql`
+  fragment SysAdminLatestCohortFields on SysAdminLatestCohort {
+    size
+    activeAtM1
   }
 `;
 
@@ -30,20 +45,22 @@ export const SYS_ADMIN_COMMUNITY_OVERVIEW_ROW_FRAGMENT = gql`
   fragment SysAdminCommunityOverviewRowFields on SysAdminCommunityOverview {
     communityId
     communityName
-    communityActivityRate
-    growthRateActivity
-    latestCohortRetentionM1
     totalMembers
-    passiveCount
-    tier1Count
-    tier2Count
     segmentCounts {
       ...SysAdminSegmentCountsFields
     }
-    alerts {
-      ...SysAdminAlertFields
+    windowActivity {
+      ...SysAdminWindowActivityFields
+    }
+    weeklyRetention {
+      ...SysAdminWeeklyRetentionFields
+    }
+    latestCohort {
+      ...SysAdminLatestCohortFields
     }
   }
   ${SYS_ADMIN_SEGMENT_COUNTS_FRAGMENT}
-  ${SYS_ADMIN_ALERT_FRAGMENT}
+  ${SYS_ADMIN_WINDOW_ACTIVITY_FRAGMENT}
+  ${SYS_ADMIN_WEEKLY_RETENTION_FRAGMENT}
+  ${SYS_ADMIN_LATEST_COHORT_FRAGMENT}
 `;

--- a/src/graphql/account/sysAdmin/server.ts
+++ b/src/graphql/account/sysAdmin/server.ts
@@ -20,13 +20,7 @@ export const GET_SYS_ADMIN_DASHBOARD_SERVER_QUERY = `
       communities {
         communityId
         communityName
-        communityActivityRate
-        growthRateActivity
-        latestCohortRetentionM1
         totalMembers
-        passiveCount
-        tier1Count
-        tier2Count
         segmentCounts {
           total
           activeCount
@@ -34,10 +28,19 @@ export const GET_SYS_ADMIN_DASHBOARD_SERVER_QUERY = `
           tier1Count
           tier2Count
         }
-        alerts {
-          activeDrop
-          churnSpike
-          noNewMembers
+        windowActivity {
+          senderCount
+          senderCountPrev
+          newMemberCount
+          newMemberCountPrev
+        }
+        weeklyRetention {
+          retainedSenders
+          churnedSenders
+        }
+        latestCohort {
+          size
+          activeAtM1
         }
       }
     }

--- a/src/graphql/account/sysAdmin/server.ts
+++ b/src/graphql/account/sysAdmin/server.ts
@@ -33,6 +33,7 @@ export const GET_SYS_ADMIN_DASHBOARD_SERVER_QUERY = `
           senderCountPrev
           newMemberCount
           newMemberCountPrev
+          retainedSenders
         }
         weeklyRetention {
           retainedSenders

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -2964,55 +2964,42 @@ export type GqlSysAdminCommunityDetailPayload = {
 };
 
 /**
- * One row of the L1 all-community table. See the module docstring for the
- * distinction between `communityActivityRate` (this type) and
- * `userSendRate` (SysAdminMemberRow).
+ * One row of the L1 all-community table. Designed for at-a-glance
+ * intervention judgment: each row carries the raw counts the client
+ * needs to derive rates, growth, alerts, sort keys, and filter
+ * predicates without a second round-trip.
+ *
+ * Calendar-month metrics live on the L2 detail card
+ * (SysAdminCommunitySummaryCard) — L1 is rolling-window only.
  */
 export type GqlSysAdminCommunityOverview = {
   __typename?: "SysAdminCommunityOverview";
-  /** Alert flags (see SysAdminCommunityAlerts). */
-  alerts: GqlSysAdminCommunityAlerts;
-  /**
-   * Community activity rate for the JST calendar month containing asOf:
-   * unique DONATION senders in that month / month-end total_members.
-   * 0.0–1.0. NOT the individual-level userSendRate.
-   */
-  communityActivityRate: Scalars["Float"]["output"];
   /** Community id. */
   communityId: Scalars["ID"]["output"];
   /** Community display name (t_communities.name). */
   communityName: Scalars["String"]["output"];
   /**
-   * Month-over-month % change in communityActivityRate.
-   * Returned as a fraction (e.g. -0.2 == -20%). null when the prior month
-   * has no data to compare against.
+   * Latest completed monthly cohort and its M+1 activity. See
+   * SysAdminLatestCohort.
    */
-  growthRateActivity?: Maybe<Scalars["Float"]["output"]>;
+  latestCohort: GqlSysAdminLatestCohort;
   /**
-   * Retention rate of the most recent completed cohort (members who joined
-   * in asOf's previous JST month) measured in the month after joining.
-   * null when that cohort is empty.
+   * Per-stage member counts (tier1 / tier2 / passive, cumulative
+   * per the type doc) classified against input.segmentThresholds.
    */
-  latestCohortRetentionM1?: Maybe<Scalars["Float"]["output"]>;
-  /**
-   * Direct member count for the "latent" stage (never donated).
-   * Convenience field (== segmentCounts.passiveCount).
-   */
-  passiveCount: Scalars["Int"]["output"];
-  /** Stage counts under the supplied thresholds (cumulative, see type doc). */
   segmentCounts: GqlSysAdminSegmentCounts;
   /**
-   * Direct member count for the "habitual" stage (userSendRate >= tier1).
-   * Convenience field (== segmentCounts.tier1Count).
+   * Total status='JOINED' members as of asOf. Members whose
+   * created_at is after asOf are excluded from the count.
    */
-  tier1Count: Scalars["Int"]["output"];
-  /**
-   * Direct member count for the "regular+habitual" stage
-   * (userSendRate >= tier2). Convenience field (== segmentCounts.tier2Count).
-   */
-  tier2Count: Scalars["Int"]["output"];
-  /** Total status='JOINED' members at asOf. */
   totalMembers: Scalars["Int"]["output"];
+  /**
+   * Latest completed-week retention signals for client-side churn
+   * detection. See SysAdminWeeklyRetention.
+   */
+  weeklyRetention: GqlSysAdminWeeklyRetention;
+  /** Rolling-window DONATION activity. See SysAdminWindowActivity. */
+  windowActivity: GqlSysAdminWindowActivity;
 };
 
 /**
@@ -3066,14 +3053,22 @@ export type GqlSysAdminCommunitySummaryCard = {
 /** Input for the L1 all-community overview (`sysAdminDashboard`). */
 export type GqlSysAdminDashboardInput = {
   /**
-   * The "as of" timestamp. All trailing-window calculations are anchored
-   * here: the "latest month" is the JST calendar month containing asOf,
-   * and "latest week" is the ISO-week containing asOf. Defaults to now
-   * when omitted.
+   * As-of timestamp anchor. All trailing-window calculations are
+   * anchored here:
+   *   - parametric activity window: [asOf - windowDays, asOf + 1 JST日)
+   *   - weekly retention: latest completed ISO week before asOf
+   *   - latest cohort: (asOf JST月 - 2) so its M+1 window is fully past
+   * Defaults to now when omitted.
    */
   asOf?: InputMaybe<Scalars["Datetime"]["input"]>;
-  /** Stage-count thresholds (see SysAdminSegmentThresholdsInput). */
+  /** Stage classification thresholds (see SysAdminSegmentThresholdsInput). */
   segmentThresholds?: InputMaybe<GqlSysAdminSegmentThresholdsInput>;
+  /**
+   * Length of the rolling activity window in JST days. Effective
+   * range 7-90; values outside are silently clamped on the server.
+   * Defaults to 28 (= 4 weeks, absorbs day-of-week variance).
+   */
+  windowDays?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 /** Root payload for sysAdminDashboard (L1). */
@@ -3085,6 +3080,34 @@ export type GqlSysAdminDashboardPayload = {
   communities: Array<GqlSysAdminCommunityOverview>;
   /** Platform-wide aggregate row. */
   platform: GqlSysAdminPlatformSummary;
+};
+
+/**
+ * Most recently completed monthly cohort plus its M+1 activity.
+ * "M+1" follows standard cohort-analysis convention: the calendar
+ * month immediately after the joining month.
+ *
+ * The cohort is selected as (asOf's JST month - 2 months) so its
+ * M+1 window — the JST month immediately preceding asOf's month —
+ * is fully past. This avoids reporting an artificially low retention
+ * during the in-progress month.
+ *
+ * Raw counts are returned; the client divides for the retention rate
+ * and decides how to handle small-N cohorts via `size`.
+ */
+export type GqlSysAdminLatestCohort = {
+  __typename?: "SysAdminLatestCohort";
+  /**
+   * Of those cohort members, how many sent at least one DONATION
+   * during the M+1 month.
+   */
+  activeAtM1: Scalars["Int"]["output"];
+  /**
+   * Cohort size: status='JOINED' members whose created_at falls
+   * within the cohort month. 0 when no one joined that month
+   * (callers should treat M+1 retention as null in that case).
+   */
+  size: Scalars["Int"]["output"];
 };
 
 /** Paginated member list for the L2 detail. */
@@ -3337,6 +3360,53 @@ export const GqlSysAdminUserSortField = {
 
 export type GqlSysAdminUserSortField =
   (typeof GqlSysAdminUserSortField)[keyof typeof GqlSysAdminUserSortField];
+/**
+ * DONATION sender retention against the most recently completed
+ * ISO week (Monday 00:00 JST). Raw signals only; the client composes
+ * churn alerts (e.g. churnedSenders > retainedSenders).
+ */
+export type GqlSysAdminWeeklyRetention = {
+  __typename?: "SysAdminWeeklyRetention";
+  /**
+   * Users who sent DONATION in the week-before-latest but NOT in
+   * the latest completed week. "Lost this week, was engaged last week."
+   */
+  churnedSenders: Scalars["Int"]["output"];
+  /**
+   * Users who sent DONATION in the latest completed week AND in
+   * the week before it. "Engaged this week, was engaged last week."
+   */
+  retainedSenders: Scalars["Int"]["output"];
+};
+
+/**
+ * DONATION activity within the parametric window driven by
+ * `SysAdminDashboardInput.windowDays`. Both the current window and
+ * the immediately preceding window of equal length are returned so
+ * the client can derive growth rates without a second query.
+ *
+ *   current  = [asOf - windowDays JST日, asOf + 1 JST日)
+ *   previous = [asOf - 2 * windowDays, asOf - windowDays)
+ */
+export type GqlSysAdminWindowActivity = {
+  __typename?: "SysAdminWindowActivity";
+  /**
+   * New JOINED memberships (t_memberships.created_at within the
+   * current window, status='JOINED').
+   */
+  newMemberCount: Scalars["Int"]["output"];
+  /** Same metric for the previous window. */
+  newMemberCountPrev: Scalars["Int"]["output"];
+  /**
+   * Unique users with at least one outgoing DONATION transaction
+   * during the current window (donation_out_count > 0 in
+   * mv_user_transaction_daily).
+   */
+  senderCount: Scalars["Int"]["output"];
+  /** Same metric for the previous window of equal length. */
+  senderCountPrev: Scalars["Int"]["output"];
+};
+
 export const GqlSysRole = {
   SysAdmin: "SYS_ADMIN",
   User: "USER",
@@ -5006,13 +5076,6 @@ export type GqlGetNftInstanceWithDidQuery = {
   } | null;
 };
 
-export type GqlSysAdminAlertFieldsFragment = {
-  __typename?: "SysAdminCommunityAlerts";
-  activeDrop: boolean;
-  churnSpike: boolean;
-  noNewMembers: boolean;
-};
-
 export type GqlSysAdminSegmentCountsFieldsFragment = {
   __typename?: "SysAdminSegmentCounts";
   total: number;
@@ -5020,6 +5083,26 @@ export type GqlSysAdminSegmentCountsFieldsFragment = {
   passiveCount: number;
   tier1Count: number;
   tier2Count: number;
+};
+
+export type GqlSysAdminWindowActivityFieldsFragment = {
+  __typename?: "SysAdminWindowActivity";
+  senderCount: number;
+  senderCountPrev: number;
+  newMemberCount: number;
+  newMemberCountPrev: number;
+};
+
+export type GqlSysAdminWeeklyRetentionFieldsFragment = {
+  __typename?: "SysAdminWeeklyRetention";
+  retainedSenders: number;
+  churnedSenders: number;
+};
+
+export type GqlSysAdminLatestCohortFieldsFragment = {
+  __typename?: "SysAdminLatestCohort";
+  size: number;
+  activeAtM1: number;
 };
 
 export type GqlSysAdminPlatformSummaryFieldsFragment = {
@@ -5033,13 +5116,7 @@ export type GqlSysAdminCommunityOverviewRowFieldsFragment = {
   __typename?: "SysAdminCommunityOverview";
   communityId: string;
   communityName: string;
-  communityActivityRate: number;
-  growthRateActivity?: number | null;
-  latestCohortRetentionM1?: number | null;
   totalMembers: number;
-  passiveCount: number;
-  tier1Count: number;
-  tier2Count: number;
   segmentCounts: {
     __typename?: "SysAdminSegmentCounts";
     total: number;
@@ -5048,112 +5125,19 @@ export type GqlSysAdminCommunityOverviewRowFieldsFragment = {
     tier1Count: number;
     tier2Count: number;
   };
-  alerts: {
-    __typename?: "SysAdminCommunityAlerts";
-    activeDrop: boolean;
-    churnSpike: boolean;
-    noNewMembers: boolean;
+  windowActivity: {
+    __typename?: "SysAdminWindowActivity";
+    senderCount: number;
+    senderCountPrev: number;
+    newMemberCount: number;
+    newMemberCountPrev: number;
   };
-};
-
-export type GqlSysAdminCommunityDetailSummaryFieldsFragment = {
-  __typename?: "SysAdminCommunitySummaryCard";
-  communityId: string;
-  communityName: string;
-  communityActivityRate: number;
-  communityActivityRate3mAvg?: number | null;
-  growthRateActivity?: number | null;
-  totalMembers: number;
-  tier2Count: number;
-  tier2Pct: number;
-  totalDonationPointsAllTime: number;
-  maxChainDepthAllTime?: number | null;
-  dataFrom?: Date | null;
-  dataTo?: Date | null;
-};
-
-export type GqlSysAdminStageBucketFieldsFragment = {
-  __typename?: "SysAdminStageBucket";
-  count: number;
-  pct: number;
-  avgSendRate: number;
-  avgMonthsIn: number;
-  pointsContributionPct: number;
-};
-
-export type GqlSysAdminStageDistributionFieldsFragment = {
-  __typename?: "SysAdminStageDistribution";
-  habitual: {
-    __typename?: "SysAdminStageBucket";
-    count: number;
-    pct: number;
-    avgSendRate: number;
-    avgMonthsIn: number;
-    pointsContributionPct: number;
+  weeklyRetention: {
+    __typename?: "SysAdminWeeklyRetention";
+    retainedSenders: number;
+    churnedSenders: number;
   };
-  regular: {
-    __typename?: "SysAdminStageBucket";
-    count: number;
-    pct: number;
-    avgSendRate: number;
-    avgMonthsIn: number;
-    pointsContributionPct: number;
-  };
-  occasional: {
-    __typename?: "SysAdminStageBucket";
-    count: number;
-    pct: number;
-    avgSendRate: number;
-    avgMonthsIn: number;
-    pointsContributionPct: number;
-  };
-  latent: {
-    __typename?: "SysAdminStageBucket";
-    count: number;
-    pct: number;
-    avgSendRate: number;
-    avgMonthsIn: number;
-    pointsContributionPct: number;
-  };
-};
-
-export type GqlSysAdminMonthlyActivityPointFieldsFragment = {
-  __typename?: "SysAdminMonthlyActivityPoint";
-  month: Date;
-  communityActivityRate: number;
-  senderCount: number;
-  newMembers: number;
-  donationPointsSum: number;
-  chainPct?: number | null;
-};
-
-export type GqlSysAdminRetentionTrendPointFieldsFragment = {
-  __typename?: "SysAdminRetentionTrendPoint";
-  week: Date;
-  communityActivityRate?: number | null;
-  retainedSenders: number;
-  churnedSenders: number;
-  returnedSenders: number;
-  newMembers: number;
-};
-
-export type GqlSysAdminCohortRetentionPointFieldsFragment = {
-  __typename?: "SysAdminCohortRetentionPoint";
-  cohortMonth: Date;
-  cohortSize: number;
-  retentionM1?: number | null;
-  retentionM3?: number | null;
-  retentionM6?: number | null;
-};
-
-export type GqlSysAdminMemberRowFieldsFragment = {
-  __typename?: "SysAdminMemberRow";
-  userId: string;
-  name?: string | null;
-  userSendRate: number;
-  totalPointsOut: number;
-  donationOutMonths: number;
-  monthsIn: number;
+  latestCohort: { __typename?: "SysAdminLatestCohort"; size: number; activeAtM1: number };
 };
 
 export type GqlGetSysAdminDashboardQueryVariables = Exact<{
@@ -5175,13 +5159,7 @@ export type GqlGetSysAdminDashboardQuery = {
       __typename?: "SysAdminCommunityOverview";
       communityId: string;
       communityName: string;
-      communityActivityRate: number;
-      growthRateActivity?: number | null;
-      latestCohortRetentionM1?: number | null;
       totalMembers: number;
-      passiveCount: number;
-      tier1Count: number;
-      tier2Count: number;
       segmentCounts: {
         __typename?: "SysAdminSegmentCounts";
         total: number;
@@ -5190,124 +5168,20 @@ export type GqlGetSysAdminDashboardQuery = {
         tier1Count: number;
         tier2Count: number;
       };
-      alerts: {
-        __typename?: "SysAdminCommunityAlerts";
-        activeDrop: boolean;
-        churnSpike: boolean;
-        noNewMembers: boolean;
+      windowActivity: {
+        __typename?: "SysAdminWindowActivity";
+        senderCount: number;
+        senderCountPrev: number;
+        newMemberCount: number;
+        newMemberCountPrev: number;
       };
+      weeklyRetention: {
+        __typename?: "SysAdminWeeklyRetention";
+        retainedSenders: number;
+        churnedSenders: number;
+      };
+      latestCohort: { __typename?: "SysAdminLatestCohort"; size: number; activeAtM1: number };
     }>;
-  };
-};
-
-export type GqlGetSysAdminCommunityDetailQueryVariables = Exact<{
-  input: GqlSysAdminCommunityDetailInput;
-}>;
-
-export type GqlGetSysAdminCommunityDetailQuery = {
-  __typename?: "Query";
-  sysAdminCommunityDetail: {
-    __typename?: "SysAdminCommunityDetailPayload";
-    asOf: Date;
-    communityId: string;
-    communityName: string;
-    windowMonths: number;
-    alerts: {
-      __typename?: "SysAdminCommunityAlerts";
-      activeDrop: boolean;
-      churnSpike: boolean;
-      noNewMembers: boolean;
-    };
-    summary: {
-      __typename?: "SysAdminCommunitySummaryCard";
-      communityId: string;
-      communityName: string;
-      communityActivityRate: number;
-      communityActivityRate3mAvg?: number | null;
-      growthRateActivity?: number | null;
-      totalMembers: number;
-      tier2Count: number;
-      tier2Pct: number;
-      totalDonationPointsAllTime: number;
-      maxChainDepthAllTime?: number | null;
-      dataFrom?: Date | null;
-      dataTo?: Date | null;
-    };
-    stages: {
-      __typename?: "SysAdminStageDistribution";
-      habitual: {
-        __typename?: "SysAdminStageBucket";
-        count: number;
-        pct: number;
-        avgSendRate: number;
-        avgMonthsIn: number;
-        pointsContributionPct: number;
-      };
-      regular: {
-        __typename?: "SysAdminStageBucket";
-        count: number;
-        pct: number;
-        avgSendRate: number;
-        avgMonthsIn: number;
-        pointsContributionPct: number;
-      };
-      occasional: {
-        __typename?: "SysAdminStageBucket";
-        count: number;
-        pct: number;
-        avgSendRate: number;
-        avgMonthsIn: number;
-        pointsContributionPct: number;
-      };
-      latent: {
-        __typename?: "SysAdminStageBucket";
-        count: number;
-        pct: number;
-        avgSendRate: number;
-        avgMonthsIn: number;
-        pointsContributionPct: number;
-      };
-    };
-    monthlyActivityTrend: Array<{
-      __typename?: "SysAdminMonthlyActivityPoint";
-      month: Date;
-      communityActivityRate: number;
-      senderCount: number;
-      newMembers: number;
-      donationPointsSum: number;
-      chainPct?: number | null;
-    }>;
-    retentionTrend: Array<{
-      __typename?: "SysAdminRetentionTrendPoint";
-      week: Date;
-      communityActivityRate?: number | null;
-      retainedSenders: number;
-      churnedSenders: number;
-      returnedSenders: number;
-      newMembers: number;
-    }>;
-    cohortRetention: Array<{
-      __typename?: "SysAdminCohortRetentionPoint";
-      cohortMonth: Date;
-      cohortSize: number;
-      retentionM1?: number | null;
-      retentionM3?: number | null;
-      retentionM6?: number | null;
-    }>;
-    memberList: {
-      __typename?: "SysAdminMemberList";
-      hasNextPage: boolean;
-      nextCursor?: string | null;
-      users: Array<{
-        __typename?: "SysAdminMemberRow";
-        userId: string;
-        name?: string | null;
-        userSendRate: number;
-        totalPointsOut: number;
-        donationOutMonths: number;
-        monthsIn: number;
-      }>;
-    };
   };
 };
 
@@ -8686,114 +8560,48 @@ export const SysAdminSegmentCountsFieldsFragmentDoc = gql`
     tier2Count
   }
 `;
-export const SysAdminAlertFieldsFragmentDoc = gql`
-  fragment SysAdminAlertFields on SysAdminCommunityAlerts {
-    activeDrop
-    churnSpike
-    noNewMembers
+export const SysAdminWindowActivityFieldsFragmentDoc = gql`
+  fragment SysAdminWindowActivityFields on SysAdminWindowActivity {
+    senderCount
+    senderCountPrev
+    newMemberCount
+    newMemberCountPrev
+  }
+`;
+export const SysAdminWeeklyRetentionFieldsFragmentDoc = gql`
+  fragment SysAdminWeeklyRetentionFields on SysAdminWeeklyRetention {
+    retainedSenders
+    churnedSenders
+  }
+`;
+export const SysAdminLatestCohortFieldsFragmentDoc = gql`
+  fragment SysAdminLatestCohortFields on SysAdminLatestCohort {
+    size
+    activeAtM1
   }
 `;
 export const SysAdminCommunityOverviewRowFieldsFragmentDoc = gql`
   fragment SysAdminCommunityOverviewRowFields on SysAdminCommunityOverview {
     communityId
     communityName
-    communityActivityRate
-    growthRateActivity
-    latestCohortRetentionM1
     totalMembers
-    passiveCount
-    tier1Count
-    tier2Count
     segmentCounts {
       ...SysAdminSegmentCountsFields
     }
-    alerts {
-      ...SysAdminAlertFields
+    windowActivity {
+      ...SysAdminWindowActivityFields
+    }
+    weeklyRetention {
+      ...SysAdminWeeklyRetentionFields
+    }
+    latestCohort {
+      ...SysAdminLatestCohortFields
     }
   }
   ${SysAdminSegmentCountsFieldsFragmentDoc}
-  ${SysAdminAlertFieldsFragmentDoc}
-`;
-export const SysAdminCommunityDetailSummaryFieldsFragmentDoc = gql`
-  fragment SysAdminCommunityDetailSummaryFields on SysAdminCommunitySummaryCard {
-    communityId
-    communityName
-    communityActivityRate
-    communityActivityRate3mAvg
-    growthRateActivity
-    totalMembers
-    tier2Count
-    tier2Pct
-    totalDonationPointsAllTime
-    maxChainDepthAllTime
-    dataFrom
-    dataTo
-  }
-`;
-export const SysAdminStageBucketFieldsFragmentDoc = gql`
-  fragment SysAdminStageBucketFields on SysAdminStageBucket {
-    count
-    pct
-    avgSendRate
-    avgMonthsIn
-    pointsContributionPct
-  }
-`;
-export const SysAdminStageDistributionFieldsFragmentDoc = gql`
-  fragment SysAdminStageDistributionFields on SysAdminStageDistribution {
-    habitual {
-      ...SysAdminStageBucketFields
-    }
-    regular {
-      ...SysAdminStageBucketFields
-    }
-    occasional {
-      ...SysAdminStageBucketFields
-    }
-    latent {
-      ...SysAdminStageBucketFields
-    }
-  }
-  ${SysAdminStageBucketFieldsFragmentDoc}
-`;
-export const SysAdminMonthlyActivityPointFieldsFragmentDoc = gql`
-  fragment SysAdminMonthlyActivityPointFields on SysAdminMonthlyActivityPoint {
-    month
-    communityActivityRate
-    senderCount
-    newMembers
-    donationPointsSum
-    chainPct
-  }
-`;
-export const SysAdminRetentionTrendPointFieldsFragmentDoc = gql`
-  fragment SysAdminRetentionTrendPointFields on SysAdminRetentionTrendPoint {
-    week
-    communityActivityRate
-    retainedSenders
-    churnedSenders
-    returnedSenders
-    newMembers
-  }
-`;
-export const SysAdminCohortRetentionPointFieldsFragmentDoc = gql`
-  fragment SysAdminCohortRetentionPointFields on SysAdminCohortRetentionPoint {
-    cohortMonth
-    cohortSize
-    retentionM1
-    retentionM3
-    retentionM6
-  }
-`;
-export const SysAdminMemberRowFieldsFragmentDoc = gql`
-  fragment SysAdminMemberRowFields on SysAdminMemberRow {
-    userId
-    name
-    userSendRate
-    totalPointsOut
-    donationOutMonths
-    monthsIn
-  }
+  ${SysAdminWindowActivityFieldsFragmentDoc}
+  ${SysAdminWeeklyRetentionFieldsFragmentDoc}
+  ${SysAdminLatestCohortFieldsFragmentDoc}
 `;
 export const PlaceFieldsFragmentDoc = gql`
   fragment PlaceFields on Place {
@@ -10978,121 +10786,6 @@ export type GetSysAdminDashboardSuspenseQueryHookResult = ReturnType<
 export type GetSysAdminDashboardQueryResult = Apollo.QueryResult<
   GqlGetSysAdminDashboardQuery,
   GqlGetSysAdminDashboardQueryVariables
->;
-export const GetSysAdminCommunityDetailDocument = gql`
-  query GetSysAdminCommunityDetail($input: SysAdminCommunityDetailInput!) {
-    sysAdminCommunityDetail(input: $input) {
-      asOf
-      communityId
-      communityName
-      windowMonths
-      alerts {
-        ...SysAdminAlertFields
-      }
-      summary {
-        ...SysAdminCommunityDetailSummaryFields
-      }
-      stages {
-        ...SysAdminStageDistributionFields
-      }
-      monthlyActivityTrend {
-        ...SysAdminMonthlyActivityPointFields
-      }
-      retentionTrend {
-        ...SysAdminRetentionTrendPointFields
-      }
-      cohortRetention {
-        ...SysAdminCohortRetentionPointFields
-      }
-      memberList {
-        hasNextPage
-        nextCursor
-        users {
-          ...SysAdminMemberRowFields
-        }
-      }
-    }
-  }
-  ${SysAdminAlertFieldsFragmentDoc}
-  ${SysAdminCommunityDetailSummaryFieldsFragmentDoc}
-  ${SysAdminStageDistributionFieldsFragmentDoc}
-  ${SysAdminMonthlyActivityPointFieldsFragmentDoc}
-  ${SysAdminRetentionTrendPointFieldsFragmentDoc}
-  ${SysAdminCohortRetentionPointFieldsFragmentDoc}
-  ${SysAdminMemberRowFieldsFragmentDoc}
-`;
-
-/**
- * __useGetSysAdminCommunityDetailQuery__
- *
- * To run a query within a React component, call `useGetSysAdminCommunityDetailQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetSysAdminCommunityDetailQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetSysAdminCommunityDetailQuery({
- *   variables: {
- *      input: // value for 'input'
- *   },
- * });
- */
-export function useGetSysAdminCommunityDetailQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GqlGetSysAdminCommunityDetailQuery,
-    GqlGetSysAdminCommunityDetailQueryVariables
-  > &
-    (
-      | { variables: GqlGetSysAdminCommunityDetailQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    ),
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GqlGetSysAdminCommunityDetailQuery,
-    GqlGetSysAdminCommunityDetailQueryVariables
-  >(GetSysAdminCommunityDetailDocument, options);
-}
-export function useGetSysAdminCommunityDetailLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GqlGetSysAdminCommunityDetailQuery,
-    GqlGetSysAdminCommunityDetailQueryVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GqlGetSysAdminCommunityDetailQuery,
-    GqlGetSysAdminCommunityDetailQueryVariables
-  >(GetSysAdminCommunityDetailDocument, options);
-}
-export function useGetSysAdminCommunityDetailSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GqlGetSysAdminCommunityDetailQuery,
-        GqlGetSysAdminCommunityDetailQueryVariables
-      >,
-) {
-  const options =
-    baseOptions === Apollo.skipToken ? baseOptions : { ...defaultOptions, ...baseOptions };
-  return Apollo.useSuspenseQuery<
-    GqlGetSysAdminCommunityDetailQuery,
-    GqlGetSysAdminCommunityDetailQueryVariables
-  >(GetSysAdminCommunityDetailDocument, options);
-}
-export type GetSysAdminCommunityDetailQueryHookResult = ReturnType<
-  typeof useGetSysAdminCommunityDetailQuery
->;
-export type GetSysAdminCommunityDetailLazyQueryHookResult = ReturnType<
-  typeof useGetSysAdminCommunityDetailLazyQuery
->;
-export type GetSysAdminCommunityDetailSuspenseQueryHookResult = ReturnType<
-  typeof useGetSysAdminCommunityDetailSuspenseQuery
->;
-export type GetSysAdminCommunityDetailQueryResult = Apollo.QueryResult<
-  GqlGetSysAdminCommunityDetailQuery,
-  GqlGetSysAdminCommunityDetailQueryVariables
 >;
 export const GetCurrentUserProfileDocument = gql`
   query GetCurrentUserProfile {

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -3398,6 +3398,16 @@ export type GqlSysAdminWindowActivity = {
   /** Same metric for the previous window. */
   newMemberCountPrev: Scalars["Int"]["output"];
   /**
+   * Users who sent at least one DONATION in BOTH the current window
+   * AND the previous window (set intersection on user_id). Same
+   * shape as SysAdminWeeklyRetention.retainedSenders but at
+   * windowDays scale, enabling client-side leaky-bucket derivation:
+   *
+   *   newlyActivatedSenders = senderCount     - retainedSenders
+   *   churnedSenders        = senderCountPrev - retainedSenders
+   */
+  retainedSenders: Scalars["Int"]["output"];
+  /**
    * Unique users with at least one outgoing DONATION transaction
    * during the current window (donation_out_count > 0 in
    * mv_user_transaction_daily).

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -5101,6 +5101,7 @@ export type GqlSysAdminWindowActivityFieldsFragment = {
   senderCountPrev: number;
   newMemberCount: number;
   newMemberCountPrev: number;
+  retainedSenders: number;
 };
 
 export type GqlSysAdminWeeklyRetentionFieldsFragment = {
@@ -5141,6 +5142,7 @@ export type GqlSysAdminCommunityOverviewRowFieldsFragment = {
     senderCountPrev: number;
     newMemberCount: number;
     newMemberCountPrev: number;
+    retainedSenders: number;
   };
   weeklyRetention: {
     __typename?: "SysAdminWeeklyRetention";
@@ -5184,6 +5186,7 @@ export type GqlGetSysAdminDashboardQuery = {
         senderCountPrev: number;
         newMemberCount: number;
         newMemberCountPrev: number;
+        retainedSenders: number;
       };
       weeklyRetention: {
         __typename?: "SysAdminWeeklyRetention";
@@ -8576,6 +8579,7 @@ export const SysAdminWindowActivityFieldsFragmentDoc = gql`
     senderCountPrev
     newMemberCount
     newMemberCountPrev
+    retainedSenders
   }
 `;
 export const SysAdminWeeklyRetentionFieldsFragmentDoc = gql`


### PR DESCRIPTION
## Summary

backend が `SysAdminCommunityOverview` を nested 構造の raw counts のみに reshape したことに追従し、portal L1 ダッシュボードを新スキーマに対応させる。

旧 schema の事前計算 field (`communityActivityRate` / `growthRateActivity` / `latestCohortRetentionM1` / top-level `tier{1,2}Count` / `passiveCount` / `alerts`) は削除され、代わりに以下の nested raw counts が返るようになった:

- `windowActivity`: rolling 28 日窓の DONATION 送付者数 / 新規加入数 (現窓 + 前窓)
- `weeklyRetention`: 直近完了週の DONATION 継続 / 離脱 raw counts
- `latestCohort`: 最直近完了月コホートのサイズと M+1 活動者数

レート / 成長率 / コホート retention / アラート boolean は **client 側で派生** する方針に変更。

## 設計判断

| 項目 | 判断 |
|---|---|
| MAU% (活動率) | `windowActivity.senderCount / totalMembers` を frontend で計算 |
| 前月比 (成長率) | `(curr - prev) / prev`、前窓 sender が 0 なら null |
| `churnSpike` 判定 | `weeklyRetention.churnedSenders > retainedSenders` |
| `activeDrop` 判定 | growth ≤ -20% (`ACTIVE_DROP_THRESHOLD = -0.2`、`derive.ts` 内定数) |
| `noNewMembers` 判定 | `windowActivity.newMemberCount === 0` (windowDays 連動、旧 14 日固定より動的) |
| コホート retention | `latestCohort.activeAtM1 / size`、size=0 なら null |
| 閾値の管理場所 | 全て frontend constants。tuning は `derive.ts` の 1 行変更で完了 |
| `windowDays` | 現状はサーバ default (28) を使用、UI からの可変化は別 PR |

## 主な変更ファイル

**新規:**
- `src/app/sysAdmin/_shared/derive.ts` — 派生計算関数群 (`deriveActivityRate` / `deriveGrowthRateActivity` / `deriveLatestCohortRetentionM1` / `deriveAlerts`) と `DerivedAlerts` 型 / `ACTIVE_DROP_THRESHOLD` 定数

**GraphQL 層:**
- `src/graphql/account/sysAdmin/fragment.ts` — fragment を nested 構造 (`windowActivity` / `weeklyRetention` / `latestCohort`) に書き換え。`SYS_ADMIN_ALERT_FRAGMENT` は削除
- `src/graphql/account/sysAdmin/server.ts` — SSR 用 string query も新 schema に同期

**消費元:**
- `CommunityRow.tsx` — `row.communityActivityRate` 等の直接参照をやめ、derive ヘルパー経由に。UI 動作は同じ
- `PrimaryAlertBadge.tsx` — prop 型を `GqlSysAdminCommunityAlerts` → `DerivedAlerts` に。優先度ロジック (`churnSpike` > `activeDrop` > `noNewMembers`) は維持

**fixtures / stories / tests:**
- `fixtures/sysAdminDashboard.ts` — `makeWindowActivity` / `makeWeeklyRetention` / `makeLatestCohort` factory を追加。`makeAlerts` は削除 (alert は underlying counts から派生する設計)
- `CommunityRow.stories.tsx` / `page.stories.tsx` / `PrimaryAlertBadge.stories.tsx` — 各 alert variant を underlying counts の構成で発火させる形に書き換え
- `PrimaryAlertBadge.test.tsx` — `__typename` を取り除き `DerivedAlerts` shape に対応

**メタ:**
- `MetricDefinitions.ts` — MAU% / 前月比の説明文を rolling 28 日窓ベースに更新
- `src/types/graphql.tsx` / `graphql.schema.json` — `pnpm gql:generate` で再生成

## Test plan

- [ ] `pnpm gql:generate` がエラーなく完了する
- [ ] `pnpm tsc --noEmit` が新規エラーを出さない
- [ ] `pnpm test src/app/sysAdmin/_shared/components/__tests__/PrimaryAlertBadge.test.tsx` が green
- [ ] Storybook で以下を目視確認:
  - [ ] `SysAdmin/Dashboard/CommunityRow` の `Healthy` / `ChurnSpike` / `ActiveDrop` / `NoNewMembers` / `NoGrowthData` 各 variant が想定通り表示
  - [ ] `SysAdmin/Pages/CommunityList/WithItems` で 4 種の alert badge (none / churnSpike / activeDrop / noNewMembers) が正しく付く
  - [ ] `SysAdmin/Shared/PrimaryAlertBadge` の優先度 (churnSpike > activeDrop > noNewMembers) が変わっていない
- [ ] `pnpm dev` で `/sysAdmin` を開き、L1 一覧が SSR で描画される

## 既知のスコープ外

- **`newMemberAdoptionLow` alert** — backend 議論で「frontend で raw rate から閾値判定」と合意したが、現時点で UI に出口がないため未実装。導入時は `derive.ts` に閾値定数 (例: 0.02) と判定関数を 1 つ追加するだけで完結する想定
- **`windowDays` の UI 可変化** — 現状サーバ default (28) を使用。SYS_ADMIN が UI から窓を切り替える機能は別 PR で
- **L2 詳細 (`SysAdminCommunitySummaryCard`)** — `tier1Pct` 追加と同方針 refactor は PR #3 (L2 復元) で実施

## 関連

- backend PR: civicship-api 側の `SysAdminCommunityOverview` reshape (リンク要)
- 元の handoff brief: PR #1170 (L1 baseline merged)
- 後続: PR #3 (L2 詳細復元 + 同方針 refactor)

https://claude.ai/code/session_01SQnU3rM72G6kWQRoPqkj2x