### PR TITLE
feat(sysAdmin): Hub をネットワーク軸 (hubMemberCount) に再定義

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -23955,6 +23955,22 @@
             "deprecationReason": null
           },
           {
+            "name": "hubMemberCount",
+            "description": "Number of members classified as a \"hub\" within the parametric\nwindow (`windowDays`):\n\n  hubMemberCount = COUNT(member)\n    WHERE windowUniqueDonationRecipients >= input.hubBreadthThreshold\n\n`windowUniqueDonationRecipients` is the count of DISTINCT users\nthis member sent a DONATION to during\n`[asOf - windowDays JST日, asOf + 1 JST日)` — distinct from the\nL2 `SysAdminMemberRow.uniqueDonationRecipients` field which is\ntenure-wide. The window-scoped variant is computed on demand in\nthis aggregate but not exposed per-member at L1 (members\nthemselves are an L2 concern).\n\nHub classification deliberately uses BREADTH only — a member\nwho reached `hubBreadthThreshold` distinct recipients during\nthe window necessarily transacted at least that many times,\nmaking an explicit frequency floor redundant. This keeps the\nthreshold knobs to one (`hubBreadthThreshold`).\n\nInvariants (the client may assert these):\n  hubMemberCount <= windowActivity.senderCount <= totalMembers\n\nThe first holds because any hub member donated >= 3 times in\nthe window and is therefore a window sender; the second because\nany window sender is a JOINED member at asOf.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "latestCohort",
             "description": "Latest completed monthly cohort and its M+1 activity. See\nSysAdminLatestCohort.",
             "args": [],
@@ -24244,6 +24260,18 @@
             "deprecationReason": null
           },
           {
+            "name": "hubBreadthThreshold",
+            "description": "Minimum number of distinct DONATION recipients within the\nparametric window (`windowDays`) for a member to be classified\nas a hub. Used to populate `SysAdminCommunityOverview.hubMemberCount`.\n\nDefaults to 3, meaning \"sent DONATION to at least 3 different\npeople during the window\". The threshold is on **unique\ncounterparties** (set cardinality), not transaction count, so a\nmember who donated 100 times to the same recipient does not\nqualify on this axis alone.\n\nEffective range 1..1000; values outside are silently clamped on\nthe server.\n\nThis is intentionally an absolute threshold rather than a\ncommunity-relative percentile: a percentile-based hub would\nalways classify ~N% of members as hubs by definition, defeating\ncross-community comparison (\"which communities have the highest\nhub ratio?\"). Community size differences are absorbed\nclient-side by displaying `hubMemberCount / totalMembers` rather\nthan the raw count.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": "3",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "segmentThresholds",
             "description": "Stage classification thresholds (see SysAdminSegmentThresholdsInput).",
             "type": {
@@ -24508,6 +24536,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "uniqueDonationRecipients",
+            "description": "All-time count of distinct OTHER users this member has sent at\nleast one DONATION to in this community. The \"network breadth\"\nhalf of the donor profile (paired with frequency-based\n`userSendRate` and volume-based `totalPointsOut`):\n\n  breadth × frequency × volume → the client's per-member\n  classification space (e.g. true hub vs single-target loyal vs\n  rare-but-far-reaching).\n\nCounts unique counterparty user_id, not transaction count, so a\nmember who sent 100 donations to the same recipient still scores\n1. Excludes burn / system targets (recipient wallets without a\nuser_id).",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               }
             },

--- a/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
+++ b/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
@@ -8,36 +8,36 @@ export type MetricDefinition = {
 export const METRIC_DEFINITIONS: Record<string, MetricDefinition> = {
   mau: {
     title: "MAU",
-    formula: "直近 28 日に DONATION を送ったユニークユーザー数 (windowDays default = 28)",
-    note: "本ツールでの Active = DONATION 送付者。MAU% の分子。暦月ではなく rolling 28 日窓。",
+    formula: "直近 windowDays 日 (default 28) に DONATION を送ったユニークユーザー数",
+    note: "本ツールでの Active = DONATION 送付者。MAU% の分子。暦月ではなく rolling 窓。",
   },
   communityActivityRate: {
     title: "MAU%",
-    formula: "MAU ÷ asOf 時点の総メンバー数 (rolling 28 日窓)",
+    formula: "MAU ÷ asOf 時点の総メンバー数 (rolling 窓は windowDays 日、default 28)",
     note: "コミュニティ単位の MAU%。個人の送付率 (user_send_rate) とは別指標。本ツールでの Active = DONATION 送付者。",
     range: "0〜100%",
   },
   growthRateActivity: {
     title: "MAU% 前月比",
-    formula: "(直近 28 日 MAU% − その前 28 日 MAU%) ÷ その前 28 日 MAU%",
-    note: "負値は MAU% が前窓より低下。前 28 日窓の MAU% が 0 のときは null。",
+    formula: "(現窓 MAU% − 前窓 MAU%) ÷ 前窓 MAU% (窓は windowDays 日、default 28)",
+    note: "負値は MAU% が前窓より低下。前窓の MAU% が 0 のときは null。",
   },
   hubUserPct: {
     title: "Hub user%",
-    formula: "hubMemberCount ÷ totalMembers (直近 28d に hubBreadthThreshold=3 以上の distinct 相手に DONATION した user)",
-    note: "ネットワーク軸の指標。「複数方面に送付している = 関係性を広げている」ユーザーの割合。ノード軸の習慣化 (userSendRate ≥ tier1) とは独立で、低頻度でも複数人に送れば hub、高頻度でも 1 人にしか送らなければ hub ではない。",
+    formula: "hubMemberCount ÷ totalMembers (現窓に hubBreadthThreshold (default 3) 以上の distinct 相手に DONATION した user)",
+    note: "ネットワーク軸の指標。「複数方面に送付している = 関係性を広げている」ユーザーの割合。ノード軸の習慣化 (userSendRate ≥ tier1) とは独立で、低頻度でも複数人に送れば hub、高頻度でも 1 人にしか送らなければ hub ではない。閾値・窓幅は SysAdminDashboardInput で可変。",
     range: "0〜100%",
   },
   newMembers: {
     title: "New",
-    formula: "直近 28 日 (windowDays default) に JOINED で加入したメンバー数",
+    formula: "現窓 (windowDays 日、default 28) に JOINED で加入したメンバー数",
     note: "row では総メンバー数の隣に `(+12)` の形で表示。0 のときは `(+0)` で「新規加入なし」のシグナルを兼ねる。",
   },
   activityFlow: {
     title: "Δ (activity flow)",
     formula:
       "↑newlyActivated = senderCount − retainedSenders / ↓churned = senderCountPrev − retainedSenders",
-    note: "leaky-bucket 検出。↑ は前 28d は送付してなく現 28d で送付した sender、↓ は前 28d は送付してたが現 28d で送付してない sender。MAU 数だけ見ても入退室で打ち消されるケースを表面化する。",
+    note: "leaky-bucket 検出。↑ は前窓では送付してなく現窓で送付した sender、↓ は前窓では送付してたが現窓で送付してない sender。窓は windowDays 日 (default 28)。MAU 数だけ見ても入退室で打ち消されるケースを表面化する。",
   },
   userSendRate: {
     title: "送付率 (個人)",

--- a/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
+++ b/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
@@ -24,8 +24,8 @@ export const METRIC_DEFINITIONS: Record<string, MetricDefinition> = {
   },
   hubUserPct: {
     title: "Hub user%",
-    formula: "tier1Count ÷ totalMembers (userSendRate ≥ tier1 を満たすメンバー)",
-    note: "ステージ最上位 (習慣化層) の比率。コミュニティの DONATION 連鎖を支える hub 役のユーザー割合。",
+    formula: "hubMemberCount ÷ totalMembers (直近 28d に hubBreadthThreshold=3 以上の distinct 相手に DONATION した user)",
+    note: "ネットワーク軸の指標。「複数方面に送付している = 関係性を広げている」ユーザーの割合。ノード軸の習慣化 (userSendRate ≥ tier1) とは独立で、低頻度でも複数人に送れば hub、高頻度でも 1 人にしか送らなければ hub ではない。",
     range: "0〜100%",
   },
   newMembers: {

--- a/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
+++ b/src/app/sysAdmin/_shared/components/MetricDefinitions.ts
@@ -108,8 +108,8 @@ export const METRIC_DEFINITIONS: Record<string, MetricDefinition> = {
   stages: {
     title: "ステージ分類",
     formula:
-      "hub: send_rate ≥ tier1 / regular: tier2 ≤ send_rate < tier1 / occasional: 0 < send_rate < tier2 / latent: send_rate = 0",
-    note: "デフォルト tier1=0.7, tier2=0.4。最上位 (hub) は DONATION ネットワークの連鎖を支える役割を表す。閾値はステージ分布の「分類設定」から変更可能。",
+      "habitual: send_rate ≥ tier1 / regular: tier2 ≤ send_rate < tier1 / occasional: 0 < send_rate < tier2 / latent: send_rate = 0",
+    note: "ノード軸 (個人の頻度継続性) のステージ分類。デフォルト tier1=0.7, tier2=0.4。閾値はステージ分布の「分類設定」から変更可能。ネットワーク軸の `Hub user%` (関係性の広さ) とは別軸で、両者は独立に評価される。",
   },
   asOf: {
     title: "集計日",

--- a/src/app/sysAdmin/_shared/derive.ts
+++ b/src/app/sysAdmin/_shared/derive.ts
@@ -35,16 +35,19 @@ export function deriveLatestCohortRetentionM1(
   return row.latestCohort.activeAtM1 / row.latestCohort.size;
 }
 
-// Hub user share: tier1 segment (userSendRate >= tier1 threshold, default 0.7).
-// "Hub" frames the highest stage as the network-role layer that anchors
-// the donation graph, distinct from generic "habitual" individual behavior.
+// Hub user share — pure network-axis metric.
+// Hub member = sent DONATION to >= hubBreadthThreshold (default 3) distinct
+// recipients within the parametric window. Independent of userSendRate
+// (the node-axis tier1/2/passive segments live in segmentCounts).
 //
-// NOTE: provisional. Pareto-based redefinition (top users covering 80%
-// of donation volume) is pending backend support; once shipped, this
-// derive switches to the Pareto count.
+//   ratio = hubMemberCount / totalMembers
+//
+// "Hub" labels the relational-breadth layer of the donation graph; the
+// node-axis "habitual / regular / occasional / latent" stage hierarchy
+// is orthogonal and surfaces in L2 detail.
 export function deriveHubUserPct(row: GqlSysAdminCommunityOverview): number {
   if (row.totalMembers === 0) return 0;
-  return row.segmentCounts.tier1Count / row.totalMembers;
+  return row.hubMemberCount / row.totalMembers;
 }
 
 // Activity-flow leaky-bucket pair derived from windowActivity raw counts.

--- a/src/app/sysAdmin/_shared/fixtures/sysAdminDashboard.ts
+++ b/src/app/sysAdmin/_shared/fixtures/sysAdminDashboard.ts
@@ -76,6 +76,8 @@ export const makePlatformSummary = (
 const DEFAULT_TIER1_RATIO = 0.33;
 const DEFAULT_TIER2_RATIO = 0.58;
 const DEFAULT_PASSIVE_RATIO = 0.21;
+// network-axis hub ratio (independent of node-axis tier1).
+const DEFAULT_HUB_RATIO = 0.18;
 
 function defaultSegmentCountsFor(total: number): GqlSysAdminSegmentCounts {
   return {
@@ -97,6 +99,7 @@ export const makeCommunityOverview = (
     communityId: "community-a",
     communityName: "コミュニティA",
     totalMembers,
+    hubMemberCount: Math.round(totalMembers * DEFAULT_HUB_RATIO),
     segmentCounts: defaultSegmentCountsFor(totalMembers),
     windowActivity: makeWindowActivity(),
     weeklyRetention: makeWeeklyRetention(),

--- a/src/app/sysAdmin/_shared/fixtures/sysAdminDashboard.ts
+++ b/src/app/sysAdmin/_shared/fixtures/sysAdminDashboard.ts
@@ -94,17 +94,23 @@ export const makeCommunityOverview = (
   overrides: Partial<GqlSysAdminCommunityOverview> = {},
 ): GqlSysAdminCommunityOverview => {
   const totalMembers = overrides.totalMembers ?? 120;
+  const windowActivity = overrides.windowActivity ?? makeWindowActivity();
+  // Invariant: hubMemberCount <= windowActivity.senderCount <= totalMembers.
+  // Resolve the effective windowActivity first, then clamp the hub default
+  // so story overrides that lower senderCount don't push Hub% above MAU%.
+  const hubMemberCount =
+    overrides.hubMemberCount ??
+    Math.min(Math.round(totalMembers * DEFAULT_HUB_RATIO), windowActivity.senderCount);
   return {
     __typename: "SysAdminCommunityOverview",
-    communityId: "community-a",
-    communityName: "コミュニティA",
+    communityId: overrides.communityId ?? "community-a",
+    communityName: overrides.communityName ?? "コミュニティA",
     totalMembers,
-    hubMemberCount: Math.round(totalMembers * DEFAULT_HUB_RATIO),
-    segmentCounts: defaultSegmentCountsFor(totalMembers),
-    windowActivity: makeWindowActivity(),
-    weeklyRetention: makeWeeklyRetention(),
-    latestCohort: makeLatestCohort(),
-    ...overrides,
+    hubMemberCount,
+    segmentCounts: overrides.segmentCounts ?? defaultSegmentCountsFor(totalMembers),
+    windowActivity,
+    weeklyRetention: overrides.weeklyRetention ?? makeWeeklyRetention(),
+    latestCohort: overrides.latestCohort ?? makeLatestCohort(),
   };
 };
 

--- a/src/graphql/account/sysAdmin/fragment.ts
+++ b/src/graphql/account/sysAdmin/fragment.ts
@@ -47,6 +47,7 @@ export const SYS_ADMIN_COMMUNITY_OVERVIEW_ROW_FRAGMENT = gql`
     communityId
     communityName
     totalMembers
+    hubMemberCount
     segmentCounts {
       ...SysAdminSegmentCountsFields
     }

--- a/src/graphql/account/sysAdmin/server.ts
+++ b/src/graphql/account/sysAdmin/server.ts
@@ -21,6 +21,7 @@ export const GET_SYS_ADMIN_DASHBOARD_SERVER_QUERY = `
         communityId
         communityName
         totalMembers
+        hubMemberCount
         segmentCounts {
           total
           activeCount

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -2979,6 +2979,35 @@ export type GqlSysAdminCommunityOverview = {
   /** Community display name (t_communities.name). */
   communityName: Scalars["String"]["output"];
   /**
+   * Number of members classified as a "hub" within the parametric
+   * window (`windowDays`):
+   *
+   *   hubMemberCount = COUNT(member)
+   *     WHERE windowUniqueDonationRecipients >= input.hubBreadthThreshold
+   *
+   * `windowUniqueDonationRecipients` is the count of DISTINCT users
+   * this member sent a DONATION to during
+   * `[asOf - windowDays JST日, asOf + 1 JST日)` — distinct from the
+   * L2 `SysAdminMemberRow.uniqueDonationRecipients` field which is
+   * tenure-wide. The window-scoped variant is computed on demand in
+   * this aggregate but not exposed per-member at L1 (members
+   * themselves are an L2 concern).
+   *
+   * Hub classification deliberately uses BREADTH only — a member
+   * who reached `hubBreadthThreshold` distinct recipients during
+   * the window necessarily transacted at least that many times,
+   * making an explicit frequency floor redundant. This keeps the
+   * threshold knobs to one (`hubBreadthThreshold`).
+   *
+   * Invariants (the client may assert these):
+   *   hubMemberCount <= windowActivity.senderCount <= totalMembers
+   *
+   * The first holds because any hub member donated >= 3 times in
+   * the window and is therefore a window sender; the second because
+   * any window sender is a JOINED member at asOf.
+   */
+  hubMemberCount: Scalars["Int"]["output"];
+  /**
    * Latest completed monthly cohort and its M+1 activity. See
    * SysAdminLatestCohort.
    */
@@ -3061,6 +3090,29 @@ export type GqlSysAdminDashboardInput = {
    * Defaults to now when omitted.
    */
   asOf?: InputMaybe<Scalars["Datetime"]["input"]>;
+  /**
+   * Minimum number of distinct DONATION recipients within the
+   * parametric window (`windowDays`) for a member to be classified
+   * as a hub. Used to populate `SysAdminCommunityOverview.hubMemberCount`.
+   *
+   * Defaults to 3, meaning "sent DONATION to at least 3 different
+   * people during the window". The threshold is on **unique
+   * counterparties** (set cardinality), not transaction count, so a
+   * member who donated 100 times to the same recipient does not
+   * qualify on this axis alone.
+   *
+   * Effective range 1..1000; values outside are silently clamped on
+   * the server.
+   *
+   * This is intentionally an absolute threshold rather than a
+   * community-relative percentile: a percentile-based hub would
+   * always classify ~N% of members as hubs by definition, defeating
+   * cross-community comparison ("which communities have the highest
+   * hub ratio?"). Community size differences are absorbed
+   * client-side by displaying `hubMemberCount / totalMembers` rather
+   * than the raw count.
+   */
+  hubBreadthThreshold?: InputMaybe<Scalars["Int"]["input"]>;
   /** Stage classification thresholds (see SysAdminSegmentThresholdsInput). */
   segmentThresholds?: InputMaybe<GqlSysAdminSegmentThresholdsInput>;
   /**
@@ -3142,6 +3194,22 @@ export type GqlSysAdminMemberRow = {
   name?: Maybe<Scalars["String"]["output"]>;
   /** All-time DONATION points sent by this user in this community. */
   totalPointsOut: Scalars["Float"]["output"];
+  /**
+   * All-time count of distinct OTHER users this member has sent at
+   * least one DONATION to in this community. The "network breadth"
+   * half of the donor profile (paired with frequency-based
+   * `userSendRate` and volume-based `totalPointsOut`):
+   *
+   *   breadth × frequency × volume → the client's per-member
+   *   classification space (e.g. true hub vs single-target loyal vs
+   *   rare-but-far-reaching).
+   *
+   * Counts unique counterparty user_id, not transaction count, so a
+   * member who sent 100 donations to the same recipient still scores
+   * 1. Excludes burn / system targets (recipient wallets without a
+   * user_id).
+   */
+  uniqueDonationRecipients: Scalars["Int"]["output"];
   /** User id. */
   userId: Scalars["ID"]["output"];
   /**

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -5196,6 +5196,7 @@ export type GqlSysAdminCommunityOverviewRowFieldsFragment = {
   communityId: string;
   communityName: string;
   totalMembers: number;
+  hubMemberCount: number;
   segmentCounts: {
     __typename?: "SysAdminSegmentCounts";
     total: number;
@@ -5240,6 +5241,7 @@ export type GqlGetSysAdminDashboardQuery = {
       communityId: string;
       communityName: string;
       totalMembers: number;
+      hubMemberCount: number;
       segmentCounts: {
         __typename?: "SysAdminSegmentCounts";
         total: number;
@@ -8667,6 +8669,7 @@ export const SysAdminCommunityOverviewRowFieldsFragmentDoc = gql`
     communityId
     communityName
     totalMembers
+    hubMemberCount
     segmentCounts {
       ...SysAdminSegmentCountsFields
     }


### PR DESCRIPTION
## Summary

L1 ダッシュボードの **Hub user%** 指標を、**ネットワーク軸 (関係性の広さ)** に基づくものに切り替える。

これまで暫定的に `tier1Count / totalMembers` (= ノード軸 = 個人の頻度継続性) で表示していた `[Hub]` ピルを、backend が新たに提供した **`hubMemberCount`** に切り替える。`hubMemberCount` は「直近 28 日に `hubBreadthThreshold` 以上の distinct な相手に DONATION した user 数」で、`userSendRate` とは独立に network-role を測る指標。

これによりユーザー評価が **node × network の双軸** で並走する設計に到達:

| 軸 | データ | セグメント |
|---|---|---|
| **ノード軸** (頻度) | `userSendRate` | habitual / regular / occasional / latent (= `segmentCounts`) |
| **ネットワーク軸** (広さ) | `windowUniqueDonationRecipients` ≥ `hubBreadthThreshold` | hub / non-hub (= `hubMemberCount`) |

両軸は **直交** していて、partition ではない。ある user は tier1 ∧ ¬hub (loyal-but-narrow) や hub ∧ ¬tier1 (rare-but-far-reaching) になり得る。

## 主な変更

- `src/graphql/account/sysAdmin/fragment.ts` — `hubMemberCount` を `SysAdminCommunityOverviewRowFields` に追加
- `src/graphql/account/sysAdmin/server.ts` — SSR 用 string query に `hubMemberCount` を追加
- `src/app/sysAdmin/_shared/derive.ts` — `deriveHubUserPct` を `hubMemberCount / totalMembers` に切替。docstring に「ネットワーク軸 only / `userSendRate` とは独立」と明記
- `src/app/sysAdmin/_shared/components/MetricDefinitions.ts` — `hubUserPct` のラベル / formula / note をネットワーク軸用に書き換え
- `src/app/sysAdmin/_shared/fixtures/sysAdminDashboard.ts` — `makeCommunityOverview` に `hubMemberCount` (default `totalMembers * 0.18`) を追加
- `src/types/graphql.tsx` / `graphql.schema.json` — `pnpm gql:generate` で再生成

## 設計上の決定 (backend と確認済)

- **Hub の判定は breadth 単軸**: `userSendRate` を一切参照しない (backend 確認済)
- **`hubBreadthThreshold = 3` は暫定**: 実データ分布で運用調整、`SysAdminDashboardInput` で input 可変
- **stage 命名 (habitual / regular / occasional / latent) はノード軸専用に維持**
- **両軸の交差 (`tier1 ∩ hub`) は L1 では未提供**: portal 側で具体的 UI 用途が決まった時に backend へ別途依頼
- **invariant**: `hubMemberCount ≤ windowActivity.senderCount ≤ totalMembers`

## Test plan

- [ ] `pnpm gql:generate` がエラーなく完了する
- [ ] `pnpm tsc --noEmit` が新規エラーを出さない
- [ ] Storybook で `SysAdmin/Dashboard/CommunityRow` の `[Hub]` ピル値が新 fixture (`hubMemberCount` 0.18 × totalMembers ベース) を反映している
- [ ] `pnpm dev` で `/sysAdmin` を開き、L1 一覧の `[Hub]` ピルがコミュニティごとに異なる比率で描画される

## 既知のスコープ外

- **Hub の階層細分化** (例: `super-hub` / `connector` 等のサブクラス) — 将来必要なら別 threshold + 別 count を追加
- **ノード × ネットワーク 交差カウント** (`tier1HubMemberCount`) — concrete UI 要件が出たら backend へ依頼
- **L2 個人 row への window-scoped breadth** (`windowUniqueDonationRecipients` per-member) — L2 で必要なら別 PR

## 関連

- 前 PR #1172 (L1 baseline + Δ pill + Hub provisional) — マージ済
- backend schema PR — `hubMemberCount` / `hubBreadthThreshold` 追加 (civicship-api 側)

https://claude.ai/code/session_01SQnU3rM72G6kWQRoPqkj2x

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQnU3rM72G6kWQRoPqkj2x)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
