### PR TITLE
fix(sysAdmin): constrain L2 overview to mobile-l width and tune header spacing

### DIFF
--- a/src/app/sysAdmin/[communityId]/page.stories.tsx
+++ b/src/app/sysAdmin/[communityId]/page.stories.tsx
@@ -7,11 +7,11 @@ import { DEFAULT_SEGMENT_THRESHOLDS } from "../_shared/derive";
 import { makeCommunityDetailPayload } from "../_shared/fixtures/sysAdminDashboard";
 
 // page.tsx は async RSC で SSR fetch するため Storybook から直接 render できない。
-// Client 部分 (`CommunityDetailPageClient`) と route の container (max-w-7xl p-4)
-// をラップで再現する。initialData=null にして Apollo mock 経路をテスト。
+// Client 部分 (`CommunityDetailPageClient`) と route の container を再現する。
+// initialData=null にして Apollo mock 経路をテスト。
 function CommunityDetailPageShell({ communityId }: { communityId: string }) {
   return (
-    <div className="mx-auto max-w-7xl p-4">
+    <div className="mx-auto max-w-mobile-l p-4 pt-8">
       <CommunityDetailPageClient communityId={communityId} initialData={null} />
     </div>
   );

--- a/src/app/sysAdmin/[communityId]/page.tsx
+++ b/src/app/sysAdmin/[communityId]/page.tsx
@@ -44,7 +44,7 @@ export default async function SysAdminCommunityDetailPage({ params }: Props) {
   const hubMemberCount = l1Row?.hubMemberCount ?? null;
 
   return (
-    <div className="mx-auto max-w-7xl p-4">
+    <div className="mx-auto max-w-mobile-l p-4 pt-8">
       <CommunityDetailPageClient
         communityId={communityId}
         initialData={initialData}

--- a/src/app/sysAdmin/features/communityDetail/components/CommunityDashboardOverview.tsx
+++ b/src/app/sysAdmin/features/communityDetail/components/CommunityDashboardOverview.tsx
@@ -226,10 +226,10 @@ export function CommunityDashboardOverview({
   );
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-3">
       {communityName && (
         // px-1: ネットワーク等 scope 見出し (px-1) と左揃え。
-        <header className="flex max-w-xl flex-col gap-1 px-1">
+        <header className="flex flex-col gap-1 px-1">
           <div className="flex items-baseline gap-3">
             <h1 className="text-2xl font-semibold leading-tight">
               {communityName}
@@ -258,9 +258,9 @@ export function CommunityDashboardOverview({
         </header>
       )}
 
+      <div className="flex flex-col gap-6">
       <Scope
         title="ネットワーク"
-        className="max-w-xl"
         note={sysAdminDashboardJa.scopeNotes.network}
         detailHref={
           enableSubpageLinks ? `/sysAdmin/${data.communityId}/network` : undefined
@@ -520,6 +520,7 @@ export function CommunityDashboardOverview({
           </Issue>
         )}
       </Scope>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
L2 was using max-w-7xl which made the dashboard stretch to 1280px on
desktop while the inner sections (header, first Scope) capped at
max-w-xl, producing a left-aligned narrow column inside a wide empty
container. Lock the route container to max-w-mobile-l (425px) for a
uniform column matching /sysAdmin/create, drop the now-inert inner
max-w-xl caps, double the top padding (p-4 → pt-8) and halve the gap
between the community header and the first Scope (gap-6 → gap-3) while
keeping gap-6 between Scopes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
