### PR TITLE
fix(sysAdmin): dashboard hook の loading フラグと URL→state 同期

### DIFF
--- a/src/app/sysAdmin/features/dashboard/hooks/useDashboardControls.ts
+++ b/src/app/sysAdmin/features/dashboard/hooks/useDashboardControls.ts
@@ -61,6 +61,25 @@ export function useDashboardControls() {
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Sync URL → state on external navigation (browser back / forward, or
+  // any other consumer changing searchParams). The state→URL writer below
+  // uses `window.history.replaceState`, which does NOT cause Next.js's
+  // `useSearchParams` to update — so this effect doesn't re-fire on our
+  // own writes. The equality guard is a belt-and-suspenders against
+  // unrelated re-renders that would otherwise produce a no-op setState.
+  useEffect(() => {
+    const hydrated = hydrateFromParams(
+      new URLSearchParams(searchParams?.toString() ?? ""),
+    );
+    setState((prev) =>
+      prev.period === hydrated.period &&
+      prev.tier1 === hydrated.tier1 &&
+      prev.tier2 === hydrated.tier2
+        ? prev
+        : hydrated,
+    );
+  }, [searchParams]);
+
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (timerRef.current) clearTimeout(timerRef.current);

--- a/src/app/sysAdmin/features/dashboard/hooks/useDashboardOverview.ts
+++ b/src/app/sysAdmin/features/dashboard/hooks/useDashboardOverview.ts
@@ -69,7 +69,11 @@ export function useDashboardOverview(
     // SSR データを fallback として使う条件:
     // - クライアント query を skip 中 (デフォルト controls のまま)
     // - もしくは Apollo がまだ data を返していない (初回フェッチ中)
-    const useSsr = skipInitialQuery || !data?.sysAdminDashboard;
+    //
+    // `data === undefined` で「まだ応答が来ていない」を厳密に判定する。
+    // `!data?.sysAdminDashboard` だと、Apollo が `null` (= 有効な空応答)
+    // を返したときに stale な initialData を表示し続けてしまう。
+    const useSsr = skipInitialQuery || data === undefined;
     const source = useSsr ? initialData : data?.sysAdminDashboard ?? null;
 
     return {

--- a/src/app/sysAdmin/features/dashboard/hooks/useDashboardOverview.ts
+++ b/src/app/sysAdmin/features/dashboard/hooks/useDashboardOverview.ts
@@ -73,7 +73,12 @@ export function useDashboardOverview(
     const source = useSsr ? initialData : data?.sysAdminDashboard ?? null;
 
     return {
-      loading: !useSsr && loading,
+      // Always reflect the actual Apollo loading state. Previously this
+      // was gated by `!useSsr`, which suppressed loading during the gap
+      // between a control change (skipInitialQuery → false) and Apollo
+      // returning data — leaving the user staring at stale SSR data
+      // with no indication that a refresh was in flight.
+      loading,
       error,
       platform: source?.platform ?? null,
       communities: source?.communities ?? [],


### PR DESCRIPTION
## Summary

L1 ダッシュボードの hook に対する Gemini レビュー指摘 2 件 (PR #1172 / #1173 で deferred されていたもの) に対応。両方とも edge case の UX 改善で、normal flow には影響しません。

## 変更内容

### 1. `useDashboardOverview` の loading フラグ修正

`loading: !useSsr && loading` → `loading` に変更。

**問題**: filter / tier 変更で `skipInitialQuery` が false になった直後、Apollo の data がまだ返ってこない間、`useSsr` は `!data?.sysAdminDashboard` で true となり、結果として `loading: false` で **stale な SSR data がそのまま「最新」のように表示** されていた (refresh 中であることがユーザに伝わらない)。

修正後: Apollo の `loading` をそのまま透過。filter 変更直後から data 到着まで loading インジケーターが正しく出る。

### 2. `useDashboardControls` の URL → state 同期

`useEffect` を追加し、`searchParams` の変更を state に同期。

**問題**: state の初期化は URL から行われるが、その後の URL 変更 (ブラウザ「戻る」/「進む」、外部からの URL push 等) を検知する仕組みがなく、**URL と state がズレる** ケースがあった。

修正後: `searchParams` 変化時に再ハイドレートして state を同期。state → URL の writer は `window.history.replaceState` を使っており Next.js の `useSearchParams` を refresh しないため、無限ループの心配なし。equality guard でも no-op setState を回避。

## 各 fix が効くシナリオ

| シナリオ | 現状 | この PR 後 |
|---|---|---|
| filter 変更直後 (Apollo fetch 中) | loading 出ず stale data 表示 | loading 出る、refetch 中だと分かる |
| filter 変更後ブラウザ「戻る」 | URL 戻るが state ズレる | state 同期して戻る |
| 共有 URL からアクセス | OK ✓ | OK ✓ |
| 通常の click-through | OK ✓ | OK ✓ |

## Test plan

- [ ] `pnpm tsc --noEmit` が新規エラーを出さない
- [ ] `pnpm dev` で `/sysAdmin` を開き、filter / tier を変更したときに loading 表示が出ることを確認
- [ ] filter 変更後にブラウザ「戻る」で URL と一覧が同期して戻ることを確認
- [ ] 共有 URL (`?period=last3m&tier1=0.6` 等) からの初期表示が壊れていないことを確認

## 既知のスコープ外

- Gemini #3 (`toCompactJa` を `Intl.NumberFormat` に置換): 既存テスト出力 (`"1.0万"` の trailing zero / 4 桁未満のカンマ等) が Intl compact と不整合のため、この PR では skip
- Gemini #4 (`toJstDate` の epoch offset): JST に DST がないため実害なし、別タイムゾーン対応時に再検討

https://claude.ai/code/session_01SQnU3rM72G6kWQRoPqkj2x

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQnU3rM72G6kWQRoPqkj2x)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
