### PR TITLE
Release: sysAdmin report template management + Phase 2 observation

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -22,8 +22,25 @@ const config: StorybookConfig = {
     viteConfig.define = {
       ...viteConfig.define,
       // src/lib/environment.ts の isStorybook 判定をビルド時に true にする。
-      // NODE_ENV など他の process.env.* は Vite のデフォルト置換に任せる。
       "process.env.ENV": JSON.stringify("STORYBOOK"),
+      // Storybook / Chromatic 環境では Firebase 関連の env が無いため、
+      // `firebase-config.ts` の module-level `initializeApp()` が
+      // `auth/invalid-api-key` で crash する。Auth 依存のあるコンポーネントは
+      // Container/View 分離で View 単体を story 化する設計だが、副作用的に
+      // 一部 import path が AuthProvider に到達するケースに備えて dummy 値を
+      // 用意して init を通過させる。
+      "process.env.NEXT_PUBLIC_FIREBASE_API_KEY": JSON.stringify(
+        "storybook-dummy-api-key",
+      ),
+      "process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID": JSON.stringify(
+        "storybook-project",
+      ),
+      "process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN": JSON.stringify(
+        "storybook.firebaseapp.com",
+      ),
+      "process.env.NEXT_PUBLIC_FIREBASE_APP_ID": JSON.stringify(
+        "storybook-app-id",
+      ),
     };
     return viteConfig;
   },

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -51,6 +51,256 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "AdminReportSummaryConnection",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AdminReportSummaryEdge",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AdminReportSummaryEdge",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AdminReportSummaryRow",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Edge",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AdminReportSummaryRow",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "community",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Community",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "daysSinceLastPublish",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastPublishedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Datetime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastPublishedReport",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Report",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedCountLast90Days",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AdminTemplateFeedbackStats",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "avgRating",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ratingDistribution",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ReportFeedbackRatingBucket",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "UNION",
         "name": "ApproveReportPayload",
         "description": null,
@@ -4247,6 +4497,11 @@
         "possibleTypes": [
           {
             "kind": "OBJECT",
+            "name": "AdminReportSummaryEdge",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "ArticleEdge",
             "ofType": null
           },
@@ -4328,6 +4583,11 @@
           {
             "kind": "OBJECT",
             "name": "ReportFeedbackEdge",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ReportTemplateStatsBreakdownEdge",
             "ofType": null
           },
           {
@@ -17428,6 +17688,310 @@
         "isOneOf": null,
         "fields": [
           {
+            "name": "adminBrowseReports",
+            "description": null,
+            "args": [
+              {
+                "name": "communityId",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "cursor",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "publishedAfter",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Datetime",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "publishedBefore",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Datetime",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "status",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "ReportStatus",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "variant",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "ReportVariant",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ReportsConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "adminReportSummary",
+            "description": null,
+            "args": [
+              {
+                "name": "cursor",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AdminReportSummaryConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "adminTemplateFeedbackStats",
+            "description": null,
+            "args": [
+              {
+                "name": "kind",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "ReportTemplateKind",
+                  "ofType": null
+                },
+                "defaultValue": "GENERATION",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "variant",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ReportVariant",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "version",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AdminTemplateFeedbackStats",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "adminTemplateFeedbacks",
+            "description": null,
+            "args": [
+              {
+                "name": "cursor",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "feedbackType",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "ReportFeedbackType",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "20",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "kind",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "ReportTemplateKind",
+                  "ofType": null
+                },
+                "defaultValue": "GENERATION",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "maxRating",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "variant",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ReportVariant",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "version",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ReportFeedbacksConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "article",
             "description": null,
             "args": [
@@ -19031,6 +19595,176 @@
                 "kind": "OBJECT",
                 "name": "ReportTemplateStats",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reportTemplateStatsBreakdown",
+            "description": null,
+            "args": [
+              {
+                "name": "cursor",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "20",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "includeInactive",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "false",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "kind",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "ReportTemplateKind",
+                  "ofType": null
+                },
+                "defaultValue": "GENERATION",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "variant",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ReportVariant",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "version",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ReportTemplateStatsBreakdownConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reportTemplates",
+            "description": null,
+            "args": [
+              {
+                "name": "communityId",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "includeInactive",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "false",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "kind",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "ReportTemplateKind",
+                  "ofType": null
+                },
+                "defaultValue": "GENERATION",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "variant",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ReportVariant",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ReportTemplate",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -21019,6 +21753,22 @@
             "deprecationReason": null
           },
           {
+            "name": "report",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Report",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "reportId",
             "description": null,
             "args": [],
@@ -21111,6 +21861,50 @@
             "ofType": null
           }
         ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ReportFeedbackRatingBucket",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rating",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -21371,6 +22165,22 @@
             "deprecationReason": null
           },
           {
+            "name": "kind",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ReportTemplateKind",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "maxTokens",
             "description": null,
             "args": [],
@@ -21566,6 +22376,30 @@
       },
       {
         "kind": "ENUM",
+        "name": "ReportTemplateKind",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "GENERATION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "JUDGE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
         "name": "ReportTemplateScope",
         "description": null,
         "isOneOf": null,
@@ -21686,6 +22520,316 @@
               "kind": "SCALAR",
               "name": "Int",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ReportTemplateStatsBreakdownConnection",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ReportTemplateStatsBreakdownEdge",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ReportTemplateStatsBreakdownEdge",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ReportTemplateStatsBreakdownRow",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Edge",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ReportTemplateStatsBreakdownRow",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "avgJudgeScore",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "avgRating",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "correlationWarning",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "experimentKey",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "feedbackCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isActive",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isEnabled",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "judgeHumanCorrelation",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ReportTemplateKind",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "scope",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ReportTemplateScope",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "templateId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "trafficWeight",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/app/sysAdmin/SysAdminPageClient.tsx
+++ b/src/app/sysAdmin/SysAdminPageClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { Plus } from "lucide-react";
+import { Plus, Settings } from "lucide-react";
 import { useAppRouter } from "@/lib/navigation";
 import useHeaderConfig from "@/hooks/useHeaderConfig";
 import { Button } from "@/components/ui/button";
@@ -39,15 +39,26 @@ export function SysAdminPageClient({ initialData }: Props) {
         <h2 className="text-body-sm text-muted-foreground pl-4">
           コミュニティ一覧
         </h2>
-        <Button
-          onClick={() => router.push("/sysAdmin/create")}
-          variant="primary"
-          size="sm"
-          className="gap-1"
-        >
-          <Plus className="h-4 w-4" />
-          作成
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            onClick={() => router.push("/sysAdmin/system/templates")}
+            variant="tertiary"
+            size="sm"
+            className="gap-1"
+          >
+            <Settings className="h-4 w-4" />
+            設定
+          </Button>
+          <Button
+            onClick={() => router.push("/sysAdmin/create")}
+            variant="primary"
+            size="sm"
+            className="gap-1"
+          >
+            <Plus className="h-4 w-4" />
+            作成
+          </Button>
+        </div>
       </div>
 
       {loading && communities.length === 0 ? (
@@ -76,4 +87,3 @@ export function SysAdminPageClient({ initialData }: Props) {
     </div>
   );
 }
-

--- a/src/app/sysAdmin/[communityId]/CommunityDetailPageClient.tsx
+++ b/src/app/sysAdmin/[communityId]/CommunityDetailPageClient.tsx
@@ -4,7 +4,9 @@ import { useMemo } from "react";
 import useHeaderConfig from "@/hooks/useHeaderConfig";
 import LoadingIndicator from "@/components/shared/LoadingIndicator";
 import { ErrorState } from "@/components/shared/ErrorState";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type {
+  GqlGetAdminBrowseReportsQuery,
   GqlGetSysAdminCommunityDetailQuery,
   GqlSysAdminTenureDistribution,
 } from "@/types/graphql";
@@ -12,6 +14,7 @@ import { useDashboardControls } from "@/app/sysAdmin/features/dashboard/hooks/us
 import { useCommunityDetail } from "@/app/sysAdmin/features/communityDetail/hooks/useCommunityDetail";
 import { sysAdminDashboardJa } from "@/app/sysAdmin/_shared/i18n/ja";
 import { CommunityDashboardOverview } from "@/app/sysAdmin/features/communityDetail/components/CommunityDashboardOverview";
+import { CommunityReportsTabContainer } from "@/app/sysAdmin/features/communityDetail/components/CommunityReportsTabContainer";
 
 type Props = {
   communityId: string;
@@ -23,6 +26,8 @@ type Props = {
    * schema には未掲載のため、tenureDistribution と同じく page.tsx で
    * L1 と並列 fetch して受け渡す。 */
   hubMemberCount?: number | null;
+  /** SSR で取得した「レポート発行履歴」初期 1 ページ。 */
+  initialReports?: GqlGetAdminBrowseReportsQuery["adminBrowseReports"] | null;
 };
 
 export function CommunityDetailPageClient({
@@ -30,6 +35,7 @@ export function CommunityDetailPageClient({
   initialData,
   tenureDistribution,
   hubMemberCount,
+  initialReports,
 }: Props) {
   const dashboard = useDashboardControls();
   const { loading, error, detail: data } = useCommunityDetail({
@@ -61,12 +67,40 @@ export function CommunityDetailPageClient({
   const newMemberCount = latestMonth?.newMembers;
 
   return (
-    <CommunityDashboardOverview
-      data={data}
-      communityName={data.communityName}
-      newMemberCount={newMemberCount}
-      tenureDistribution={tenureDistribution ?? undefined}
-      hubMemberCount={hubMemberCount ?? undefined}
-    />
+    <div className="flex flex-col gap-6">
+      {/* community 概況 (header + funnel) は常時表示。
+          ファネル以下の詳細とレポートはタブで切替する。 */}
+      <CommunityDashboardOverview
+        data={data}
+        communityName={data.communityName}
+        newMemberCount={newMemberCount}
+        tenureDistribution={tenureDistribution ?? undefined}
+        hubMemberCount={hubMemberCount ?? undefined}
+        slot="summary"
+      />
+      <Tabs defaultValue="dashboard" className="w-full">
+        <TabsList className="grid w-full grid-cols-2 mb-2">
+          <TabsTrigger value="dashboard">ダッシュボード</TabsTrigger>
+          <TabsTrigger value="reports">レポート</TabsTrigger>
+        </TabsList>
+        <TabsContent value="dashboard">
+          <CommunityDashboardOverview
+            data={data}
+            communityName={data.communityName}
+            newMemberCount={newMemberCount}
+            tenureDistribution={tenureDistribution ?? undefined}
+            hubMemberCount={hubMemberCount ?? undefined}
+            slot="details"
+          />
+        </TabsContent>
+        <TabsContent value="reports">
+          <CommunityReportsTabContainer
+            key={communityId}
+            communityId={communityId}
+            initialReports={initialReports ?? null}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
   );
 }

--- a/src/app/sysAdmin/[communityId]/page.tsx
+++ b/src/app/sysAdmin/[communityId]/page.tsx
@@ -1,5 +1,6 @@
 import { fetchSysAdminCommunityDetailServer } from "@/app/sysAdmin/_shared/server/fetchSysAdminCommunityDetail";
 import { fetchSysAdminDashboardServer } from "@/app/sysAdmin/_shared/server/fetchSysAdminDashboard";
+import { fetchAdminBrowseReportsServer } from "@/app/sysAdmin/_shared/server/fetchAdminBrowseReports";
 import { DEFAULT_SEGMENT_THRESHOLDS } from "@/app/sysAdmin/_shared/derive";
 import {
   GqlSysAdminSortOrder,
@@ -16,10 +17,10 @@ type Props = {
 export default async function SysAdminCommunityDetailPage({ params }: Props) {
   const { communityId } = await params;
 
-  // L2 detail と L1 dashboard を並列で SSR fetch。L2 payload は
-  // tenureDistribution を持たないため、L1 の該当 community 行から
-  // 抜き出して overview に渡す。
-  const [initialData, l1Data] = await Promise.all([
+  // L2 detail / L1 dashboard / レポート発行履歴 を並列で SSR fetch。
+  // - L2 payload は tenureDistribution を持たないため L1 から抜き出す
+  // - レポート履歴は client-side fetch だと auth race の原因になるため SSR
+  const [initialData, l1Data, initialReports] = await Promise.all([
     fetchSysAdminCommunityDetailServer({
       communityId,
       asOf: undefined,
@@ -42,6 +43,7 @@ export default async function SysAdminCommunityDetailPage({ params }: Props) {
       limit: 1000,
     }),
     fetchSysAdminDashboardServer({ asOf: undefined }),
+    fetchAdminBrowseReportsServer(communityId),
   ]);
 
   const l1Row = l1Data?.communities.find(
@@ -57,6 +59,7 @@ export default async function SysAdminCommunityDetailPage({ params }: Props) {
         initialData={initialData}
         tenureDistribution={tenureDistribution}
         hubMemberCount={hubMemberCount}
+        initialReports={initialReports}
       />
     </div>
   );

--- a/src/app/sysAdmin/[communityId]/reports/[reportId]/SysAdminReportDetailPageClient.tsx
+++ b/src/app/sysAdmin/[communityId]/reports/[reportId]/SysAdminReportDetailPageClient.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useMemo } from "react";
+import useHeaderConfig from "@/hooks/useHeaderConfig";
+import type {
+  GqlGetAdminReportQuery,
+  GqlReportFeedbackFieldsFragment,
+} from "@/types/graphql";
+import { variantLabel } from "@/app/sysAdmin/features/system/templates/shared/labels";
+import { ReportDetailContainer } from "@/app/sysAdmin/features/reportDetail/components/ReportDetailContainer";
+
+type Report = NonNullable<GqlGetAdminReportQuery["report"]>;
+
+type Props = {
+  report: Report;
+  bodyHtml: string | null;
+  feedbacks: GqlReportFeedbackFieldsFragment[];
+  feedbacksTotalCount: number;
+};
+
+/**
+ * Report detail page の client wrapper。
+ * header config を当てて Container にデータを橋渡しするだけ。
+ */
+export function SysAdminReportDetailPageClient({
+  report,
+  bodyHtml,
+  feedbacks,
+  feedbacksTotalCount,
+}: Props) {
+  const headerConfig = useMemo(
+    () => ({
+      title: `${report.community.name ?? report.community.id} / ${variantLabel(report.variant)}`,
+      showBackButton: true,
+      showLogo: false,
+    }),
+    [report.community.name, report.community.id, report.variant],
+  );
+  useHeaderConfig(headerConfig);
+
+  return (
+    <div className="max-w-xl mx-auto mt-8 px-4">
+      <ReportDetailContainer
+        report={report}
+        bodyHtml={bodyHtml}
+        feedbacks={feedbacks}
+        feedbacksTotalCount={feedbacksTotalCount}
+      />
+    </div>
+  );
+}

--- a/src/app/sysAdmin/[communityId]/reports/[reportId]/page.stories.tsx
+++ b/src/app/sysAdmin/[communityId]/reports/[reportId]/page.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { withApollo, withPageShell } from "../../../../../../.storybook/decorators";
+import {
+  mockReport,
+  mockReportFeedbacks,
+} from "@/app/sysAdmin/features/reportDetail/fixtures";
+import { SysAdminReportDetailPageClient } from "./SysAdminReportDetailPageClient";
+
+const meta: Meta<typeof SysAdminReportDetailPageClient> = {
+  title: "SysAdmin/Pages/ReportDetail",
+  component: SysAdminReportDetailPageClient,
+  parameters: { layout: "fullscreen" },
+  decorators: [withPageShell, withApollo],
+};
+
+export default meta;
+type Story = StoryObj<typeof SysAdminReportDetailPageClient>;
+
+const baseBodyHtml = `
+<h1>4 月第 4 週のニュースレター</h1>
+<p>今週は <strong>3 件のイベント</strong> が開催され、合計 <strong>42 名</strong> のメンバーが参加しました。</p>
+<h2>ハイライト</h2>
+<ul>
+  <li>火曜の朝活でメンバー同士のつながりが生まれた</li>
+  <li>木曜のワークショップは満席</li>
+  <li>週末のフィールドワークで新規参加者 5 名</li>
+</ul>
+`;
+
+const feedbacks = mockReportFeedbacks(3);
+
+export const WithItems: Story = {
+  args: {
+    report: mockReport(),
+    bodyHtml: baseBodyHtml,
+    feedbacks,
+    feedbacksTotalCount: feedbacks.length,
+  },
+};
+
+export const Skipped: Story = {
+  args: {
+    report: mockReport({
+      outputMarkdown: null,
+      finalContent: null,
+      skipReason: "対象期間中の活動が少なくスキップしました",
+    }),
+    bodyHtml: null,
+    feedbacks: [],
+    feedbacksTotalCount: 0,
+  },
+};

--- a/src/app/sysAdmin/[communityId]/reports/[reportId]/page.tsx
+++ b/src/app/sysAdmin/[communityId]/reports/[reportId]/page.tsx
@@ -1,0 +1,55 @@
+import { notFound } from "next/navigation";
+import {
+  fetchAdminReportFeedbacksServer,
+  fetchAdminReportServer,
+} from "@/app/sysAdmin/_shared/server/fetchAdminReport";
+import { convertMarkdownToHtml } from "@/utils/markdownUtils";
+import { SysAdminReportDetailPageClient } from "./SysAdminReportDetailPageClient";
+
+type PageProps = {
+  params: Promise<{ communityId: string; reportId: string }>;
+};
+
+/**
+ * sysAdmin Report detail page。
+ *
+ * SSR + cookie で `report(id)` と `report.feedbacks` を並行取得し、本文
+ * markdown を sanitize 済み HTML に変換した上で client wrapper に渡す。
+ * markdown 変換は server only (sanitize に xss / unified を使うため) なので
+ * RSC 側で済ませる。
+ *
+ * Report と feedbacks Connection を別 query にしているのは Armor の cost
+ * limit 回避のため (`graphql/account/report/server.ts` のコメント参照)。
+ *
+ * `params.communityId` は URL の確認用。本来 sysAdmin はオーナー権限なので
+ * 任意の community にアクセスできるが、URL と Report.community.id が違う
+ * 場合は 404 にして混乱を防ぐ。
+ */
+export default async function SysAdminReportDetailPage({ params }: PageProps) {
+  const { communityId, reportId } = await params;
+  const [report, feedbacksConnection] = await Promise.all([
+    fetchAdminReportServer(reportId),
+    fetchAdminReportFeedbacksServer(reportId),
+  ]);
+  if (!report) notFound();
+  if (report.community.id !== communityId) notFound();
+
+  const source = report.finalContent ?? report.outputMarkdown ?? null;
+  const bodyHtml = source ? await convertMarkdownToHtml(source) : null;
+
+  const feedbacks =
+    feedbacksConnection?.edges
+      ?.map((e) => e?.node)
+      .filter((n): n is NonNullable<typeof n> => n != null) ?? [];
+  const feedbacksTotalCount =
+    feedbacksConnection?.totalCount ?? feedbacks.length;
+
+  return (
+    <SysAdminReportDetailPageClient
+      report={report}
+      bodyHtml={bodyHtml}
+      feedbacks={feedbacks}
+      feedbacksTotalCount={feedbacksTotalCount}
+    />
+  );
+}

--- a/src/app/sysAdmin/_shared/components/MetadataChips.tsx
+++ b/src/app/sysAdmin/_shared/components/MetadataChips.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+type Item = ReactNode | { label: ReactNode; emphasis?: boolean };
+
+type Props = {
+  /**
+   * メタ chip の一覧。`null` / `undefined` は無視するので、条件付きの値も
+   * `value && { label: ... }` の形でそのまま渡せる。
+   */
+  items: Array<Item | null | undefined | false>;
+  className?: string;
+};
+
+/**
+ * 「v3」「配信比率 70%」のようなメタ情報を Badge で横並びに出す共通 chip 群。
+ * テンプレ詳細の inline header / Report detail header で使う。
+ */
+export function MetadataChips({ items, className }: Props) {
+  const filtered = items.filter(
+    (i): i is Item => i != null && i !== false,
+  );
+  if (filtered.length === 0) return null;
+  return (
+    <div className={cn("flex flex-wrap items-center gap-1.5", className)}>
+      {filtered.map((item, i) => {
+        const isObj =
+          typeof item === "object" && item !== null && "label" in item;
+        const label = isObj ? (item as { label: ReactNode }).label : item;
+        const emphasis = isObj && (item as { emphasis?: boolean }).emphasis;
+        return (
+          <Badge
+            key={i}
+            variant={emphasis ? "primary" : "outline"}
+            size="sm"
+            className="font-normal text-body-xs tabular-nums"
+          >
+            {label}
+          </Badge>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/sysAdmin/_shared/feedback/FeedbackCard.stories.tsx
+++ b/src/app/sysAdmin/_shared/feedback/FeedbackCard.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { GqlReportFeedbackType } from "@/types/graphql";
+import { FeedbackCard } from "./FeedbackCard";
+
+const meta: Meta<typeof FeedbackCard> = {
+  title: "SysAdmin/Shared/Feedback/FeedbackCard",
+  component: FeedbackCard,
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-md p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof FeedbackCard>;
+
+const baseUser = { __typename: "User" as const, id: "u_1", name: "佐藤花子" };
+
+export const HighRating: Story = {
+  args: {
+    feedback: {
+      __typename: "ReportFeedback",
+      id: "f_1",
+      rating: 5,
+      comment: "全体的に読みやすかった。次回も同じトーンで続けてほしい。",
+      feedbackType: GqlReportFeedbackType.Tone,
+      sectionKey: "intro",
+      createdAt: new Date("2026-04-25"),
+      user: baseUser,
+    },
+  },
+};
+
+export const LowRating: Story = {
+  args: {
+    feedback: {
+      __typename: "ReportFeedback",
+      id: "f_2",
+      rating: 2,
+      comment:
+        "数字に違和感があります。先月の値が混ざっている可能性があるため確認してください。本文の長さも冗長で、本題が後半に集中している印象です。",
+      feedbackType: GqlReportFeedbackType.Accuracy,
+      sectionKey: null,
+      createdAt: new Date("2026-04-23"),
+      user: baseUser,
+    },
+  },
+};
+
+export const NoComment: Story = {
+  args: {
+    feedback: {
+      __typename: "ReportFeedback",
+      id: "f_3",
+      rating: 4,
+      comment: null,
+      feedbackType: GqlReportFeedbackType.Quality,
+      sectionKey: null,
+      createdAt: new Date("2026-04-20"),
+      user: baseUser,
+    },
+  },
+};
+
+export const WithReportLink: Story = {
+  args: {
+    feedback: {
+      __typename: "ReportFeedback",
+      id: "f_4",
+      rating: 3,
+      comment: "中盤の段落が冗長。箇条書きにした方が伝わる。",
+      feedbackType: GqlReportFeedbackType.Structure,
+      sectionKey: "highlight",
+      createdAt: new Date("2026-04-22"),
+      user: baseUser,
+    },
+    reportLink: {
+      href: "/sysAdmin/c_kibotcha/reports/r_42",
+      label: "kibotcha",
+    },
+  },
+};

--- a/src/app/sysAdmin/_shared/feedback/FeedbackCard.tsx
+++ b/src/app/sysAdmin/_shared/feedback/FeedbackCard.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { feedbackTypeLabel } from "@/app/sysAdmin/features/system/templates/shared/labels";
+import type { GqlReportFeedbackFieldsFragment } from "@/types/graphql";
+import { Stars } from "./Stars";
+
+type Props = {
+  feedback: GqlReportFeedbackFieldsFragment;
+  /**
+   * 表示文脈で「このフィードバックの元のレポート」へ飛ぶ link を出す場合に渡す。
+   * Report detail 内では文脈上「現在見ているレポート」なので不要。
+   * テンプレ詳細の feed では `feedback.report` から構築して渡す。
+   */
+  reportLink?: { href: string; label: string };
+};
+
+/**
+ * shadcnblocks の Customer Reviews 風カード。
+ * 上段に avatar + name + date + 星、下段に種類タイトル + comment、
+ * 必要に応じて section key と report link を末尾に出す。
+ *
+ * 単一の card で「テンプレ詳細 (report link 付き) / Report detail (link 無し)」
+ * 両方の文脈を吸収する。
+ */
+export function FeedbackCard({ feedback, reportLink }: Props) {
+  const initial = feedback.user.name?.slice(0, 1) ?? "?";
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0 p-4">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <Avatar className="h-10 w-10">
+            <AvatarFallback>{initial}</AvatarFallback>
+          </Avatar>
+          <div className="min-w-0">
+            <p className="truncate text-body-sm font-medium">
+              {feedback.user.name}
+            </p>
+            <p className="text-body-xs text-muted-foreground tabular-nums">
+              {new Date(feedback.createdAt).toLocaleDateString("ja-JP")}
+            </p>
+          </div>
+        </div>
+        <Stars rating={feedback.rating} />
+      </CardHeader>
+      <CardContent className="space-y-2 px-4 pb-4 pt-0">
+        {feedback.feedbackType && (
+          <p className="text-body-sm font-semibold">
+            {feedbackTypeLabel(feedback.feedbackType)}
+          </p>
+        )}
+        {feedback.comment ? (
+          <p className="line-clamp-3 text-body-sm leading-relaxed">
+            {feedback.comment}
+          </p>
+        ) : (
+          <p className="text-body-xs italic text-muted-foreground">
+            (コメントなし)
+          </p>
+        )}
+        {(feedback.sectionKey || reportLink) && (
+          <div className="flex flex-wrap items-center gap-1 pt-1 text-body-xs text-muted-foreground">
+            {feedback.sectionKey && (
+              <Badge variant="outline" className="font-mono">
+                {feedback.sectionKey}
+              </Badge>
+            )}
+            {reportLink && (
+              <Link
+                href={reportLink.href}
+                className="ml-auto inline-flex items-center gap-1 text-body-xs text-muted-foreground hover:text-foreground"
+              >
+                <span>{reportLink.label}</span>
+                <ExternalLink className="h-3 w-3" aria-hidden />
+                <span className="sr-only">レポートを開く</span>
+              </Link>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/sysAdmin/_shared/feedback/FeedbackList.stories.tsx
+++ b/src/app/sysAdmin/_shared/feedback/FeedbackList.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { makeMockFeedbacks } from "@/app/sysAdmin/features/system/templates/feedback/fixtures";
+import { FeedbackList } from "./FeedbackList";
+import { RatingSummary } from "./RatingSummary";
+
+const meta: Meta<typeof FeedbackList> = {
+  title: "SysAdmin/Shared/Feedback/FeedbackList",
+  component: FeedbackList,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-xl p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof FeedbackList>;
+
+const feedbacks = makeMockFeedbacks(8);
+
+export const ReportDetailContext: Story = {
+  args: {
+    feedbacks,
+    totalCount: feedbacks.length,
+  },
+};
+
+/**
+ * テンプレ詳細での使い方。`reportLinkFor` callback で `feedback.report` から
+ * link を組み立てる必要があるため、generic component を直接 render して
+ * T を `with-report` 型に bind する。
+ */
+export const TemplateDetailContext: Story = {
+  render: () => (
+    <FeedbackList
+      feedbacks={feedbacks}
+      totalCount={feedbacks.length}
+      reportLinkFor={(fb) => ({
+        href: `/sysAdmin/${fb.report.community.id}/reports/${fb.report.id}`,
+        label: fb.report.community.name ?? fb.report.community.id,
+      })}
+      summary={
+        <RatingSummary
+          avgRating={4.3}
+          totalCount={feedbacks.length}
+          distribution={[
+            { rating: 1, count: 0 },
+            { rating: 2, count: 0 },
+            { rating: 3, count: 1 },
+            { rating: 4, count: 3 },
+            { rating: 5, count: 4 },
+          ]}
+        />
+      }
+    />
+  ),
+};
+
+export const HasMore: Story = {
+  args: {
+    feedbacks,
+    totalCount: 47,
+    pagination: {
+      hasNextPage: true,
+      loadingMore: false,
+      onLoadMore: () => undefined,
+    },
+  },
+};
+
+export const LoadingMore: Story = {
+  args: {
+    feedbacks,
+    totalCount: 47,
+    pagination: {
+      hasNextPage: true,
+      loadingMore: true,
+      onLoadMore: () => undefined,
+    },
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    feedbacks: [],
+  },
+};

--- a/src/app/sysAdmin/_shared/feedback/FeedbackList.tsx
+++ b/src/app/sysAdmin/_shared/feedback/FeedbackList.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import type { GqlReportFeedbackFieldsFragment } from "@/types/graphql";
+import { FeedbackCard } from "./FeedbackCard";
+
+type Props<T extends GqlReportFeedbackFieldsFragment> = {
+  feedbacks: T[];
+  totalCount?: number;
+  /**
+   * 各 card に出す Report への link を、外から組み立てて渡す関数。
+   * 渡されないと link 無し card になる (Report detail 内など)。
+   *
+   * `T` を generic にしてあるのは、テンプレ詳細では
+   * `ReportFeedbackWithReportFieldsFragment` を渡して
+   * `feedback.report` にアクセスして link を組み立てたいため。
+   */
+  reportLinkFor?: (feedback: T) => { href: string; label: string } | null;
+  /**
+   * リスト上部に出す summary slot (`<RatingSummary />` を入れる想定)。
+   * 不要な文脈 (Report detail 内) では省略する。
+   */
+  summary?: ReactNode;
+  pagination?: {
+    hasNextPage: boolean;
+    loadingMore: boolean;
+    onLoadMore: () => void;
+  };
+};
+
+export function FeedbackList<T extends GqlReportFeedbackFieldsFragment>({
+  feedbacks,
+  totalCount,
+  reportLinkFor,
+  summary,
+  pagination,
+}: Props<T>) {
+  // summary の有無で header の見せ方を変える:
+  //   - summary あり (テンプレ詳細): "フィードバック" を大きく見出しとして出し、
+  //     件数は summary が責任を持つ (= "全 N 件のフィードバック")
+  //   - summary なし (Report detail): 1 行 header に件数 chip を併置
+  return (
+    <section className="space-y-6">
+      {summary ? (
+        <>
+          <h2 className="text-2xl font-bold">フィードバック</h2>
+          {summary}
+        </>
+      ) : (
+        <header className="flex items-baseline justify-between">
+          <h3 className="text-body-sm font-semibold">フィードバック</h3>
+          {feedbacks.length > 0 && (
+            <span className="text-body-xs text-muted-foreground tabular-nums">
+              {feedbacks.length}
+              {totalCount != null && totalCount !== feedbacks.length
+                ? ` / ${totalCount}`
+                : ""}{" "}
+              件
+            </span>
+          )}
+        </header>
+      )}
+
+      {feedbacks.length === 0 ? (
+        <p className="rounded border border-dashed border-border py-6 text-center text-body-sm text-muted-foreground">
+          まだフィードバックはありません
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {feedbacks.map((fb) => (
+            <FeedbackCard
+              key={fb.id}
+              feedback={fb}
+              reportLink={reportLinkFor?.(fb) ?? undefined}
+            />
+          ))}
+        </div>
+      )}
+
+      {pagination?.hasNextPage && (
+        <div className="flex justify-center">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={pagination.onLoadMore}
+            disabled={pagination.loadingMore}
+          >
+            {pagination.loadingMore ? "読み込み中..." : "もっと見る"}
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/app/sysAdmin/_shared/feedback/RatingSummary.stories.tsx
+++ b/src/app/sysAdmin/_shared/feedback/RatingSummary.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { RatingSummary } from "./RatingSummary";
+
+const meta: Meta<typeof RatingSummary> = {
+  title: "SysAdmin/Shared/Feedback/RatingSummary",
+  component: RatingSummary,
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-md p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof RatingSummary>;
+
+export const SummaryOnly: Story = {
+  args: {
+    avgRating: 4.3,
+    totalCount: 6,
+  },
+};
+
+export const WithDistribution: Story = {
+  args: {
+    avgRating: 4.3,
+    totalCount: 6,
+    distribution: [
+      { rating: 1, count: 0 },
+      { rating: 2, count: 0 },
+      { rating: 3, count: 1 },
+      { rating: 4, count: 2 },
+      { rating: 5, count: 3 },
+    ],
+  },
+};
+
+export const NoFeedback: Story = {
+  args: {
+    avgRating: null,
+    totalCount: 0,
+    distribution: [
+      { rating: 1, count: 0 },
+      { rating: 2, count: 0 },
+      { rating: 3, count: 0 },
+      { rating: 4, count: 0 },
+      { rating: 5, count: 0 },
+    ],
+  },
+};

--- a/src/app/sysAdmin/_shared/feedback/RatingSummary.tsx
+++ b/src/app/sysAdmin/_shared/feedback/RatingSummary.tsx
@@ -1,0 +1,97 @@
+import { Star } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Stars } from "./Stars";
+
+type DistributionBucket = {
+  rating: number;
+  count: number;
+};
+
+type Props = {
+  /** 0 件のとき null。表示は "—" に落ちる。 */
+  avgRating: number | null;
+  totalCount: number;
+  /**
+   * backend の `adminTemplateFeedbackStats.ratingDistribution` をそのまま渡す。
+   * dense 5 行 (1..5) で count=0 を含むのが backend 仕様。
+   * undefined の場合は distribution bar を出さない (= summary だけ)。
+   */
+  distribution?: DistributionBucket[];
+  className?: string;
+};
+
+/**
+ * shadcnblocks の Customer Reviews 上部風 summary。
+ *
+ * 表示:
+ *   ┌──────────────────────────────────┐
+ *   │              4.3                 │
+ *   │           ★★★★☆                  │
+ *   │       全 6 件のフィードバック    │
+ *   │                                  │
+ *   │  5★ [████████░░░░░░░] 3          │
+ *   │  4★ [█████░░░░░░░░░░] 2          │
+ *   │  3★ [██░░░░░░░░░░░░░] 1          │
+ *   │  2★ [░░░░░░░░░░░░░░░] 0          │
+ *   │  1★ [░░░░░░░░░░░░░░░] 0          │
+ *   └──────────────────────────────────┘
+ *
+ * `distribution` が無いときは下半分 (bar chart) を省略し、上の集計値だけ出す。
+ */
+export function RatingSummary({
+  avgRating,
+  totalCount,
+  distribution,
+  className,
+}: Props) {
+  const rounded = avgRating != null ? Math.round(avgRating) : 0;
+  const max = distribution
+    ? Math.max(1, ...distribution.map((b) => b.count))
+    : 0;
+
+  return (
+    <section className={cn("space-y-6", className)}>
+      <div className="flex flex-col items-center gap-2">
+        <p className="text-6xl font-bold tabular-nums leading-none">
+          {avgRating != null ? avgRating.toFixed(1) : "—"}
+        </p>
+        <Stars rating={rounded} size="lg" />
+        <p className="text-body-sm text-muted-foreground tabular-nums">
+          全 {totalCount} 件のフィードバック
+        </p>
+      </div>
+
+      {distribution && distribution.length > 0 && (
+        <ul className="space-y-2">
+          {[5, 4, 3, 2, 1].map((rating) => {
+            const bucket = distribution.find((b) => b.rating === rating);
+            const count = bucket?.count ?? 0;
+            const ratio = max > 0 ? count / max : 0;
+            return (
+              <li
+                key={rating}
+                className="grid grid-cols-[3rem_1fr_2rem] items-center gap-3 text-body-sm text-muted-foreground"
+              >
+                <span className="inline-flex items-center gap-1 tabular-nums">
+                  <span>{rating}</span>
+                  <Star
+                    className="h-3.5 w-3.5 fill-foreground text-foreground"
+                    aria-hidden
+                  />
+                </span>
+                <span className="relative h-3 overflow-hidden rounded-full bg-muted">
+                  <span
+                    className="absolute inset-y-0 left-0 rounded-full bg-foreground"
+                    style={{ width: `${ratio * 100}%` }}
+                    aria-hidden
+                  />
+                </span>
+                <span className="text-right tabular-nums">{count}</span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/app/sysAdmin/_shared/feedback/Stars.stories.tsx
+++ b/src/app/sysAdmin/_shared/feedback/Stars.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Stars } from "./Stars";
+
+const meta: Meta<typeof Stars> = {
+  title: "SysAdmin/Shared/Feedback/Stars",
+  component: Stars,
+  parameters: { layout: "centered" },
+};
+
+export default meta;
+type Story = StoryObj<typeof Stars>;
+
+export const Five: Story = { args: { rating: 5 } };
+export const Four: Story = { args: { rating: 4 } };
+export const Three: Story = { args: { rating: 3 } };
+export const Zero: Story = { args: { rating: 0 } };
+export const Large: Story = { args: { rating: 4, size: "lg" } };
+export const Small: Story = { args: { rating: 4, size: "sm" } };

--- a/src/app/sysAdmin/_shared/feedback/Stars.tsx
+++ b/src/app/sysAdmin/_shared/feedback/Stars.tsx
@@ -1,0 +1,40 @@
+import { Star } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  rating: number;
+  /** 1 個あたりの大きさ (Tailwind size class)。デフォルト `h-3.5 w-3.5`。 */
+  size?: "sm" | "md" | "lg";
+  className?: string;
+};
+
+const SIZE_CLASS: Record<NonNullable<Props["size"]>, string> = {
+  sm: "h-3 w-3",
+  md: "h-3.5 w-3.5",
+  lg: "h-5 w-5",
+};
+
+/**
+ * read-only な 5 段星表示。アクセシビリティのため
+ * `role="img"` + `aria-label` で「N / 5」を発音させる。
+ */
+export function Stars({ rating, size = "md", className }: Props) {
+  return (
+    <span
+      role="img"
+      aria-label={`${rating} / 5`}
+      className={cn("inline-flex shrink-0", className)}
+    >
+      {[1, 2, 3, 4, 5].map((n) => (
+        <Star
+          key={n}
+          className={cn(
+            SIZE_CLASS[size],
+            n <= rating ? "fill-amber-400 text-amber-400" : "text-muted",
+          )}
+          aria-hidden
+        />
+      ))}
+    </span>
+  );
+}

--- a/src/app/sysAdmin/_shared/hooks/useCursorPagination.ts
+++ b/src/app/sysAdmin/_shared/hooks/useCursorPagination.ts
@@ -1,0 +1,182 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * GraphQL Connection 型 (Relay 互換) の最小形。
+ * 各 query の Connection 型はこれに structurally compatible なので、
+ * `as` cast せずにそのまま渡せる。
+ */
+export type ConnectionLike<TItem> = {
+  edges?:
+    | Array<{
+        cursor: string;
+        node?: TItem | null;
+      } | null>
+    | null;
+  pageInfo: {
+    hasNextPage: boolean;
+    endCursor?: string | null;
+  };
+  totalCount?: number;
+};
+
+type FetchMore<TItem> = (
+  cursor: string,
+  first: number,
+) => Promise<ConnectionLike<TItem>>;
+
+type Options<TItem> = {
+  initial: ConnectionLike<TItem>;
+  fetchMore: FetchMore<TItem>;
+  pageSize?: number;
+  onError?: (err: unknown) => void;
+  /**
+   * 論理的な「データセットの identity」を表すキー (例: filter のハッシュ、
+   * variant + version など)。これが変わったとき *だけ* 内部 state を
+   * `initial` で再同期する。
+   *
+   * 省略すると `initial` の参照 (object identity) を dep に使うので、
+   * 呼び出し側で `initial` を `useMemo` などでメモ化しないと、毎レンダー
+   * state が wipe されて pagination が破綻する。安全のため `resetKey` の
+   * 利用を推奨。
+   */
+  resetKey?: string | number;
+};
+
+type Result<TItem> = {
+  items: TItem[];
+  hasNextPage: boolean;
+  loading: boolean;
+  loadMore: () => Promise<void>;
+  reset: (next: ConnectionLike<TItem>) => void;
+};
+
+function extractItems<TItem>(conn: ConnectionLike<TItem>): TItem[] {
+  return (
+    conn.edges
+      ?.map((e) => e?.node)
+      .filter((n): n is TItem => n != null) ?? []
+  );
+}
+
+/**
+ * GraphQL Connection を cursor pagination で消費する generic hook。
+ *
+ * 以下の流れを抽象化:
+ *   1. 初期 Connection を items にバラす
+ *   2. loadMore 呼び出しで fetchMore(cursor) → 結果を items に append
+ *   3. hasNextPage / endCursor を内部 state で管理
+ *
+ * Apollo の useQuery + fetchMore パターンに被せる場合は、
+ * fetchMore コールバック内で client.query などを使って次ページを取得する
+ * function を渡す。
+ *
+ * ⚠ `initial` は object なので、毎レンダーで違う参照を渡すと内部 state が
+ * 毎回リセットされる。安全策として:
+ *   - `resetKey` を指定する (= filter / variant / version など、論理的な
+ *     identity を表す primitive 値)。これが変わった時だけ state を再同期する。
+ *   - `resetKey` を指定しない場合は呼び出し側で `initial` を useMemo して
+ *     参照安定化させること。
+ */
+export function useCursorPagination<TItem>({
+  initial,
+  fetchMore,
+  pageSize = 20,
+  onError,
+  resetKey,
+}: Options<TItem>): Result<TItem> {
+  const [items, setItems] = useState<TItem[]>(() => extractItems(initial));
+  const [endCursor, setEndCursor] = useState<string | null>(
+    initial.pageInfo.endCursor ?? null,
+  );
+  const [hasNextPage, setHasNextPage] = useState<boolean>(
+    initial.pageInfo.hasNextPage,
+  );
+  const [loading, setLoading] = useState(false);
+
+  // 同期的な並行制御用 ref。setLoading は非同期反映のため、
+  // rapid loadMore() 呼び出し (例: スクロール / 連打) で重複 fetch が
+  // 起きるのを防ぐ。endCursor / hasNextPage も同様に最新値を保持。
+  const loadingRef = useRef(false);
+  const endCursorRef = useRef<string | null>(initial.pageInfo.endCursor ?? null);
+  const hasNextPageRef = useRef<boolean>(initial.pageInfo.hasNextPage);
+
+  // initial 切替 (= filter 変更などで親が再 fetch) と in-flight な loadMore の
+  // 競合で stale append が起きないよう、世代カウンタで in-flight 結果を破棄する。
+  const generationRef = useRef(0);
+
+  // useEffect の dep 切替時に最新の `initial` を読むための ref。
+  // dep に initial を直接入れず resetKey 主軸で fire させたいので、
+  // 中身は ref で覗く。
+  const initialRef = useRef(initial);
+  initialRef.current = initial;
+
+  // resetKey が指定されればそれを dep にし、無ければ initial の参照を dep に
+  // フォールバックする (= caller が useMemo などで stable に保つ前提)。
+  const depKey = resetKey ?? initial;
+
+  useEffect(() => {
+    const latest = initialRef.current;
+    generationRef.current += 1;
+    // in-flight な loadMore の loadingRef が立ったままだと、新しい initial に
+    // 対する次の loadMore が「まだ読み込み中」と誤判定されてブロックされる。
+    // generation でレスポンスは捨てられるので、guard も明示的にリセットする。
+    loadingRef.current = false;
+    setItems(extractItems(latest));
+    setEndCursor(latest.pageInfo.endCursor ?? null);
+    setHasNextPage(latest.pageInfo.hasNextPage);
+    setLoading(false);
+    endCursorRef.current = latest.pageInfo.endCursor ?? null;
+    hasNextPageRef.current = latest.pageInfo.hasNextPage;
+  }, [depKey]);
+
+  const loadMore = useCallback(async () => {
+    if (loadingRef.current || !hasNextPageRef.current || !endCursorRef.current) {
+      return;
+    }
+    loadingRef.current = true;
+    setLoading(true);
+    const cursor = endCursorRef.current;
+    const requestGeneration = generationRef.current;
+    try {
+      const next = await fetchMore(cursor, pageSize);
+      // 取得中に initial が再投入された場合は結果を捨てる (stale page を append しない)
+      if (requestGeneration !== generationRef.current) return;
+      const nextEndCursor = next.pageInfo.endCursor ?? null;
+      const nextHasNextPage = next.pageInfo.hasNextPage;
+      endCursorRef.current = nextEndCursor;
+      hasNextPageRef.current = nextHasNextPage;
+      setItems((prev) => [...prev, ...extractItems(next)]);
+      setEndCursor(nextEndCursor);
+      setHasNextPage(nextHasNextPage);
+    } catch (err) {
+      if (requestGeneration === generationRef.current) {
+        onError?.(err);
+      }
+    } finally {
+      // generation が一致する request だけが loadingRef を解除できる。
+      // stale な finally で解除すると、その間に始まった新 generation の
+      // loadMore の guard を誤ってクリアしてしまう。
+      if (requestGeneration === generationRef.current) {
+        loadingRef.current = false;
+        setLoading(false);
+      }
+    }
+  }, [fetchMore, pageSize, onError]);
+
+  const reset = useCallback((next: ConnectionLike<TItem>) => {
+    generationRef.current += 1;
+    loadingRef.current = false;
+    const nextEndCursor = next.pageInfo.endCursor ?? null;
+    const nextHasNextPage = next.pageInfo.hasNextPage;
+    endCursorRef.current = nextEndCursor;
+    hasNextPageRef.current = nextHasNextPage;
+    setItems(extractItems(next));
+    setEndCursor(nextEndCursor);
+    setHasNextPage(nextHasNextPage);
+    setLoading(false);
+  }, []);
+
+  return { items, hasNextPage, loading, loadMore, reset };
+}

--- a/src/app/sysAdmin/_shared/hooks/useCursorPagination.ts
+++ b/src/app/sysAdmin/_shared/hooks/useCursorPagination.ts
@@ -48,6 +48,10 @@ type Result<TItem> = {
   items: TItem[];
   hasNextPage: boolean;
   loading: boolean;
+  /** 母集団件数。SSR initial と各 fetchMore レスポンスから常に最新を保つ。 */
+  totalCount: number;
+  /** 直近の loadMore で発生した例外。次回成功時に null に戻る。 */
+  error: unknown;
   loadMore: () => Promise<void>;
   reset: (next: ConnectionLike<TItem>) => void;
 };
@@ -66,7 +70,7 @@ function extractItems<TItem>(conn: ConnectionLike<TItem>): TItem[] {
  * 以下の流れを抽象化:
  *   1. 初期 Connection を items にバラす
  *   2. loadMore 呼び出しで fetchMore(cursor) → 結果を items に append
- *   3. hasNextPage / endCursor を内部 state で管理
+ *   3. hasNextPage / endCursor / totalCount / error を内部 state で管理
  *
  * Apollo の useQuery + fetchMore パターンに被せる場合は、
  * fetchMore コールバック内で client.query などを使って次ページを取得する
@@ -94,6 +98,10 @@ export function useCursorPagination<TItem>({
     initial.pageInfo.hasNextPage,
   );
   const [loading, setLoading] = useState(false);
+  const [totalCount, setTotalCount] = useState<number>(
+    initial.totalCount ?? extractItems(initial).length,
+  );
+  const [error, setError] = useState<unknown>(null);
 
   // 同期的な並行制御用 ref。setLoading は非同期反映のため、
   // rapid loadMore() 呼び出し (例: スクロール / 連打) で重複 fetch が
@@ -123,20 +131,30 @@ export function useCursorPagination<TItem>({
     // 対する次の loadMore が「まだ読み込み中」と誤判定されてブロックされる。
     // generation でレスポンスは捨てられるので、guard も明示的にリセットする。
     loadingRef.current = false;
-    setItems(extractItems(latest));
+    const latestItems = extractItems(latest);
+    setItems(latestItems);
     setEndCursor(latest.pageInfo.endCursor ?? null);
     setHasNextPage(latest.pageInfo.hasNextPage);
     setLoading(false);
+    setTotalCount(latest.totalCount ?? latestItems.length);
+    setError(null);
     endCursorRef.current = latest.pageInfo.endCursor ?? null;
     hasNextPageRef.current = latest.pageInfo.hasNextPage;
   }, [depKey]);
 
   const loadMore = useCallback(async () => {
-    if (loadingRef.current || !hasNextPageRef.current || !endCursorRef.current) {
+    // 空文字 cursor も「終端」ではなく有効値として扱うため、null/undefined を
+    // 明示的にチェックする (`!cursor` だと "" が偽になる)。
+    if (
+      loadingRef.current ||
+      !hasNextPageRef.current ||
+      endCursorRef.current == null
+    ) {
       return;
     }
     loadingRef.current = true;
     setLoading(true);
+    setError(null);
     const cursor = endCursorRef.current;
     const requestGeneration = generationRef.current;
     try {
@@ -147,11 +165,18 @@ export function useCursorPagination<TItem>({
       const nextHasNextPage = next.pageInfo.hasNextPage;
       endCursorRef.current = nextEndCursor;
       hasNextPageRef.current = nextHasNextPage;
-      setItems((prev) => [...prev, ...extractItems(next)]);
+      const nextItems = extractItems(next);
+      setItems((prev) => [...prev, ...nextItems]);
+      // backend が totalCount を返さないケースは累積件数で代替。
+      // setItems の updater は純粋関数として保つため、setTotalCount は外側で
+      // 独立に呼ぶ (Strict Mode で updater が二重実行されても副作用が
+      // 漏れないように)。
+      setTotalCount((prev) => next.totalCount ?? prev + nextItems.length);
       setEndCursor(nextEndCursor);
       setHasNextPage(nextHasNextPage);
     } catch (err) {
       if (requestGeneration === generationRef.current) {
+        setError(err);
         onError?.(err);
       }
     } finally {
@@ -172,11 +197,22 @@ export function useCursorPagination<TItem>({
     const nextHasNextPage = next.pageInfo.hasNextPage;
     endCursorRef.current = nextEndCursor;
     hasNextPageRef.current = nextHasNextPage;
-    setItems(extractItems(next));
+    const nextItems = extractItems(next);
+    setItems(nextItems);
     setEndCursor(nextEndCursor);
     setHasNextPage(nextHasNextPage);
     setLoading(false);
+    setTotalCount(next.totalCount ?? nextItems.length);
+    setError(null);
   }, []);
 
-  return { items, hasNextPage, loading, loadMore, reset };
+  return {
+    items,
+    hasNextPage,
+    loading,
+    totalCount,
+    error,
+    loadMore,
+    reset,
+  };
 }

--- a/src/app/sysAdmin/_shared/server/fetchActiveTemplate.ts
+++ b/src/app/sysAdmin/_shared/server/fetchActiveTemplate.ts
@@ -1,0 +1,77 @@
+import "server-only";
+
+import { executeServerGraphQLQuery } from "@/lib/graphql/server";
+import { hasServerSession } from "@/lib/auth/server/session";
+import { logger } from "@/lib/logging";
+import {
+  GET_REPORT_TEMPLATE_SERVER_QUERY,
+  GET_REPORT_TEMPLATES_SERVER_QUERY,
+} from "@/graphql/account/reportTemplate/server";
+import {
+  GqlReportTemplateKind,
+  type GqlGetReportTemplateQuery,
+  type GqlGetReportTemplatesQuery,
+  type GqlReportTemplateFieldsFragment,
+  type GqlReportVariant,
+} from "@/types/graphql";
+
+/**
+ * variant の active な GENERATION template を SSR で取得 (1 件)。
+ * editor の初期表示用。backend `reportTemplate` は GENERATION 固定。
+ */
+export async function fetchActiveGenerationTemplateServer(
+  variant: GqlReportVariant,
+): Promise<GqlReportTemplateFieldsFragment | null> {
+  const hasSession = await hasServerSession();
+  if (!hasSession) return null;
+
+  try {
+    const data = await executeServerGraphQLQuery<
+      GqlGetReportTemplateQuery,
+      { variant: GqlReportVariant; communityId?: string | null }
+    >(GET_REPORT_TEMPLATE_SERVER_QUERY, { variant });
+    return data.reportTemplate ?? null;
+  } catch (error) {
+    logger.warn("[sysAdmin] fetchActiveGenerationTemplateServer failed", {
+      message: (error as Error).message,
+      variant,
+      component: "fetchActiveGenerationTemplateServer",
+    });
+    return null;
+  }
+}
+
+/**
+ * variant の active な JUDGE template を SSR で取得 (1 件)。
+ * 配列で返るので [0] を取る (= active かつ最新版)。
+ */
+export async function fetchActiveJudgeTemplateServer(
+  variant: GqlReportVariant,
+): Promise<GqlReportTemplateFieldsFragment | null> {
+  const hasSession = await hasServerSession();
+  if (!hasSession) return null;
+
+  try {
+    const data = await executeServerGraphQLQuery<
+      GqlGetReportTemplatesQuery,
+      {
+        variant: GqlReportVariant;
+        communityId?: string | null;
+        kind?: GqlReportTemplateKind | null;
+        includeInactive?: boolean | null;
+      }
+    >(GET_REPORT_TEMPLATES_SERVER_QUERY, {
+      variant,
+      kind: GqlReportTemplateKind.Judge,
+      includeInactive: false,
+    });
+    return data.reportTemplates[0] ?? null;
+  } catch (error) {
+    logger.warn("[sysAdmin] fetchActiveJudgeTemplateServer failed", {
+      message: (error as Error).message,
+      variant,
+      component: "fetchActiveJudgeTemplateServer",
+    });
+    return null;
+  }
+}

--- a/src/app/sysAdmin/_shared/server/fetchAdminBrowseReports.ts
+++ b/src/app/sysAdmin/_shared/server/fetchAdminBrowseReports.ts
@@ -1,0 +1,44 @@
+import "server-only";
+
+import { executeServerGraphQLQuery } from "@/lib/graphql/server";
+import { hasServerSession } from "@/lib/auth/server/session";
+import { logger } from "@/lib/logging";
+import { GET_ADMIN_BROWSE_REPORTS_SERVER_QUERY } from "@/graphql/account/adminReports/server";
+import type { GqlGetAdminBrowseReportsQuery } from "@/types/graphql";
+
+const PAGE_SIZE = 20;
+
+/**
+ * 単一 community のレポート発行履歴を SSR で取得 (1 ページ目)。
+ * client-side の追加ロード (もっと見る) は引き続き Apollo fetchMore を使う。
+ */
+export async function fetchAdminBrowseReportsServer(
+  communityId: string,
+): Promise<
+  NonNullable<GqlGetAdminBrowseReportsQuery["adminBrowseReports"]> | null
+> {
+  const hasSession = await hasServerSession();
+  if (!hasSession) return null;
+
+  try {
+    const data = await executeServerGraphQLQuery<
+      GqlGetAdminBrowseReportsQuery,
+      {
+        communityId?: string | null;
+        first?: number | null;
+        cursor?: string | null;
+      }
+    >(GET_ADMIN_BROWSE_REPORTS_SERVER_QUERY, {
+      communityId,
+      first: PAGE_SIZE,
+    });
+    return data.adminBrowseReports ?? null;
+  } catch (error) {
+    logger.warn("[sysAdmin] fetchAdminBrowseReportsServer failed", {
+      message: (error as Error).message,
+      communityId,
+      component: "fetchAdminBrowseReportsServer",
+    });
+    return null;
+  }
+}

--- a/src/app/sysAdmin/_shared/server/fetchAdminReport.ts
+++ b/src/app/sysAdmin/_shared/server/fetchAdminReport.ts
@@ -1,0 +1,78 @@
+import "server-only";
+
+import { executeServerGraphQLQuery } from "@/lib/graphql/server";
+import { hasServerSession } from "@/lib/auth/server/session";
+import { logger } from "@/lib/logging";
+import {
+  GET_ADMIN_REPORT_FEEDBACKS_SERVER_QUERY,
+  GET_ADMIN_REPORT_SERVER_QUERY,
+} from "@/graphql/account/report/server";
+import type {
+  GqlGetAdminReportFeedbacksQuery,
+  GqlGetAdminReportFeedbacksQueryVariables,
+  GqlGetAdminReportQuery,
+  GqlGetAdminReportQueryVariables,
+} from "@/types/graphql";
+
+const FEEDBACKS_PAGE_SIZE = 20;
+
+/**
+ * Report detail page で表示する Report 単票を SSR で取得。
+ * sysAdmin は全 community のオーナーなので、community 制約なしで叩ける。
+ */
+export async function fetchAdminReportServer(
+  id: string,
+): Promise<NonNullable<GqlGetAdminReportQuery["report"]> | null> {
+  const hasSession = await hasServerSession();
+  if (!hasSession) return null;
+
+  try {
+    const data = await executeServerGraphQLQuery<
+      GqlGetAdminReportQuery,
+      GqlGetAdminReportQueryVariables
+    >(GET_ADMIN_REPORT_SERVER_QUERY, { id });
+    return data.report ?? null;
+  } catch (error) {
+    logger.warn("[sysAdmin] fetchAdminReportServer failed", {
+      message: (error as Error).message,
+      id,
+      component: "fetchAdminReportServer",
+    });
+    return null;
+  }
+}
+
+/**
+ * Report detail page の feedback 一覧 (1 ページ目) を SSR で取得。
+ * Report 本体とは別 query に分けてあるのは Armor の cost 制限を避けるため
+ * (`graphql/account/report/server.ts` のコメント参照)。
+ */
+export async function fetchAdminReportFeedbacksServer(
+  reportId: string,
+): Promise<
+  | NonNullable<
+      NonNullable<GqlGetAdminReportFeedbacksQuery["report"]>["feedbacks"]
+    >
+  | null
+> {
+  const hasSession = await hasServerSession();
+  if (!hasSession) return null;
+
+  try {
+    const data = await executeServerGraphQLQuery<
+      GqlGetAdminReportFeedbacksQuery,
+      GqlGetAdminReportFeedbacksQueryVariables
+    >(GET_ADMIN_REPORT_FEEDBACKS_SERVER_QUERY, {
+      id: reportId,
+      first: FEEDBACKS_PAGE_SIZE,
+    });
+    return data.report?.feedbacks ?? null;
+  } catch (error) {
+    logger.warn("[sysAdmin] fetchAdminReportFeedbacksServer failed", {
+      message: (error as Error).message,
+      reportId,
+      component: "fetchAdminReportFeedbacksServer",
+    });
+    return null;
+  }
+}

--- a/src/app/sysAdmin/_shared/server/fetchAdminTemplateFeedbackStats.ts
+++ b/src/app/sysAdmin/_shared/server/fetchAdminTemplateFeedbackStats.ts
@@ -1,0 +1,38 @@
+import "server-only";
+
+import { executeServerGraphQLQuery } from "@/lib/graphql/server";
+import { hasServerSession } from "@/lib/auth/server/session";
+import { logger } from "@/lib/logging";
+import { GET_ADMIN_TEMPLATE_FEEDBACK_STATS_SERVER_QUERY } from "@/graphql/account/adminTemplateFeedbacks/server";
+import type {
+  GqlGetAdminTemplateFeedbackStatsQuery,
+  GqlGetAdminTemplateFeedbackStatsQueryVariables,
+} from "@/types/graphql";
+
+/**
+ * テンプレ詳細の summary (avgRating / 件数 / rating 分布) を SSR で取得。
+ *
+ * list 側 (`fetchAdminTemplateFeedbacksServer`) と並行で叩く想定。
+ * 引数 (`variant` / `version` / `kind`) は同じ filter object から流す。
+ */
+export async function fetchAdminTemplateFeedbackStatsServer(
+  variables: GqlGetAdminTemplateFeedbackStatsQueryVariables,
+): Promise<GqlGetAdminTemplateFeedbackStatsQuery["adminTemplateFeedbackStats"] | null> {
+  const hasSession = await hasServerSession();
+  if (!hasSession) return null;
+
+  try {
+    const data = await executeServerGraphQLQuery<
+      GqlGetAdminTemplateFeedbackStatsQuery,
+      GqlGetAdminTemplateFeedbackStatsQueryVariables
+    >(GET_ADMIN_TEMPLATE_FEEDBACK_STATS_SERVER_QUERY, variables);
+    return data.adminTemplateFeedbackStats ?? null;
+  } catch (error) {
+    logger.warn("[sysAdmin] fetchAdminTemplateFeedbackStatsServer failed", {
+      message: (error as Error).message,
+      variables,
+      component: "fetchAdminTemplateFeedbackStatsServer",
+    });
+    return null;
+  }
+}

--- a/src/app/sysAdmin/_shared/server/fetchAdminTemplateFeedbacks.ts
+++ b/src/app/sysAdmin/_shared/server/fetchAdminTemplateFeedbacks.ts
@@ -1,0 +1,43 @@
+import "server-only";
+
+import { executeServerGraphQLQuery } from "@/lib/graphql/server";
+import { hasServerSession } from "@/lib/auth/server/session";
+import { logger } from "@/lib/logging";
+import { GET_ADMIN_TEMPLATE_FEEDBACKS_SERVER_QUERY } from "@/graphql/account/adminTemplateFeedbacks/server";
+import type {
+  GqlGetAdminTemplateFeedbacksQuery,
+  GqlGetAdminTemplateFeedbacksQueryVariables,
+} from "@/types/graphql";
+
+const PAGE_SIZE = 20;
+
+/**
+ * テンプレ詳細の feedback feed の 1 ページ目を SSR で取得。
+ * 「もっと見る」は client-side で Apollo client.query を叩く想定。
+ */
+export async function fetchAdminTemplateFeedbacksServer(
+  variables: GqlGetAdminTemplateFeedbacksQueryVariables,
+): Promise<
+  NonNullable<GqlGetAdminTemplateFeedbacksQuery["adminTemplateFeedbacks"]> | null
+> {
+  const hasSession = await hasServerSession();
+  if (!hasSession) return null;
+
+  try {
+    const data = await executeServerGraphQLQuery<
+      GqlGetAdminTemplateFeedbacksQuery,
+      GqlGetAdminTemplateFeedbacksQueryVariables
+    >(GET_ADMIN_TEMPLATE_FEEDBACKS_SERVER_QUERY, {
+      first: PAGE_SIZE,
+      ...variables,
+    });
+    return data.adminTemplateFeedbacks ?? null;
+  } catch (error) {
+    logger.warn("[sysAdmin] fetchAdminTemplateFeedbacksServer failed", {
+      message: (error as Error).message,
+      variables,
+      component: "fetchAdminTemplateFeedbacksServer",
+    });
+    return null;
+  }
+}

--- a/src/app/sysAdmin/_shared/server/fetchTemplateBreakdown.ts
+++ b/src/app/sysAdmin/_shared/server/fetchTemplateBreakdown.ts
@@ -1,0 +1,60 @@
+import "server-only";
+
+import { executeServerGraphQLQuery } from "@/lib/graphql/server";
+import { hasServerSession } from "@/lib/auth/server/session";
+import { logger } from "@/lib/logging";
+import { GET_REPORT_TEMPLATE_STATS_BREAKDOWN_SERVER_QUERY } from "@/graphql/account/reportTemplate/server";
+import {
+  GqlReportTemplateKind,
+  type GqlGetReportTemplateStatsBreakdownQuery,
+  type GqlReportTemplateStatsBreakdownRowFieldsFragment,
+  type GqlReportVariant,
+} from "@/types/graphql";
+
+const HISTORY_PAGE_SIZE = 50;
+
+/**
+ * variant + kind の breakdown rows を SSR で取得。
+ * client-side fetch だと auth race で IsAdmin failed になるため SSR に統一。
+ */
+export async function fetchTemplateBreakdownServer(
+  variant: GqlReportVariant,
+  kind: GqlReportTemplateKind = GqlReportTemplateKind.Generation,
+): Promise<GqlReportTemplateStatsBreakdownRowFieldsFragment[]> {
+  const hasSession = await hasServerSession();
+  if (!hasSession) return [];
+
+  try {
+    const data = await executeServerGraphQLQuery<
+      GqlGetReportTemplateStatsBreakdownQuery,
+      {
+        variant: GqlReportVariant;
+        kind?: GqlReportTemplateKind | null;
+        includeInactive?: boolean | null;
+        first?: number | null;
+        cursor?: string | null;
+        version?: number | null;
+      }
+    >(GET_REPORT_TEMPLATE_STATS_BREAKDOWN_SERVER_QUERY, {
+      variant,
+      kind,
+      includeInactive: true,
+      first: HISTORY_PAGE_SIZE,
+    });
+    return (
+      data.reportTemplateStatsBreakdown.edges
+        ?.map((e) => e?.node)
+        .filter(
+          (n): n is GqlReportTemplateStatsBreakdownRowFieldsFragment => n != null,
+        ) ?? []
+    );
+  } catch (error) {
+    logger.warn("[sysAdmin] fetchTemplateBreakdownServer failed", {
+      message: (error as Error).message,
+      variant,
+      kind,
+      component: "fetchTemplateBreakdownServer",
+    });
+    return [];
+  }
+}

--- a/src/app/sysAdmin/features/communityDetail/components/CommunityDashboardOverview.tsx
+++ b/src/app/sysAdmin/features/communityDetail/components/CommunityDashboardOverview.tsx
@@ -62,6 +62,13 @@ type Props = {
   /** subpage CTA を出すか (storybook design preview 専用、production では
    * subpage 未実装なので default false)。 */
   enableSubpageLinks?: boolean;
+  /**
+   * レンダリング範囲。
+   * - "full" (default): 全体 (header + funnel + scopes)
+   * - "summary": community ヘッダーと funnel まで (タブ「上」に常時表示用)
+   * - "details": funnel より下の scope 群 (タブ「下」用)
+   */
+  slot?: "full" | "summary" | "details";
 };
 
 const SCOPE_COLOR = {
@@ -84,6 +91,7 @@ export function CommunityDashboardOverview({
   newMemberCount,
   tenureDistribution,
   enableSubpageLinks = false,
+  slot = "full",
 }: Props) {
   // Schema 上は summary / stages / memberList とその nested buckets は全て
   // non-null だが、production の partial response (network エラー後の
@@ -117,6 +125,11 @@ export function CommunityDashboardOverview({
         hasCohortRetention: !!data.cohortRetention,
       });
     }
+    // slot="details" のときは error バナーを描画しない。
+    // CommunityDetailPageClient が summary と details の 2 回 render するため、
+    // そのまま両方で出すとバナーが画面に 2 つ並んでしまう。summary 側が必ず
+    // 先に render されるので、そこに集約する。
+    if (slot === "details") return null;
     return (
       <div className="rounded-2xl border border-amber-200 bg-amber-50/60 p-6 text-sm text-amber-900">
         コミュニティ詳細データの一部が取得できませんでした。時間をおいて再度お試しください。
@@ -326,9 +339,12 @@ export function CommunityDashboardOverview({
     },
   ];
 
+  const showSummary = slot === "full" || slot === "summary";
+  const showDetails = slot === "full" || slot === "details";
+
   return (
     <div className="flex flex-col gap-3">
-      {communityName && (
+      {showSummary && communityName && (
         // px-1: ネットワーク等 scope 見出し (px-1) と左揃え。
         <header className="flex flex-col gap-1 px-1">
           <div className="flex items-baseline gap-3">
@@ -359,18 +375,22 @@ export function CommunityDashboardOverview({
         </header>
       )}
 
-      {/* highlight: アクティベーション・ファネル。L2 単一値カードでは見えに
-          くい「ステージ間の脱落幅」を 1 枚で読ませる。 cohortFunnel での詳細
-          (cohort 別比較) は L3 /activity 行き。 */}
-      <ActivationFunnelCard
-        denominator={funnelDenominator}
-        stages={funnelStages}
-        memberSampleComplete={memberSampleComplete}
-        detailHref={
-          enableSubpageLinks ? `/sysAdmin/${data.communityId}/activity#funnel` : undefined
-        }
-      />
+      {showSummary && (
+        // highlight: アクティベーション・ファネル。L2 単一値カードでは見え
+        // にくい「ステージ間の脱落幅」を 1 枚で読ませる。 cohortFunnel での
+        // 詳細 (cohort 別比較) は L3 /activity 行き。
+        <ActivationFunnelCard
+          denominator={funnelDenominator}
+          stages={funnelStages}
+          memberSampleComplete={memberSampleComplete}
+          detailHref={
+            enableSubpageLinks ? `/sysAdmin/${data.communityId}/activity#funnel` : undefined
+          }
+        />
+      )}
 
+      {showDetails && (
+      <>
       {/* state group: 関係 (Network) + 個人 (Member) を上に。
           いずれも累計 / 現在の構造を表す snapshot 系メトリクス。 */}
       <div className="flex flex-col gap-6">
@@ -711,6 +731,8 @@ export function CommunityDashboardOverview({
           </Issue>
         )}
       </Scope>
+      </>
+      )}
     </div>
   );
 }

--- a/src/app/sysAdmin/features/communityDetail/components/CommunityReportsTab.stories.tsx
+++ b/src/app/sysAdmin/features/communityDetail/components/CommunityReportsTab.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import {
+  GqlReportStatus,
+  GqlReportVariant,
+} from "@/types/graphql";
+import { CommunityReportsTab, type ReportRow } from "./CommunityReportsTab";
+
+const meta: Meta<typeof CommunityReportsTab> = {
+  title: "SysAdmin/CommunityDetail/CommunityReportsTab",
+  component: CommunityReportsTab,
+  parameters: { layout: "fullscreen" },
+  args: { communityId: "c_kibotcha" },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-xl p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof CommunityReportsTab>;
+
+const sampleReports: ReportRow[] = [
+  {
+    id: "r1",
+    variant: GqlReportVariant.MemberNewsletter,
+    status: GqlReportStatus.Published,
+    publishedAt: new Date("2026-04-25"),
+  },
+  {
+    id: "r2",
+    variant: GqlReportVariant.WeeklySummary,
+    status: GqlReportStatus.Published,
+    publishedAt: new Date("2026-04-18"),
+  },
+  {
+    id: "r3",
+    variant: GqlReportVariant.MediaPr,
+    status: GqlReportStatus.Approved,
+    publishedAt: null,
+  },
+];
+
+export const WithReports: Story = {
+  args: {
+    reports: sampleReports,
+    totalCount: 3,
+    hasNextPage: false,
+    loading: false,
+    error: null,
+    loadingMore: false,
+    onLoadMore: () => undefined,
+  },
+};
+
+export const HasMorePages: Story = {
+  args: {
+    reports: sampleReports,
+    totalCount: 47,
+    hasNextPage: true,
+    loading: false,
+    error: null,
+    loadingMore: false,
+    onLoadMore: () => undefined,
+  },
+};
+
+export const LoadingMore: Story = {
+  args: {
+    reports: sampleReports,
+    totalCount: 47,
+    hasNextPage: true,
+    loading: false,
+    error: null,
+    loadingMore: true,
+    onLoadMore: () => undefined,
+  },
+};
+
+export const PaginationError: Story = {
+  args: {
+    reports: sampleReports,
+    totalCount: 47,
+    hasNextPage: true,
+    loading: false,
+    error: new Error("network error"),
+    loadingMore: false,
+    onLoadMore: () => undefined,
+  },
+};
+
+export const InitialLoading: Story = {
+  args: {
+    reports: [],
+    totalCount: 0,
+    hasNextPage: false,
+    loading: true,
+    error: null,
+    loadingMore: false,
+    onLoadMore: () => undefined,
+  },
+};
+
+export const InitialError: Story = {
+  args: {
+    reports: [],
+    totalCount: 0,
+    hasNextPage: false,
+    loading: false,
+    error: new Error("backend unreachable"),
+    loadingMore: false,
+    onLoadMore: () => undefined,
+  },
+};
+
+export const EmptyState: Story = {
+  args: {
+    reports: [],
+    totalCount: 0,
+    hasNextPage: false,
+    loading: false,
+    error: null,
+    loadingMore: false,
+    onLoadMore: () => undefined,
+  },
+};

--- a/src/app/sysAdmin/features/communityDetail/components/CommunityReportsTab.tsx
+++ b/src/app/sysAdmin/features/communityDetail/components/CommunityReportsTab.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import LoadingIndicator from "@/components/shared/LoadingIndicator";
+import { ErrorState } from "@/components/shared/ErrorState";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  GqlReportStatus,
+  type GqlReportVariant,
+} from "@/types/graphql";
+import { variantLabel, statusLabel } from "@/app/sysAdmin/features/system/templates/shared/labels";
+
+export type ReportRow = {
+  id: string;
+  variant: GqlReportVariant;
+  status: GqlReportStatus;
+  publishedAt?: Date | null;
+};
+
+export type CommunityReportsTabProps = {
+  /** 行クリックで Report detail page (`/sysAdmin/{communityId}/reports/{id}`) に遷移するため */
+  communityId: string;
+  reports: ReportRow[];
+  totalCount: number;
+  hasNextPage: boolean;
+  loading: boolean;
+  error: unknown;
+  loadingMore: boolean;
+  onLoadMore: () => void;
+};
+
+/**
+ * L2 詳細の [レポート] タブ (presentational only)。
+ * data fetching は `CommunityReportsTabContainer` 側で行う。
+ */
+export function CommunityReportsTab({
+  communityId,
+  reports,
+  totalCount,
+  hasNextPage,
+  loading,
+  error,
+  loadingMore,
+  onLoadMore,
+}: CommunityReportsTabProps) {
+  const router = useRouter();
+  const goToDetail = (id: string) => {
+    router.push(`/sysAdmin/${communityId}/reports/${id}`);
+  };
+  if (loading && reports.length === 0) {
+    return <LoadingIndicator fullScreen={false} />;
+  }
+
+  // 初回ロード失敗のみ全画面 ErrorState。
+  // pagination 失敗 (= 既にデータがある) は table を残して下部にインライン表示する
+  // (load-more ボタンも残るのでリトライ可能)。
+  if (error && reports.length === 0) {
+    return <ErrorState title="レポート履歴の取得に失敗しました" />;
+  }
+
+  if (reports.length === 0) {
+    return (
+      <div className="py-8 text-center text-body-sm text-muted-foreground">
+        この community のレポートはまだ発行されていません
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 py-4">
+      <div className="flex items-baseline justify-between text-body-sm text-muted-foreground">
+        <span>レポート発行履歴</span>
+        <span className="tabular-nums">
+          {reports.length} / {Math.max(totalCount, reports.length)} 件
+        </span>
+      </div>
+      <div className="overflow-hidden rounded border border-border">
+        <Table className="text-body-sm">
+          <TableHeader className="bg-muted/50">
+            <TableRow>
+              <TableHead className="h-9 px-2 py-1.5">公開日</TableHead>
+              <TableHead className="h-9 px-2 py-1.5">種類</TableHead>
+              <TableHead className="h-9 px-2 py-1.5">ステータス</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {reports.map((r) => (
+              <TableRow
+                key={r.id}
+                tabIndex={0}
+                role="link"
+                onClick={() => goToDetail(r.id)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    goToDetail(r.id);
+                  }
+                }}
+                className="cursor-pointer focus-visible:bg-muted/50 focus-visible:outline-none"
+              >
+                <TableCell className="px-2 py-1.5 tabular-nums">
+                  {r.publishedAt
+                    ? new Date(r.publishedAt).toLocaleDateString("ja-JP")
+                    : "—"}
+                </TableCell>
+                <TableCell className="px-2 py-1.5">
+                  {variantLabel(r.variant)}
+                </TableCell>
+                <TableCell className="px-2 py-1.5 text-muted-foreground">
+                  {statusLabel(r.status)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      {error != null && (
+        <p className="text-center text-body-sm text-destructive">
+          追加読み込みに失敗しました
+        </p>
+      )}
+      {hasNextPage && (
+        <div className="flex justify-center">
+          <Button
+            variant="tertiary"
+            size="sm"
+            onClick={onLoadMore}
+            disabled={loadingMore}
+          >
+            {loadingMore ? "読み込み中..." : "もっと見る"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/sysAdmin/features/communityDetail/components/CommunityReportsTabContainer.tsx
+++ b/src/app/sysAdmin/features/communityDetail/components/CommunityReportsTabContainer.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback } from "react";
 import { useApolloClient } from "@apollo/client";
 import { GET_ADMIN_BROWSE_REPORTS } from "@/graphql/account/adminReports/query";
 import type {
   GqlGetAdminBrowseReportsQuery,
   GqlGetAdminBrowseReportsQueryVariables,
 } from "@/types/graphql";
+import { useCursorPagination } from "@/app/sysAdmin/_shared/hooks/useCursorPagination";
 import {
   CommunityReportsTab,
   type ReportRow,
@@ -14,101 +15,88 @@ import {
 
 const PAGE_SIZE = 20;
 
+type ReportsConnection = NonNullable<
+  GqlGetAdminBrowseReportsQuery["adminBrowseReports"]
+>;
+
 type Props = {
   communityId: string;
-  initialReports: GqlGetAdminBrowseReportsQuery["adminBrowseReports"] | null;
+  initialReports: ReportsConnection | null;
+};
+
+const EMPTY_CONNECTION: ReportsConnection = {
+  __typename: "ReportsConnection",
+  edges: [],
+  pageInfo: {
+    __typename: "PageInfo",
+    hasNextPage: false,
+    endCursor: null,
+  },
+  totalCount: 0,
 };
 
 /**
  * `CommunityReportsTab` (View) のための data wiring。
  *
  * 初期 1 ページは SSR (`fetchAdminBrowseReportsServer`) で取得して props で
- * 受け取る。「もっと見る」での追加ページは Apollo client.query で fetch して
- * local state に append する。
+ * 受け取る。以降は generic な `useCursorPagination` フックに任せ、totalCount /
+ * error / loading / loadMore を一括管理する (= テンプレ詳細の Container と
+ * 同じパターン)。
  *
- * Apollo の `useQuery` 経路を使わない理由: SSR と整合させたいので Apollo
- * cache を経由せず、SSR data を一次ソースとして扱う。
+ * `useCursorPagination` を使う方針: SSR と整合させたいので Apollo cache を
+ * 経由せず、SSR data を `initial` として hook に渡す。fetchMore は client.query
+ * で都度叩く。
+ *
+ * `resetKey={communityId}` でコミュニティ切替 (= 同コンポーネントが別 community
+ * 用に再利用される) 時に内部 state を再同期する。
  */
 export function CommunityReportsTabContainer({
   communityId,
   initialReports,
 }: Props) {
   const apollo = useApolloClient();
-  const [reports, setReports] = useState<ReportRow[]>(
-    () => extractReports(initialReports),
-  );
-  const [endCursor, setEndCursor] = useState<string | null>(
-    initialReports?.pageInfo.endCursor ?? null,
-  );
-  const [hasNextPage, setHasNextPage] = useState<boolean>(
-    initialReports?.pageInfo.hasNextPage ?? false,
-  );
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [loadError, setLoadError] = useState<unknown>(null);
-  // totalCount は initial で SSR 値を入れ、各 fetchMore レスポンスでも更新する。
-  // backend が「全体件数」を返す前提で、追加ロード中に totalCount が増減しても
-  // 表示と一致させるため (= "48 / 47 件" のような stale 表示を防ぐ)。
-  const [totalCount, setTotalCount] = useState<number>(
-    initialReports?.totalCount ?? 0,
-  );
 
-  // setLoadingMore / setEndCursor / setHasNextPage は state なので非同期で反映
-  // される。rapid に「もっと見る」を連打した時に同じ cursor で重複 fetch しない
-  // よう、同期的な ref で guard する (useCursorPagination と同じパターン)。
-  // Relay 実装によっては最終ページでも `endCursor` が non-null で返ることが
-  // あるので、`hasNextPageRef` を必ず併用する。
-  const loadingRef = useRef(false);
-  const endCursorRef = useRef<string | null>(
-    initialReports?.pageInfo.endCursor ?? null,
-  );
-  const hasNextPageRef = useRef<boolean>(
-    initialReports?.pageInfo.hasNextPage ?? false,
-  );
-
-  const handleLoadMore = useCallback(async () => {
-    if (
-      loadingRef.current ||
-      !hasNextPageRef.current ||
-      !endCursorRef.current
-    ) {
-      return;
-    }
-    const cursor = endCursorRef.current;
-    loadingRef.current = true;
-    setLoadingMore(true);
-    setLoadError(null);
-    try {
+  const fetchMoreReports = useCallback(
+    async (cursor: string, first: number) => {
       const result = await apollo.query<
         GqlGetAdminBrowseReportsQuery,
         GqlGetAdminBrowseReportsQueryVariables
       >({
         query: GET_ADMIN_BROWSE_REPORTS,
-        variables: { communityId, cursor, first: PAGE_SIZE },
+        variables: { communityId, cursor, first },
         fetchPolicy: "network-only",
       });
-      const next = result.data.adminBrowseReports;
-      const nextEndCursor = next.pageInfo.endCursor ?? null;
-      const nextHasNextPage = next.pageInfo.hasNextPage;
-      endCursorRef.current = nextEndCursor;
-      hasNextPageRef.current = nextHasNextPage;
-      setReports((prev) => [...prev, ...extractReports(next)]);
-      setEndCursor(nextEndCursor);
-      setHasNextPage(nextHasNextPage);
-      setTotalCount(next.totalCount);
-    } catch (err) {
-      // catch しないと button onClick で発火する promise が unhandled rejection に
-      // なる。View 側は error prop を表示できるので state にセットして渡す。
-      setLoadError(err);
-    } finally {
-      loadingRef.current = false;
-      setLoadingMore(false);
-    }
-  }, [apollo, communityId]);
+      return result.data.adminBrowseReports ?? EMPTY_CONNECTION;
+    },
+    [apollo, communityId],
+  );
+
+  const {
+    items: reports,
+    totalCount,
+    hasNextPage,
+    loading: loadingMore,
+    error: loadError,
+    loadMore,
+  } = useCursorPagination({
+    initial: initialReports ?? EMPTY_CONNECTION,
+    fetchMore: fetchMoreReports,
+    pageSize: PAGE_SIZE,
+    resetKey: communityId,
+  });
+
+  const handleLoadMore = useCallback(() => {
+    void loadMore();
+  }, [loadMore]);
+
+  // backend fragment (`AdminBrowseReportFields`) は ReportRow の super set
+  // (id/variant/status/publishedAt + community{id,name}) なので構造的に互換。
+  const reportRows: ReportRow[] = reports;
 
   return (
     <CommunityReportsTab
       communityId={communityId}
-      reports={reports}
+      reports={reportRows}
       totalCount={totalCount}
       hasNextPage={hasNextPage}
       loading={false}
@@ -116,16 +104,5 @@ export function CommunityReportsTabContainer({
       loadingMore={loadingMore}
       onLoadMore={handleLoadMore}
     />
-  );
-}
-
-function extractReports(
-  conn: GqlGetAdminBrowseReportsQuery["adminBrowseReports"] | null | undefined,
-): ReportRow[] {
-  if (!conn) return [];
-  return (
-    conn.edges
-      ?.map((e) => e?.node)
-      .filter(<T,>(n: T | null | undefined): n is T => n != null) ?? []
   );
 }

--- a/src/app/sysAdmin/features/communityDetail/components/CommunityReportsTabContainer.tsx
+++ b/src/app/sysAdmin/features/communityDetail/components/CommunityReportsTabContainer.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { useApolloClient } from "@apollo/client";
+import { GET_ADMIN_BROWSE_REPORTS } from "@/graphql/account/adminReports/query";
+import type {
+  GqlGetAdminBrowseReportsQuery,
+  GqlGetAdminBrowseReportsQueryVariables,
+} from "@/types/graphql";
+import {
+  CommunityReportsTab,
+  type ReportRow,
+} from "./CommunityReportsTab";
+
+const PAGE_SIZE = 20;
+
+type Props = {
+  communityId: string;
+  initialReports: GqlGetAdminBrowseReportsQuery["adminBrowseReports"] | null;
+};
+
+/**
+ * `CommunityReportsTab` (View) のための data wiring。
+ *
+ * 初期 1 ページは SSR (`fetchAdminBrowseReportsServer`) で取得して props で
+ * 受け取る。「もっと見る」での追加ページは Apollo client.query で fetch して
+ * local state に append する。
+ *
+ * Apollo の `useQuery` 経路を使わない理由: SSR と整合させたいので Apollo
+ * cache を経由せず、SSR data を一次ソースとして扱う。
+ */
+export function CommunityReportsTabContainer({
+  communityId,
+  initialReports,
+}: Props) {
+  const apollo = useApolloClient();
+  const [reports, setReports] = useState<ReportRow[]>(
+    () => extractReports(initialReports),
+  );
+  const [endCursor, setEndCursor] = useState<string | null>(
+    initialReports?.pageInfo.endCursor ?? null,
+  );
+  const [hasNextPage, setHasNextPage] = useState<boolean>(
+    initialReports?.pageInfo.hasNextPage ?? false,
+  );
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadError, setLoadError] = useState<unknown>(null);
+  // totalCount は initial で SSR 値を入れ、各 fetchMore レスポンスでも更新する。
+  // backend が「全体件数」を返す前提で、追加ロード中に totalCount が増減しても
+  // 表示と一致させるため (= "48 / 47 件" のような stale 表示を防ぐ)。
+  const [totalCount, setTotalCount] = useState<number>(
+    initialReports?.totalCount ?? 0,
+  );
+
+  // setLoadingMore / setEndCursor / setHasNextPage は state なので非同期で反映
+  // される。rapid に「もっと見る」を連打した時に同じ cursor で重複 fetch しない
+  // よう、同期的な ref で guard する (useCursorPagination と同じパターン)。
+  // Relay 実装によっては最終ページでも `endCursor` が non-null で返ることが
+  // あるので、`hasNextPageRef` を必ず併用する。
+  const loadingRef = useRef(false);
+  const endCursorRef = useRef<string | null>(
+    initialReports?.pageInfo.endCursor ?? null,
+  );
+  const hasNextPageRef = useRef<boolean>(
+    initialReports?.pageInfo.hasNextPage ?? false,
+  );
+
+  const handleLoadMore = useCallback(async () => {
+    if (
+      loadingRef.current ||
+      !hasNextPageRef.current ||
+      !endCursorRef.current
+    ) {
+      return;
+    }
+    const cursor = endCursorRef.current;
+    loadingRef.current = true;
+    setLoadingMore(true);
+    setLoadError(null);
+    try {
+      const result = await apollo.query<
+        GqlGetAdminBrowseReportsQuery,
+        GqlGetAdminBrowseReportsQueryVariables
+      >({
+        query: GET_ADMIN_BROWSE_REPORTS,
+        variables: { communityId, cursor, first: PAGE_SIZE },
+        fetchPolicy: "network-only",
+      });
+      const next = result.data.adminBrowseReports;
+      const nextEndCursor = next.pageInfo.endCursor ?? null;
+      const nextHasNextPage = next.pageInfo.hasNextPage;
+      endCursorRef.current = nextEndCursor;
+      hasNextPageRef.current = nextHasNextPage;
+      setReports((prev) => [...prev, ...extractReports(next)]);
+      setEndCursor(nextEndCursor);
+      setHasNextPage(nextHasNextPage);
+      setTotalCount(next.totalCount);
+    } catch (err) {
+      // catch しないと button onClick で発火する promise が unhandled rejection に
+      // なる。View 側は error prop を表示できるので state にセットして渡す。
+      setLoadError(err);
+    } finally {
+      loadingRef.current = false;
+      setLoadingMore(false);
+    }
+  }, [apollo, communityId]);
+
+  return (
+    <CommunityReportsTab
+      communityId={communityId}
+      reports={reports}
+      totalCount={totalCount}
+      hasNextPage={hasNextPage}
+      loading={false}
+      error={loadError}
+      loadingMore={loadingMore}
+      onLoadMore={handleLoadMore}
+    />
+  );
+}
+
+function extractReports(
+  conn: GqlGetAdminBrowseReportsQuery["adminBrowseReports"] | null | undefined,
+): ReportRow[] {
+  if (!conn) return [];
+  return (
+    conn.edges
+      ?.map((e) => e?.node)
+      .filter(<T,>(n: T | null | undefined): n is T => n != null) ?? []
+  );
+}

--- a/src/app/sysAdmin/features/reportDetail/components/ReportContentSection.tsx
+++ b/src/app/sysAdmin/features/reportDetail/components/ReportContentSection.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+type Props = {
+  /**
+   * SSR で `convertMarkdownToHtml` 済みの sanitize 済み HTML 文字列。
+   * 何も無い (生成中 / skipped) 場合は null を渡し、placeholder を表示する。
+   */
+  bodyHtml: string | null;
+  skipReason?: string | null;
+};
+
+/**
+ * Report 本文の表示。markdown は SSR で sanitize 済み HTML に変換して
+ * 渡される前提のため、ここでは dangerouslySetInnerHTML で挿入するだけ。
+ */
+export function ReportContentSection({ bodyHtml, skipReason }: Props) {
+  if (skipReason) {
+    return (
+      <section className="rounded border border-dashed border-border p-4 text-body-sm text-muted-foreground">
+        <p className="font-semibold">スキップ</p>
+        <p className="mt-1">{skipReason}</p>
+      </section>
+    );
+  }
+
+  if (!bodyHtml) {
+    return (
+      <p className="py-6 text-center text-body-sm text-muted-foreground">
+        本文がまだ生成されていません
+      </p>
+    );
+  }
+
+  return (
+    <article
+      className="prose prose-sm max-w-none"
+      dangerouslySetInnerHTML={{ __html: bodyHtml }}
+    />
+  );
+}

--- a/src/app/sysAdmin/features/reportDetail/components/ReportDetailContainer.tsx
+++ b/src/app/sysAdmin/features/reportDetail/components/ReportDetailContainer.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import {
+  useSubmitReportFeedbackMutation,
+  type GqlGetAdminReportQuery,
+  type GqlReportFeedbackFieldsFragment,
+} from "@/types/graphql";
+import { ReportDetailView } from "./ReportDetailView";
+import type { FeedbackFormInput } from "./ReportFeedbackForm";
+
+type Report = NonNullable<GqlGetAdminReportQuery["report"]>;
+
+type Props = {
+  report: Report;
+  bodyHtml: string | null;
+  feedbacks: GqlReportFeedbackFieldsFragment[];
+  feedbacksTotalCount: number;
+};
+
+/**
+ * `ReportDetailView` (presentational) と submitReportFeedback mutation を
+ * 結ぶ container。
+ *
+ * 投稿成功後は `router.refresh()` で SSR を再走させ、`myFeedback` と
+ * `feedbacks` connection を最新化する。Apollo cache を直接書き換える形に
+ * すると、SSR で hydrate された initial state との整合を取るのが面倒
+ * (Connection の cursor / totalCount との辻褄合わせ) なので、SSR 再走で
+ * 揃えるのが運用上シンプル。
+ */
+export function ReportDetailContainer({
+  report,
+  bodyHtml,
+  feedbacks,
+  feedbacksTotalCount,
+}: Props) {
+  const router = useRouter();
+  const [submit, { loading: saving, error: saveError }] =
+    useSubmitReportFeedbackMutation();
+
+  const handleSubmit = useCallback(
+    async (input: FeedbackFormInput) => {
+      try {
+        await submit({
+          variables: {
+            input: {
+              reportId: report.id,
+              rating: input.rating,
+              feedbackType: input.feedbackType ?? undefined,
+              comment: input.comment ?? undefined,
+            },
+            permission: { communityId: report.community.id },
+          },
+        });
+        router.refresh();
+      } catch {
+        // saveError state でハンドル済み
+      }
+    },
+    [submit, report.id, report.community.id, router],
+  );
+
+  const handleSubmitSync = useCallback(
+    (input: FeedbackFormInput) => {
+      // form の onSubmit が同期 () => void なので、async 結果は捨てる
+      void handleSubmit(input);
+    },
+    [handleSubmit],
+  );
+
+  return (
+    <ReportDetailView
+      report={report}
+      bodyHtml={bodyHtml}
+      feedbacks={feedbacks}
+      feedbacksTotalCount={feedbacksTotalCount}
+      saving={saving}
+      saveError={saveError ?? null}
+      onSubmitFeedback={handleSubmitSync}
+    />
+  );
+}

--- a/src/app/sysAdmin/features/reportDetail/components/ReportDetailHeader.tsx
+++ b/src/app/sysAdmin/features/reportDetail/components/ReportDetailHeader.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+import {
+  type GqlReportStatus,
+  type GqlReportVariant,
+} from "@/types/graphql";
+import {
+  statusLabel,
+  variantLabel,
+} from "@/app/sysAdmin/features/system/templates/shared/labels";
+import { variantToSlug } from "@/app/sysAdmin/features/system/templates/shared/variantSlug";
+import { MetadataChips } from "@/app/sysAdmin/_shared/components/MetadataChips";
+
+type Props = {
+  variant: GqlReportVariant;
+  status: GqlReportStatus;
+  periodFrom: Date;
+  periodTo: Date;
+  templateVersion?: number | null;
+};
+
+/**
+ * Report detail page の header。
+ * 期間 / variant / status を chip 並びで出し、その下にこのレポートを生成した
+ * テンプレ詳細へのリンクを置く (templateVersion が分かれば付ける)。
+ */
+export function ReportDetailHeader({
+  variant,
+  status,
+  periodFrom,
+  periodTo,
+  templateVersion,
+}: Props) {
+  const slug = variantToSlug(variant);
+  const templateHref = slug
+    ? `/sysAdmin/system/templates/${slug}`
+    : null;
+
+  return (
+    <header className="space-y-2">
+      <MetadataChips
+        items={[
+          `${formatDate(periodFrom)} 〜 ${formatDate(periodTo)}`,
+          variantLabel(variant),
+          statusLabel(status),
+        ]}
+      />
+      {templateHref && (
+        <Link
+          href={templateHref}
+          className="inline-flex items-center gap-1 text-body-xs text-muted-foreground hover:text-foreground"
+        >
+          <span>
+            このレポートのテンプレートを開く
+            {templateVersion != null ? ` (v${templateVersion})` : ""}
+          </span>
+          <ExternalLink className="h-3 w-3" aria-hidden />
+        </Link>
+      )}
+    </header>
+  );
+}
+
+function formatDate(d: Date): string {
+  return new Date(d).toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}

--- a/src/app/sysAdmin/features/reportDetail/components/ReportDetailView.stories.tsx
+++ b/src/app/sysAdmin/features/reportDetail/components/ReportDetailView.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import {
+  mockReport,
+  mockReportFeedback,
+  mockReportFeedbacks,
+} from "../fixtures";
+import { ReportDetailView } from "./ReportDetailView";
+
+const meta: Meta<typeof ReportDetailView> = {
+  title: "SysAdmin/ReportDetail/ReportDetailView",
+  component: ReportDetailView,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-xl p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ReportDetailView>;
+
+const baseBodyHtml = `
+<h1>4 月第 4 週のニュースレター</h1>
+<p>今週は <strong>3 件のイベント</strong> が開催され、合計 <strong>42 名</strong> のメンバーが参加しました。</p>
+<h2>ハイライト</h2>
+<ul>
+  <li>火曜の朝活でメンバー同士のつながりが生まれた</li>
+  <li>木曜のワークショップは満席</li>
+  <li>週末のフィールドワークで新規参加者 5 名</li>
+</ul>
+`;
+
+const feedbacks = mockReportFeedbacks(3);
+
+export const WithFeedbacks: Story = {
+  args: {
+    report: mockReport(),
+    bodyHtml: baseBodyHtml,
+    feedbacks,
+    feedbacksTotalCount: feedbacks.length,
+    saving: false,
+    saveError: null,
+    onSubmitFeedback: () => undefined,
+  },
+};
+
+export const WithMyFeedback: Story = {
+  args: {
+    report: mockReport({ myFeedback: mockReportFeedback(0) }),
+    bodyHtml: baseBodyHtml,
+    feedbacks,
+    feedbacksTotalCount: feedbacks.length,
+    saving: false,
+    saveError: null,
+    onSubmitFeedback: () => undefined,
+  },
+};
+
+export const NoFeedbacks: Story = {
+  args: {
+    report: mockReport({ myFeedback: null }),
+    bodyHtml: baseBodyHtml,
+    feedbacks: [],
+    feedbacksTotalCount: 0,
+    saving: false,
+    saveError: null,
+    onSubmitFeedback: () => undefined,
+  },
+};
+
+export const Skipped: Story = {
+  args: {
+    report: mockReport({
+      outputMarkdown: null,
+      finalContent: null,
+      skipReason: "対象期間中の活動が少なくスキップしました",
+    }),
+    bodyHtml: null,
+    feedbacks: [],
+    feedbacksTotalCount: 0,
+    saving: false,
+    saveError: null,
+    onSubmitFeedback: () => undefined,
+  },
+};
+
+export const Submitting: Story = {
+  args: {
+    report: mockReport(),
+    bodyHtml: baseBodyHtml,
+    feedbacks,
+    feedbacksTotalCount: feedbacks.length,
+    saving: true,
+    saveError: null,
+    onSubmitFeedback: () => undefined,
+  },
+};
+
+export const SubmitError: Story = {
+  args: {
+    report: mockReport(),
+    bodyHtml: baseBodyHtml,
+    feedbacks,
+    feedbacksTotalCount: feedbacks.length,
+    saving: false,
+    saveError: { message: "送信に失敗しました。もう一度お試しください。" },
+    onSubmitFeedback: () => undefined,
+  },
+};

--- a/src/app/sysAdmin/features/reportDetail/components/ReportDetailView.tsx
+++ b/src/app/sysAdmin/features/reportDetail/components/ReportDetailView.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type {
+  GqlGetAdminReportQuery,
+  GqlReportFeedbackFieldsFragment,
+} from "@/types/graphql";
+import { FeedbackList } from "@/app/sysAdmin/_shared/feedback/FeedbackList";
+import { ReportDetailHeader } from "./ReportDetailHeader";
+import { ReportContentSection } from "./ReportContentSection";
+import {
+  ReportFeedbackForm,
+  type FeedbackFormInput,
+} from "./ReportFeedbackForm";
+
+type Report = NonNullable<GqlGetAdminReportQuery["report"]>;
+
+export type ReportDetailViewProps = {
+  report: Report;
+  bodyHtml: string | null;
+  feedbacks: GqlReportFeedbackFieldsFragment[];
+  feedbacksTotalCount: number;
+  saving: boolean;
+  saveError: { message: string } | null;
+  onSubmitFeedback: (input: FeedbackFormInput) => void;
+};
+
+/**
+ * Report detail page の presentational layout。
+ *
+ * Header (期間・variant・status・テンプレリンク) → 本文 →
+ * 既存フィードバック一覧 → 投稿フォーム の縦並び。
+ *
+ * `feedbacks` は SSR で別 query (Armor の cost 制限回避) で取得し、
+ * ここでは生の配列として受け取る。pagination は今のところ未対応
+ * (1 Report あたり数件想定なので必要になってから追加)。
+ */
+export function ReportDetailView({
+  report,
+  bodyHtml,
+  feedbacks,
+  feedbacksTotalCount,
+  saving,
+  saveError,
+  onSubmitFeedback,
+}: ReportDetailViewProps) {
+  return (
+    <div className="space-y-6">
+      <ReportDetailHeader
+        variant={report.variant}
+        status={report.status}
+        periodFrom={report.periodFrom}
+        periodTo={report.periodTo}
+        templateVersion={report.template?.version ?? null}
+      />
+      <ReportContentSection bodyHtml={bodyHtml} skipReason={report.skipReason} />
+      <FeedbackList feedbacks={feedbacks} totalCount={feedbacksTotalCount} />
+      <ReportFeedbackForm
+        existingFeedback={report.myFeedback ?? null}
+        saving={saving}
+        saveError={saveError}
+        onSubmit={onSubmitFeedback}
+      />
+    </div>
+  );
+}

--- a/src/app/sysAdmin/features/reportDetail/components/ReportFeedbackForm.tsx
+++ b/src/app/sysAdmin/features/reportDetail/components/ReportFeedbackForm.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Star } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { cn } from "@/lib/utils";
+import {
+  GqlReportFeedbackType,
+  type GqlReportFeedbackFieldsFragment,
+} from "@/types/graphql";
+import {
+  feedbackTypeLabel,
+  FEEDBACK_TYPE_LABELS,
+} from "@/app/sysAdmin/features/system/templates/shared/labels";
+
+export type FeedbackFormInput = {
+  rating: number;
+  feedbackType: GqlReportFeedbackType | null;
+  comment: string | null;
+};
+
+const FEEDBACK_TYPES = Object.keys(FEEDBACK_TYPE_LABELS) as GqlReportFeedbackType[];
+
+const formSchema = z.object({
+  rating: z
+    .number({ required_error: "評価を選んでください" })
+    .int()
+    .min(1, "評価を選んでください")
+    .max(5),
+  feedbackType: z.nativeEnum(GqlReportFeedbackType).nullable(),
+  comment: z.string().nullable(),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+type Props = {
+  /** 過去に投稿済みの feedback (= myFeedback)。あれば「投稿済み」として下に表示する。 */
+  existingFeedback?: GqlReportFeedbackFieldsFragment | null;
+  saving: boolean;
+  saveError: { message: string } | null;
+  onSubmit: (input: FeedbackFormInput) => void;
+};
+
+/**
+ * sysAdmin 代行投稿用 feedback フォーム。
+ *
+ * `submitReportFeedback` の input そのまま (rating + comment + feedbackType)
+ * を扱う。送信は container 側で mutation + cache 更新を行うので、本コンポーネント
+ * は入力 UI と onSubmit 通知だけに責務を絞る。
+ *
+ * 入力部品はすべて shadcn / radix primitives:
+ *   - Form (react-hook-form + zod)
+ *   - ToggleGroup type="single" (rating の星選択 / feedbackType の chip 選択)
+ *   - Textarea (comment)
+ */
+export function ReportFeedbackForm({
+  existingFeedback,
+  saving,
+  saveError,
+  onSubmit,
+}: Props) {
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      rating: 0,
+      feedbackType: null,
+      comment: "",
+    },
+  });
+
+  // 投稿成功で saving が false に戻ったタイミングで form をリセットする。
+  // saveError がある場合は入力を残してもう一度送れるようにしておく。
+  useEffect(() => {
+    if (!saving && form.formState.isSubmitSuccessful && !saveError) {
+      form.reset({ rating: 0, feedbackType: null, comment: "" });
+    }
+  }, [saving, saveError, form]);
+
+  const handleValid = (values: FormValues) => {
+    onSubmit({
+      rating: values.rating,
+      feedbackType: values.feedbackType,
+      comment:
+        values.comment != null && values.comment.trim() !== ""
+          ? values.comment.trim()
+          : null,
+    });
+  };
+
+  return (
+    <section className="space-y-3 rounded border border-border p-4">
+      <h3 className="text-body-sm font-semibold">フィードバックを投稿</h3>
+
+      {existingFeedback && (
+        <p className="text-body-xs text-muted-foreground">
+          自分の最新投稿: {existingFeedback.rating} / 5
+          {existingFeedback.comment ? ` · ${existingFeedback.comment}` : ""}
+        </p>
+      )}
+
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(handleValid)}
+          className="space-y-4"
+        >
+          <FormField
+            control={form.control}
+            name="rating"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-body-xs">評価</FormLabel>
+                <FormControl>
+                  <ToggleGroup
+                    type="single"
+                    value={field.value > 0 ? String(field.value) : ""}
+                    onValueChange={(v) => field.onChange(v ? Number(v) : 0)}
+                    className="justify-start"
+                    aria-label="評価"
+                  >
+                    {[1, 2, 3, 4, 5].map((n) => (
+                      <ToggleGroupItem
+                        key={n}
+                        value={String(n)}
+                        aria-label={`${n} / 5`}
+                        className="h-9 w-9 px-0"
+                      >
+                        <Star
+                          className={cn(
+                            "h-5 w-5",
+                            n <= field.value
+                              ? "fill-amber-400 text-amber-400"
+                              : "text-muted-foreground",
+                          )}
+                        />
+                      </ToggleGroupItem>
+                    ))}
+                  </ToggleGroup>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="feedbackType"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-body-xs">種類 (任意)</FormLabel>
+                <FormControl>
+                  <ToggleGroup
+                    type="single"
+                    value={field.value ?? ""}
+                    onValueChange={(v) =>
+                      field.onChange(v ? (v as GqlReportFeedbackType) : null)
+                    }
+                    className="flex-wrap justify-start"
+                    aria-label="種類"
+                  >
+                    {FEEDBACK_TYPES.map((t) => (
+                      <ToggleGroupItem
+                        key={t}
+                        value={t}
+                        className="h-7 px-2 text-body-xs"
+                      >
+                        {feedbackTypeLabel(t)}
+                      </ToggleGroupItem>
+                    ))}
+                  </ToggleGroup>
+                </FormControl>
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="comment"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-body-xs">
+                  コメント (任意)
+                </FormLabel>
+                <FormControl>
+                  <Textarea
+                    {...field}
+                    value={field.value ?? ""}
+                    rows={4}
+                    className="text-body-sm"
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+
+          {saveError && (
+            <p className="text-body-xs text-destructive">{saveError.message}</p>
+          )}
+
+          <div className="flex justify-end">
+            <Button type="submit" size="sm" disabled={saving}>
+              {saving ? "送信中..." : "送信"}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </section>
+  );
+}

--- a/src/app/sysAdmin/features/reportDetail/fixtures.ts
+++ b/src/app/sysAdmin/features/reportDetail/fixtures.ts
@@ -1,0 +1,100 @@
+import {
+  GqlReportFeedbackType,
+  GqlReportStatus,
+  GqlReportTemplateKind,
+  GqlReportVariant,
+  type GqlGetAdminReportQuery,
+  type GqlReportFeedbackFieldsFragment,
+} from "@/types/graphql";
+
+export type MockReport = NonNullable<GqlGetAdminReportQuery["report"]>;
+
+const mockUser = (id: string, name: string) => ({
+  __typename: "User" as const,
+  id,
+  name,
+});
+
+export function mockReportFeedback(
+  i: number,
+): GqlReportFeedbackFieldsFragment {
+  const rating = ((i * 7) % 4) + 2;
+  return {
+    __typename: "ReportFeedback",
+    id: `fb_${i + 1}`,
+    rating,
+    comment:
+      i % 3 === 0
+        ? "全体的に読みやすかった。次回も同じトーンで。"
+        : i % 3 === 1
+          ? "数字が違う。確認してほしい。"
+          : null,
+    feedbackType:
+      i % 2 === 0
+        ? GqlReportFeedbackType.Tone
+        : GqlReportFeedbackType.Accuracy,
+    sectionKey: i % 2 === 0 ? "intro" : null,
+    createdAt: new Date(`2026-04-${20 + (i % 5)}T12:00:00Z`),
+    user: mockUser(`u_${i + 1}`, ["田中太郎", "佐藤花子", "鈴木次郎"][i % 3]),
+  };
+}
+
+export function mockReportFeedbacks(
+  count: number = 3,
+): GqlReportFeedbackFieldsFragment[] {
+  return Array.from({ length: count }, (_, i) => mockReportFeedback(i));
+}
+
+const sampleMarkdown = `# 4 月第 4 週のニュースレター
+
+今週は **3 件のイベント** が開催され、合計 **42 名** のメンバーが参加しました。
+
+## ハイライト
+
+- 火曜の朝活でメンバー同士のつながりが生まれた
+- 木曜のワークショップは満席
+- 週末のフィールドワークで新規参加者 5 名
+
+## 来週の予定
+
+- 月曜: ふりかえり MTG
+- 水曜: 新企画ブレスト
+`;
+
+export function mockReport(overrides: Partial<MockReport> = {}): MockReport {
+  const periodTo = new Date("2026-04-22T00:00:00Z");
+  const periodFrom = new Date("2026-04-15T00:00:00Z");
+  return {
+    __typename: "Report",
+    id: "r_42",
+    variant: GqlReportVariant.MemberNewsletter,
+    status: GqlReportStatus.Published,
+    publishedAt: new Date("2026-04-23T09:00:00Z"),
+    createdAt: new Date("2026-04-22T12:00:00Z"),
+    updatedAt: new Date("2026-04-23T09:00:00Z"),
+    periodFrom,
+    periodTo,
+    outputMarkdown: sampleMarkdown,
+    finalContent: sampleMarkdown,
+    skipReason: null,
+    regenerateCount: 0,
+    community: {
+      __typename: "Community",
+      id: "c_kibotcha",
+      name: "kibotcha",
+    },
+    template: {
+      __typename: "ReportTemplate",
+      id: "tpl_1",
+      variant: GqlReportVariant.MemberNewsletter,
+      version: 3,
+      kind: GqlReportTemplateKind.Generation,
+      experimentKey: "baseline",
+      trafficWeight: 70,
+    },
+    generatedByUser: mockUser("u_admin", "システム管理者"),
+    publishedByUser: mockUser("u_admin", "システム管理者"),
+    myFeedback: null,
+    ...overrides,
+  };
+}

--- a/src/app/sysAdmin/features/system/templates/editor/components/ExperimentSection.stories.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/ExperimentSection.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { mockBreakdown } from "@/app/sysAdmin/features/system/templates/shared/fixtures";
+import { GqlReportVariant } from "@/types/graphql";
+import { ExperimentSection } from "./ExperimentSection";
+
+const meta: Meta<typeof ExperimentSection> = {
+  title: "SysAdmin/System/Templates/ExperimentSection",
+  component: ExperimentSection,
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-xl p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ExperimentSection>;
+
+export const FullHistory: Story = {
+  args: {
+    rows: mockBreakdown(GqlReportVariant.MemberNewsletter),
+  },
+};
+
+export const CurrentVersionOnly: Story = {
+  args: {
+    rows: mockBreakdown(GqlReportVariant.WeeklySummary).filter((r) => r.version === 3),
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    rows: [],
+  },
+};

--- a/src/app/sysAdmin/features/system/templates/editor/components/ExperimentSection.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/ExperimentSection.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import type { TemplateBreakdownRow } from "@/app/sysAdmin/features/system/templates/shared/fixtures";
+
+type Props = {
+  rows: TemplateBreakdownRow[];
+};
+
+/**
+ * A/B 候補一覧を table 形式で表示。
+ * 同 variant 内で「どの template が並列稼働しているか」「各々の評価指標」が一目でわかる。
+ */
+export function ExperimentSection({ rows }: Props) {
+  if (rows.length === 0) {
+    return (
+      <section className="space-y-2">
+        <h3 className="text-body-sm font-semibold">実験</h3>
+        <p className="text-body-sm text-muted-foreground">
+          対象 template がありません
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-2">
+      <h3 className="text-body-sm font-semibold">実験</h3>
+      <div className="overflow-hidden rounded border border-border">
+        <Table className="text-body-xs tabular-nums">
+          <TableHeader className="bg-muted/50">
+            <TableRow>
+              <TableHead className="h-8 px-2 py-1">ver</TableHead>
+              <TableHead className="h-8 px-2 py-1">experiment</TableHead>
+              <TableHead className="h-8 px-2 py-1 text-right">weight</TableHead>
+              <TableHead className="h-8 px-2 py-1 text-center">active</TableHead>
+              <TableHead className="h-8 px-2 py-1 text-right">feedback</TableHead>
+              <TableHead className="h-8 px-2 py-1 text-right">avgR</TableHead>
+              <TableHead className="h-8 px-2 py-1 text-right">judge相関</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow
+                key={row.templateId}
+                className={cn(!row.isActive && "text-muted-foreground")}
+              >
+                <TableCell className="px-2 py-1.5">v{row.version}</TableCell>
+                <TableCell className="px-2 py-1.5">
+                  {row.experimentKey ?? "—"}
+                </TableCell>
+                <TableCell className="px-2 py-1.5 text-right">
+                  {row.trafficWeight}%
+                </TableCell>
+                <TableCell className="px-2 py-1.5 text-center">
+                  {row.isActive ? (row.isEnabled ? "✓" : "○") : "−"}
+                </TableCell>
+                <TableCell className="px-2 py-1.5 text-right">
+                  {row.feedbackCount}
+                </TableCell>
+                <TableCell className="px-2 py-1.5 text-right">
+                  {row.avgRating != null ? row.avgRating.toFixed(2) : "—"}
+                </TableCell>
+                <TableCell className="px-2 py-1.5 text-right">
+                  <span
+                    className={cn(
+                      "inline-flex items-center gap-1",
+                      row.correlationWarning && "text-destructive",
+                    )}
+                  >
+                    {row.judgeHumanCorrelation != null
+                      ? row.judgeHumanCorrelation.toFixed(2)
+                      : "—"}
+                    {row.correlationWarning && (
+                      <AlertTriangle className="h-3 w-3" />
+                    )}
+                  </span>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </section>
+  );
+}

--- a/src/app/sysAdmin/features/system/templates/editor/components/GenerationTemplateContainer.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/GenerationTemplateContainer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useApolloClient } from "@apollo/client";
 import {
@@ -68,9 +68,6 @@ export function GenerationTemplateContainer({
 }: Props) {
   const router = useRouter();
   const apollo = useApolloClient();
-  const [feedbackTotalCount, setFeedbackTotalCount] = useState(
-    initialFeedbacks?.totalCount ?? 0,
-  );
 
   const [save, { loading: saving, error: saveError }] =
     useUpdateReportTemplateMutation();
@@ -129,15 +126,14 @@ export function GenerationTemplateContainer({
         },
         fetchPolicy: "network-only",
       });
-      const conn = result.data.adminTemplateFeedbacks ?? EMPTY_CONNECTION;
-      setFeedbackTotalCount(conn.totalCount);
-      return conn;
+      return result.data.adminTemplateFeedbacks ?? EMPTY_CONNECTION;
     },
     [apollo, variant],
   );
 
   const {
     items: feedbacks,
+    totalCount: feedbackTotalCount,
     hasNextPage: feedbacksHasNextPage,
     loading: feedbacksLoadingMore,
     loadMore: loadMoreFeedbacks,

--- a/src/app/sysAdmin/features/system/templates/editor/components/GenerationTemplateContainer.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/GenerationTemplateContainer.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useApolloClient } from "@apollo/client";
+import {
+  GqlReportTemplateKind,
+  useUpdateReportTemplateMutation,
+  type GqlGetAdminTemplateFeedbackStatsQuery,
+  type GqlGetAdminTemplateFeedbacksQuery,
+  type GqlGetAdminTemplateFeedbacksQueryVariables,
+  type GqlReportTemplateFieldsFragment,
+  type GqlReportTemplateStatsBreakdownRowFieldsFragment,
+  type GqlReportVariant,
+} from "@/types/graphql";
+import { GET_ADMIN_TEMPLATE_FEEDBACKS } from "@/graphql/account/adminTemplateFeedbacks/query";
+import { useCursorPagination } from "@/app/sysAdmin/_shared/hooks/useCursorPagination";
+import { GenerationTemplateView } from "./GenerationTemplateView";
+import type { PromptFormValues } from "./PromptEditor";
+
+type FeedbacksConnection = NonNullable<
+  GqlGetAdminTemplateFeedbacksQuery["adminTemplateFeedbacks"]
+>;
+type FeedbackStats =
+  GqlGetAdminTemplateFeedbackStatsQuery["adminTemplateFeedbackStats"];
+
+type Props = {
+  variant: GqlReportVariant;
+  initialBreakdownRows: GqlReportTemplateStatsBreakdownRowFieldsFragment[];
+  initialTemplate: GqlReportTemplateFieldsFragment | null;
+  initialFeedbacks: FeedbacksConnection | null;
+  initialStats: FeedbackStats | null;
+};
+
+const PAGE_SIZE = 20;
+
+const EMPTY_CONNECTION: FeedbacksConnection = {
+  __typename: "ReportFeedbacksConnection",
+  edges: [],
+  pageInfo: {
+    __typename: "PageInfo",
+    hasNextPage: false,
+    endCursor: null,
+  },
+  totalCount: 0,
+};
+
+/**
+ * `GenerationTemplateView` (presentational) と
+ * mutation hook + feedback pagination を結ぶ container。
+ *
+ * 初期 data (breakdown / template / feedbacks 1 ページ目) は SSR で取得して
+ * props で受け取る。client-side fetch は auth race の原因になるため使わない。
+ * 「もっと見る」だけ Apollo client.query で追加ページを取りに行く。
+ *
+ * Prompt の編集 state は `<PromptEditor>` 内の react-hook-form が管理する
+ * (= Container は initial 値を渡し submit 時の values を受け取るだけ)。
+ *
+ * 保存後は `router.refresh()` で SSR を再走させ、stats / template / feedbacks
+ * を最新化する。
+ */
+export function GenerationTemplateContainer({
+  variant,
+  initialBreakdownRows,
+  initialTemplate,
+  initialFeedbacks,
+  initialStats,
+}: Props) {
+  const router = useRouter();
+  const apollo = useApolloClient();
+  const [feedbackTotalCount, setFeedbackTotalCount] = useState(
+    initialFeedbacks?.totalCount ?? 0,
+  );
+
+  const [save, { loading: saving, error: saveError }] =
+    useUpdateReportTemplateMutation();
+
+  const handleSubmitPrompt = useCallback(
+    async (values: PromptFormValues) => {
+      if (!initialTemplate) return;
+      try {
+        await save({
+          variables: {
+            variant,
+            input: {
+              model: initialTemplate.model,
+              maxTokens: initialTemplate.maxTokens,
+              temperature: initialTemplate.temperature ?? undefined,
+              stopSequences: initialTemplate.stopSequences,
+              systemPrompt: values.systemPrompt,
+              userPromptTemplate: values.userPromptTemplate,
+              experimentKey: initialTemplate.experimentKey ?? undefined,
+              isActive: initialTemplate.isActive,
+              isEnabled: initialTemplate.isEnabled,
+              trafficWeight: initialTemplate.trafficWeight,
+              communityContext: initialTemplate.communityContext ?? undefined,
+            },
+          },
+        });
+        // SSR 経路の data を最新化する → PromptEditor の useEffect で
+        // initial が新値に reset される
+        router.refresh();
+      } catch {
+        // saveError state でハンドル済み
+      }
+    },
+    [initialTemplate, save, variant, router],
+  );
+
+  const handleSubmitPromptSync = useCallback(
+    (values: PromptFormValues) => {
+      void handleSubmitPrompt(values);
+    },
+    [handleSubmitPrompt],
+  );
+
+  const fetchMoreFeedbacks = useCallback(
+    async (cursor: string, first: number) => {
+      const result = await apollo.query<
+        GqlGetAdminTemplateFeedbacksQuery,
+        GqlGetAdminTemplateFeedbacksQueryVariables
+      >({
+        query: GET_ADMIN_TEMPLATE_FEEDBACKS,
+        variables: {
+          variant,
+          kind: GqlReportTemplateKind.Generation,
+          cursor,
+          first,
+        },
+        fetchPolicy: "network-only",
+      });
+      const conn = result.data.adminTemplateFeedbacks ?? EMPTY_CONNECTION;
+      setFeedbackTotalCount(conn.totalCount);
+      return conn;
+    },
+    [apollo, variant],
+  );
+
+  const {
+    items: feedbacks,
+    hasNextPage: feedbacksHasNextPage,
+    loading: feedbacksLoadingMore,
+    loadMore: loadMoreFeedbacks,
+  } = useCursorPagination({
+    initial: initialFeedbacks ?? EMPTY_CONNECTION,
+    fetchMore: fetchMoreFeedbacks,
+    pageSize: PAGE_SIZE,
+    resetKey: `${variant}:GENERATION`,
+  });
+
+  const handleLoadMoreFeedbacks = useCallback(() => {
+    void loadMoreFeedbacks();
+  }, [loadMoreFeedbacks]);
+
+  return (
+    <GenerationTemplateView
+      rows={initialBreakdownRows}
+      breakdownLoading={false}
+      breakdownError={null}
+      template={initialTemplate}
+      editorLoading={false}
+      editorError={null}
+      saving={saving}
+      saveError={saveError ?? null}
+      onSubmitPrompt={handleSubmitPromptSync}
+      feedbacks={feedbacks}
+      feedbackTotalCount={feedbackTotalCount}
+      feedbacksHasNextPage={feedbacksHasNextPage}
+      feedbacksLoadingMore={feedbacksLoadingMore}
+      onLoadMoreFeedbacks={handleLoadMoreFeedbacks}
+      feedbackStats={initialStats}
+    />
+  );
+}

--- a/src/app/sysAdmin/features/system/templates/editor/components/GenerationTemplateView.stories.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/GenerationTemplateView.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import {
+  mockActiveTemplate,
+  mockBreakdown,
+} from "@/app/sysAdmin/features/system/templates/shared/fixtures";
+import {
+  makeMockFeedbackStats,
+  makeMockFeedbacks,
+} from "@/app/sysAdmin/features/system/templates/feedback/fixtures";
+import { GqlReportVariant } from "@/types/graphql";
+import { GenerationTemplateView } from "./GenerationTemplateView";
+
+const meta: Meta<typeof GenerationTemplateView> = {
+  title: "SysAdmin/System/Templates/GenerationTemplateView",
+  component: GenerationTemplateView,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-xl p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof GenerationTemplateView>;
+
+const template = mockActiveTemplate(GqlReportVariant.MemberNewsletter);
+const rows = mockBreakdown(GqlReportVariant.MemberNewsletter);
+const feedbacks = makeMockFeedbacks(8);
+const feedbackStats = makeMockFeedbackStats(feedbacks.length);
+
+export const WithData: Story = {
+  args: {
+    rows,
+    breakdownLoading: false,
+    breakdownError: null,
+    template,
+    editorLoading: false,
+    editorError: null,
+    saving: false,
+    saveError: null,
+    onSubmitPrompt: () => undefined,
+    feedbacks,
+    feedbackTotalCount: feedbacks.length,
+    feedbackStats,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    rows: [],
+    breakdownLoading: true,
+    breakdownError: null,
+    template: null,
+    editorLoading: true,
+    editorError: null,
+    saving: false,
+    saveError: null,
+    onSubmitPrompt: () => undefined,
+    feedbacks: [],
+    feedbackStats: null,
+  },
+};
+
+export const NoTemplate: Story = {
+  args: {
+    rows: [],
+    breakdownLoading: false,
+    breakdownError: null,
+    template: null,
+    editorLoading: false,
+    editorError: null,
+    saving: false,
+    saveError: null,
+    onSubmitPrompt: () => undefined,
+    feedbacks: [],
+    feedbackStats: null,
+  },
+};
+
+export const BreakdownError: Story = {
+  args: {
+    rows: [],
+    breakdownLoading: false,
+    breakdownError: new Error("Network error"),
+    template,
+    editorLoading: false,
+    editorError: null,
+    saving: false,
+    saveError: null,
+    onSubmitPrompt: () => undefined,
+    feedbacks,
+    feedbackTotalCount: feedbacks.length,
+    feedbackStats,
+  },
+};

--- a/src/app/sysAdmin/features/system/templates/editor/components/GenerationTemplateView.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/GenerationTemplateView.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AlertTriangle } from "lucide-react";
+import LoadingIndicator from "@/components/shared/LoadingIndicator";
+import { ErrorState } from "@/components/shared/ErrorState";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { MetadataChips } from "@/app/sysAdmin/_shared/components/MetadataChips";
+import type {
+  GqlGetAdminTemplateFeedbackStatsQuery,
+  GqlReportFeedbackWithReportFieldsFragment,
+  GqlReportTemplateFieldsFragment,
+  GqlReportTemplateStatsBreakdownRowFieldsFragment,
+} from "@/types/graphql";
+import { PromptEditor, type PromptFormValues } from "./PromptEditor";
+import { ExperimentSection } from "./ExperimentSection";
+import { VersionSelector } from "./VersionSelector";
+import { FeedbackList } from "@/app/sysAdmin/_shared/feedback/FeedbackList";
+import { RatingSummary } from "@/app/sysAdmin/_shared/feedback/RatingSummary";
+
+type FeedbackStats =
+  GqlGetAdminTemplateFeedbackStatsQuery["adminTemplateFeedbackStats"];
+
+export type GenerationTemplateViewProps = {
+  rows: GqlReportTemplateStatsBreakdownRowFieldsFragment[];
+  breakdownLoading: boolean;
+  breakdownError: unknown;
+
+  template: GqlReportTemplateFieldsFragment | null;
+  editorLoading: boolean;
+  editorError: unknown;
+
+  saving: boolean;
+  saveError: { message: string } | null;
+  onSubmitPrompt: (values: PromptFormValues) => void;
+
+  feedbacks: GqlReportFeedbackWithReportFieldsFragment[];
+  feedbackTotalCount?: number;
+  feedbacksHasNextPage?: boolean;
+  feedbacksLoadingMore?: boolean;
+  onLoadMoreFeedbacks?: () => void;
+  /**
+   * `adminTemplateFeedbackStats` の SSR 結果。null = 取得失敗 / 未認証。
+   * RatingSummary をフィードバック一覧の上に出すために使う。
+   */
+  feedbackStats: FeedbackStats | null;
+};
+
+/**
+ * GENERATION template の閲覧 + 編集 view (presentational only)。
+ *
+ * レイアウト:
+ *   1. inline header (現行 active 行のメタ + 集計 stats を 1 行で)
+ *   2. PromptEditor (主、編集が即触れる位置)
+ *   3. FeedbackList (主、レビュー一覧)
+ *   4. 履歴・A/B (折りたたみ、必要時に開く)
+ */
+export function GenerationTemplateView({
+  rows,
+  breakdownLoading,
+  breakdownError,
+  template,
+  editorLoading,
+  editorError,
+  saving,
+  saveError,
+  onSubmitPrompt,
+  feedbacks,
+  feedbackTotalCount,
+  feedbacksHasNextPage,
+  feedbacksLoadingMore,
+  onLoadMoreFeedbacks,
+  feedbackStats,
+}: GenerationTemplateViewProps) {
+  const versions = useMemo(
+    () =>
+      Array.from(new Set(rows.map((r) => r.version))).sort((a, b) => b - a),
+    [rows],
+  );
+  const [selectedVersion, setSelectedVersion] = useState<number | null>(null);
+  const filteredRows = useMemo(
+    () =>
+      selectedVersion == null
+        ? rows
+        : rows.filter((r) => r.version === selectedVersion),
+    [rows, selectedVersion],
+  );
+
+  const isInitialLoading =
+    (editorLoading && !template) || (breakdownLoading && rows.length === 0);
+
+  if (isInitialLoading) {
+    return <LoadingIndicator fullScreen={false} />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <InlineHeader rows={rows} template={template} />
+
+      {editorError && !template ? (
+        <ErrorState title="テンプレートの取得に失敗しました" />
+      ) : !template ? (
+        <p className="text-body-sm text-muted-foreground">
+          この variant の SYSTEM テンプレートが見つかりません
+        </p>
+      ) : (
+        <PromptEditor
+          initialSystemPrompt={template.systemPrompt}
+          initialUserPromptTemplate={template.userPromptTemplate}
+          onSubmit={onSubmitPrompt}
+          saving={saving}
+          saveError={saveError}
+        />
+      )}
+
+      <FeedbackList
+        feedbacks={feedbacks}
+        totalCount={feedbackTotalCount}
+        reportLinkFor={(fb) => ({
+          href: `/sysAdmin/${fb.report.community.id}/reports/${fb.report.id}`,
+          label: fb.report.community.name ?? fb.report.community.id,
+        })}
+        summary={
+          feedbackStats ? (
+            <RatingSummary
+              avgRating={feedbackStats.avgRating ?? null}
+              totalCount={feedbackStats.totalCount}
+              distribution={feedbackStats.ratingDistribution}
+            />
+          ) : undefined
+        }
+        pagination={
+          onLoadMoreFeedbacks
+            ? {
+                hasNextPage: feedbacksHasNextPage ?? false,
+                loadingMore: feedbacksLoadingMore ?? false,
+                onLoadMore: onLoadMoreFeedbacks,
+              }
+            : undefined
+        }
+      />
+
+      <Accordion type="single" collapsible>
+        <AccordionItem value="history" className="border-none">
+          <AccordionTrigger className="text-body-sm font-semibold">
+            履歴・A/B 比較
+          </AccordionTrigger>
+          <AccordionContent className="space-y-4">
+            {breakdownError ? (
+              <ErrorState title="評価指標の取得に失敗しました" />
+            ) : (
+              <>
+                <VersionSelector
+                  versions={versions}
+                  selected={selectedVersion}
+                  onSelect={setSelectedVersion}
+                />
+                <ExperimentSection rows={filteredRows} />
+              </>
+            )}
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </div>
+  );
+}
+
+function InlineHeader({
+  rows,
+  template,
+}: {
+  rows: GqlReportTemplateStatsBreakdownRowFieldsFragment[];
+  template: GqlReportTemplateFieldsFragment | null;
+}) {
+  // 集計値 (avgRating / feedback / 相関) は active な行のみで集計。
+  const activeRows = rows.filter((r) => r.isActive && r.isEnabled);
+  const totalFeedback = activeRows.reduce((s, r) => s + r.feedbackCount, 0);
+  const rated = activeRows.filter((r) => r.avgRating != null);
+  const ratedFeedback = rated.reduce((s, r) => s + r.feedbackCount, 0);
+  const avgRating =
+    ratedFeedback > 0
+      ? rated.reduce((s, r) => s + (r.avgRating ?? 0) * r.feedbackCount, 0) /
+        ratedFeedback
+      : null;
+  const corrRows = activeRows.filter((r) => r.judgeHumanCorrelation != null);
+  const corrFeedback = corrRows.reduce((s, r) => s + r.feedbackCount, 0);
+  const avgCorrelation =
+    corrFeedback > 0
+      ? corrRows.reduce(
+          (s, r) => s + (r.judgeHumanCorrelation ?? 0) * r.feedbackCount,
+          0,
+        ) / corrFeedback
+      : null;
+  const hasWarning = activeRows.some((r) => r.correlationWarning);
+
+  return (
+    <div className="space-y-2">
+      <MetadataChips
+        items={[
+          template && { label: `v${template.version}`, emphasis: true },
+          template?.experimentKey
+            ? `ブランチ: ${template.experimentKey}`
+            : null,
+          template && `配信比率 ${template.trafficWeight}%`,
+          `評価 ${avgRating != null ? avgRating.toFixed(2) : "—"} (${totalFeedback})`,
+          `LLM-人間 一致度 ${avgCorrelation != null ? avgCorrelation.toFixed(2) : "—"}`,
+        ]}
+      />
+      {hasWarning && (
+        <Alert variant="destructive" className="py-2">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription className="text-body-xs">
+            この active 行に LLM-人間 一致度の警告があります
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}

--- a/src/app/sysAdmin/features/system/templates/editor/components/JudgeTemplateContainer.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/JudgeTemplateContainer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { useApolloClient } from "@apollo/client";
 import {
   GqlReportTemplateKind,
@@ -57,9 +57,6 @@ export function JudgeTemplateContainer({
   initialStats,
 }: Props) {
   const apollo = useApolloClient();
-  const [feedbackTotalCount, setFeedbackTotalCount] = useState(
-    initialFeedbacks?.totalCount ?? 0,
-  );
 
   const fetchMoreFeedbacks = useCallback(
     async (cursor: string, first: number) => {
@@ -76,15 +73,14 @@ export function JudgeTemplateContainer({
         },
         fetchPolicy: "network-only",
       });
-      const conn = result.data.adminTemplateFeedbacks ?? EMPTY_CONNECTION;
-      setFeedbackTotalCount(conn.totalCount);
-      return conn;
+      return result.data.adminTemplateFeedbacks ?? EMPTY_CONNECTION;
     },
     [apollo, variant],
   );
 
   const {
     items: feedbacks,
+    totalCount: feedbackTotalCount,
     hasNextPage: feedbacksHasNextPage,
     loading: feedbacksLoadingMore,
     loadMore: loadMoreFeedbacks,

--- a/src/app/sysAdmin/features/system/templates/editor/components/JudgeTemplateContainer.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/JudgeTemplateContainer.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useApolloClient } from "@apollo/client";
+import {
+  GqlReportTemplateKind,
+  type GqlGetAdminTemplateFeedbackStatsQuery,
+  type GqlGetAdminTemplateFeedbacksQuery,
+  type GqlGetAdminTemplateFeedbacksQueryVariables,
+  type GqlReportTemplateFieldsFragment,
+  type GqlReportTemplateStatsBreakdownRowFieldsFragment,
+  type GqlReportVariant,
+} from "@/types/graphql";
+import { GET_ADMIN_TEMPLATE_FEEDBACKS } from "@/graphql/account/adminTemplateFeedbacks/query";
+import { useCursorPagination } from "@/app/sysAdmin/_shared/hooks/useCursorPagination";
+import { JudgeTemplateView } from "./JudgeTemplateView";
+
+type FeedbacksConnection = NonNullable<
+  GqlGetAdminTemplateFeedbacksQuery["adminTemplateFeedbacks"]
+>;
+type FeedbackStats =
+  GqlGetAdminTemplateFeedbackStatsQuery["adminTemplateFeedbackStats"];
+
+type Props = {
+  variant: GqlReportVariant;
+  initialBreakdownRows: GqlReportTemplateStatsBreakdownRowFieldsFragment[];
+  initialJudgeTemplate: GqlReportTemplateFieldsFragment | null;
+  initialFeedbacks: FeedbacksConnection | null;
+  initialStats: FeedbackStats | null;
+};
+
+const PAGE_SIZE = 20;
+
+const EMPTY_CONNECTION: FeedbacksConnection = {
+  __typename: "ReportFeedbacksConnection",
+  edges: [],
+  pageInfo: {
+    __typename: "PageInfo",
+    hasNextPage: false,
+    endCursor: null,
+  },
+  totalCount: 0,
+};
+
+/**
+ * `JudgeTemplateView` (presentational) と SSR initial data + feedback
+ * pagination を結ぶ container。
+ *
+ * JUDGE は閲覧専用のため mutation は使わない。「もっと見る」だけ Apollo
+ * client.query で追加ページを取得する。
+ */
+export function JudgeTemplateContainer({
+  variant,
+  initialBreakdownRows,
+  initialJudgeTemplate,
+  initialFeedbacks,
+  initialStats,
+}: Props) {
+  const apollo = useApolloClient();
+  const [feedbackTotalCount, setFeedbackTotalCount] = useState(
+    initialFeedbacks?.totalCount ?? 0,
+  );
+
+  const fetchMoreFeedbacks = useCallback(
+    async (cursor: string, first: number) => {
+      const result = await apollo.query<
+        GqlGetAdminTemplateFeedbacksQuery,
+        GqlGetAdminTemplateFeedbacksQueryVariables
+      >({
+        query: GET_ADMIN_TEMPLATE_FEEDBACKS,
+        variables: {
+          variant,
+          kind: GqlReportTemplateKind.Judge,
+          cursor,
+          first,
+        },
+        fetchPolicy: "network-only",
+      });
+      const conn = result.data.adminTemplateFeedbacks ?? EMPTY_CONNECTION;
+      setFeedbackTotalCount(conn.totalCount);
+      return conn;
+    },
+    [apollo, variant],
+  );
+
+  const {
+    items: feedbacks,
+    hasNextPage: feedbacksHasNextPage,
+    loading: feedbacksLoadingMore,
+    loadMore: loadMoreFeedbacks,
+  } = useCursorPagination({
+    initial: initialFeedbacks ?? EMPTY_CONNECTION,
+    fetchMore: fetchMoreFeedbacks,
+    pageSize: PAGE_SIZE,
+    resetKey: `${variant}:JUDGE`,
+  });
+
+  const handleLoadMoreFeedbacks = useCallback(() => {
+    void loadMoreFeedbacks();
+  }, [loadMoreFeedbacks]);
+
+  return (
+    <JudgeTemplateView
+      rows={initialBreakdownRows}
+      breakdownLoading={false}
+      breakdownError={null}
+      template={initialJudgeTemplate}
+      templateLoading={false}
+      templateError={null}
+      feedbacks={feedbacks}
+      feedbackTotalCount={feedbackTotalCount}
+      feedbacksHasNextPage={feedbacksHasNextPage}
+      feedbacksLoadingMore={feedbacksLoadingMore}
+      onLoadMoreFeedbacks={handleLoadMoreFeedbacks}
+      feedbackStats={initialStats}
+    />
+  );
+}

--- a/src/app/sysAdmin/features/system/templates/editor/components/JudgeTemplateView.stories.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/JudgeTemplateView.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import {
+  mockActiveTemplate,
+  mockBreakdown,
+} from "@/app/sysAdmin/features/system/templates/shared/fixtures";
+import {
+  makeMockFeedbackStats,
+  makeMockFeedbacks,
+} from "@/app/sysAdmin/features/system/templates/feedback/fixtures";
+import { GqlReportTemplateKind, GqlReportVariant } from "@/types/graphql";
+import { JudgeTemplateView } from "./JudgeTemplateView";
+
+const meta: Meta<typeof JudgeTemplateView> = {
+  title: "SysAdmin/System/Templates/JudgeTemplateView",
+  component: JudgeTemplateView,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-xl p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof JudgeTemplateView>;
+
+const judgeTemplate = mockActiveTemplate(
+  GqlReportVariant.MemberNewsletter,
+  GqlReportTemplateKind.Judge,
+);
+const judgeRows = mockBreakdown(GqlReportVariant.MemberNewsletter).map((r) => ({
+  ...r,
+  kind: GqlReportTemplateKind.Judge,
+}));
+const feedbacks = makeMockFeedbacks(6);
+const feedbackStats = makeMockFeedbackStats(feedbacks.length);
+
+export const WithData: Story = {
+  args: {
+    rows: judgeRows,
+    breakdownLoading: false,
+    breakdownError: null,
+    template: judgeTemplate,
+    templateLoading: false,
+    templateError: null,
+    feedbacks,
+    feedbackTotalCount: feedbacks.length,
+    feedbackStats,
+  },
+};
+
+export const NoTemplate: Story = {
+  args: {
+    rows: [],
+    breakdownLoading: false,
+    breakdownError: null,
+    template: null,
+    templateLoading: false,
+    templateError: null,
+    feedbacks: [],
+    feedbackStats: null,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    rows: [],
+    breakdownLoading: true,
+    breakdownError: null,
+    template: null,
+    templateLoading: true,
+    templateError: null,
+    feedbacks: [],
+    feedbackStats: null,
+  },
+};
+
+export const FetchError: Story = {
+  args: {
+    rows: [],
+    breakdownLoading: false,
+    breakdownError: new Error("Network error"),
+    template: null,
+    templateLoading: false,
+    templateError: null,
+    feedbacks: [],
+    feedbackStats: null,
+  },
+};

--- a/src/app/sysAdmin/features/system/templates/editor/components/JudgeTemplateView.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/JudgeTemplateView.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AlertTriangle } from "lucide-react";
+import LoadingIndicator from "@/components/shared/LoadingIndicator";
+import { ErrorState } from "@/components/shared/ErrorState";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { MetadataChips } from "@/app/sysAdmin/_shared/components/MetadataChips";
+import type {
+  GqlGetAdminTemplateFeedbackStatsQuery,
+  GqlReportFeedbackWithReportFieldsFragment,
+  GqlReportTemplateFieldsFragment,
+  GqlReportTemplateStatsBreakdownRowFieldsFragment,
+} from "@/types/graphql";
+import { ExperimentSection } from "./ExperimentSection";
+import { VersionSelector } from "./VersionSelector";
+import { FeedbackList } from "@/app/sysAdmin/_shared/feedback/FeedbackList";
+import { RatingSummary } from "@/app/sysAdmin/_shared/feedback/RatingSummary";
+
+type FeedbackStats =
+  GqlGetAdminTemplateFeedbackStatsQuery["adminTemplateFeedbackStats"];
+
+export type JudgeTemplateViewProps = {
+  rows: GqlReportTemplateStatsBreakdownRowFieldsFragment[];
+  breakdownLoading: boolean;
+  breakdownError: unknown;
+
+  template: GqlReportTemplateFieldsFragment | null;
+  templateLoading: boolean;
+  templateError: unknown;
+
+  feedbacks: GqlReportFeedbackWithReportFieldsFragment[];
+  feedbackTotalCount?: number;
+  feedbacksHasNextPage?: boolean;
+  feedbacksLoadingMore?: boolean;
+  onLoadMoreFeedbacks?: () => void;
+  feedbackStats: FeedbackStats | null;
+};
+
+/**
+ * JUDGE template の閲覧専用 view。
+ *
+ * GENERATION と構造を揃える: inline header → prompt (read-only) →
+ * フィードバック → 折りたたみ「履歴・A/B」。
+ * JUDGE は内部評価用の prompt なので、admin UI から編集すると過去の
+ * judgeScore との比較が断絶する。本 view は閲覧のみで、警告バナーを
+ * 常時表示する。将来 backend が JUDGE 対応 mutation を追加したら、
+ * `JudgeWarningModal` を save 前に挟んで編集可能化する。
+ */
+export function JudgeTemplateView({
+  rows,
+  breakdownLoading,
+  breakdownError,
+  template,
+  templateLoading,
+  templateError,
+  feedbacks,
+  feedbackTotalCount,
+  feedbacksHasNextPage,
+  feedbacksLoadingMore,
+  onLoadMoreFeedbacks,
+  feedbackStats,
+}: JudgeTemplateViewProps) {
+  const versions = useMemo(
+    () =>
+      Array.from(new Set(rows.map((r) => r.version))).sort((a, b) => b - a),
+    [rows],
+  );
+  const [selectedVersion, setSelectedVersion] = useState<number | null>(null);
+  const filteredRows = useMemo(
+    () =>
+      selectedVersion == null
+        ? rows
+        : rows.filter((r) => r.version === selectedVersion),
+    [rows, selectedVersion],
+  );
+
+  const isInitialLoading =
+    (breakdownLoading && rows.length === 0) || (templateLoading && !template);
+
+  if (isInitialLoading) {
+    return <LoadingIndicator fullScreen={false} />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <Alert variant="destructive">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertTitle>JUDGE template は閲覧専用</AlertTitle>
+        <AlertDescription className="text-body-xs">
+          prompt の更新は seed 投入で行ってください。admin UI から編集すると過去の judgeScore との比較が断絶し、評価指標の連続性が崩れます。
+        </AlertDescription>
+      </Alert>
+
+      <InlineHeader rows={rows} template={template} />
+
+      {breakdownError ? (
+        <ErrorState title="JUDGE 評価指標の取得に失敗しました" />
+      ) : templateError ? (
+        <ErrorState title="JUDGE template の取得に失敗しました" />
+      ) : !template ? (
+        <p className="text-body-sm text-muted-foreground">
+          この variant の JUDGE template は登録されていません
+        </p>
+      ) : (
+        <div className="space-y-4">
+          <section className="space-y-2">
+            <Label htmlFor="judgeSystemPrompt" className="text-body-sm font-semibold">
+              system prompt
+            </Label>
+            <Textarea
+              id="judgeSystemPrompt"
+              value={template.systemPrompt}
+              readOnly
+              className="min-h-[240px] font-mono text-body-xs"
+            />
+          </section>
+          <section className="space-y-2">
+            <Label htmlFor="judgeUserPrompt" className="text-body-sm font-semibold">
+              user prompt template
+            </Label>
+            <Textarea
+              id="judgeUserPrompt"
+              value={template.userPromptTemplate}
+              readOnly
+              className="min-h-[240px] font-mono text-body-xs"
+            />
+          </section>
+        </div>
+      )}
+
+      <FeedbackList
+        feedbacks={feedbacks}
+        totalCount={feedbackTotalCount}
+        reportLinkFor={(fb) => ({
+          href: `/sysAdmin/${fb.report.community.id}/reports/${fb.report.id}`,
+          label: fb.report.community.name ?? fb.report.community.id,
+        })}
+        summary={
+          feedbackStats ? (
+            <RatingSummary
+              avgRating={feedbackStats.avgRating ?? null}
+              totalCount={feedbackStats.totalCount}
+              distribution={feedbackStats.ratingDistribution}
+            />
+          ) : undefined
+        }
+        pagination={
+          onLoadMoreFeedbacks
+            ? {
+                hasNextPage: feedbacksHasNextPage ?? false,
+                loadingMore: feedbacksLoadingMore ?? false,
+                onLoadMore: onLoadMoreFeedbacks,
+              }
+            : undefined
+        }
+      />
+
+      <Accordion type="single" collapsible>
+        <AccordionItem value="history" className="border-none">
+          <AccordionTrigger className="text-body-sm font-semibold">
+            履歴・A/B 比較
+          </AccordionTrigger>
+          <AccordionContent className="space-y-4">
+            <VersionSelector
+              versions={versions}
+              selected={selectedVersion}
+              onSelect={setSelectedVersion}
+            />
+            <ExperimentSection rows={filteredRows} />
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </div>
+  );
+}
+
+function InlineHeader({
+  rows,
+  template,
+}: {
+  rows: GqlReportTemplateStatsBreakdownRowFieldsFragment[];
+  template: GqlReportTemplateFieldsFragment | null;
+}) {
+  const activeRows = rows.filter((r) => r.isActive && r.isEnabled);
+  const totalFeedback = activeRows.reduce((s, r) => s + r.feedbackCount, 0);
+  const rated = activeRows.filter((r) => r.avgRating != null);
+  const ratedFeedback = rated.reduce((s, r) => s + r.feedbackCount, 0);
+  const avgRating =
+    ratedFeedback > 0
+      ? rated.reduce((s, r) => s + (r.avgRating ?? 0) * r.feedbackCount, 0) /
+        ratedFeedback
+      : null;
+
+  return (
+    <MetadataChips
+      items={[
+        template && { label: `v${template.version}`, emphasis: true },
+        template?.experimentKey ? `ブランチ: ${template.experimentKey}` : null,
+        `評価 ${avgRating != null ? avgRating.toFixed(2) : "—"} (${totalFeedback})`,
+      ]}
+    />
+  );
+}

--- a/src/app/sysAdmin/features/system/templates/editor/components/PromptEditor.stories.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/PromptEditor.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { mockActiveTemplate } from "@/app/sysAdmin/features/system/templates/shared/fixtures";
+import { GqlReportVariant } from "@/types/graphql";
+import { PromptEditor } from "./PromptEditor";
+
+const meta: Meta<typeof PromptEditor> = {
+  title: "SysAdmin/System/Templates/PromptEditor",
+  component: PromptEditor,
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-xl p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof PromptEditor>;
+
+const template = mockActiveTemplate(GqlReportVariant.MemberNewsletter);
+
+export const Pristine: Story = {
+  args: {
+    initialSystemPrompt: template.systemPrompt,
+    initialUserPromptTemplate: template.userPromptTemplate,
+    saving: false,
+    saveError: null,
+    onSubmit: () => undefined,
+  },
+};
+
+export const Saving: Story = {
+  args: {
+    initialSystemPrompt: template.systemPrompt,
+    initialUserPromptTemplate: template.userPromptTemplate,
+    saving: true,
+    saveError: null,
+    onSubmit: () => undefined,
+  },
+};
+
+export const SaveError: Story = {
+  args: {
+    initialSystemPrompt: template.systemPrompt,
+    initialUserPromptTemplate: template.userPromptTemplate,
+    saving: false,
+    saveError: { message: "Network error: failed to reach server" },
+    onSubmit: () => undefined,
+  },
+};

--- a/src/app/sysAdmin/features/system/templates/editor/components/PromptEditor.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/PromptEditor.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
+
+const formSchema = z.object({
+  systemPrompt: z.string().min(1, "system prompt は必須です"),
+  userPromptTemplate: z.string().min(1, "user prompt template は必須です"),
+});
+
+export type PromptFormValues = z.infer<typeof formSchema>;
+
+type Props = {
+  initialSystemPrompt: string;
+  initialUserPromptTemplate: string;
+  saving: boolean;
+  saveError?: { message: string } | null;
+  onSubmit: (values: PromptFormValues) => void;
+};
+
+/**
+ * Prompt 編集の主役 UI。shadcn `Form` (react-hook-form + zod) ベース。
+ *
+ * version / model / experimentKey 等のメタデータは ExperimentSection の
+ * table と重複するため、ここでは表示しない (= 親 View が MetadataChips
+ * で集約表示する)。
+ *
+ * `initial*` prop が変わったとき (例: 親で `router.refresh()` 後に
+ * SSR data が再投入されたとき) は内部 form を `form.reset` で同期する。
+ */
+export function PromptEditor({
+  initialSystemPrompt,
+  initialUserPromptTemplate,
+  saving,
+  saveError,
+  onSubmit,
+}: Props) {
+  const form = useForm<PromptFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      systemPrompt: initialSystemPrompt,
+      userPromptTemplate: initialUserPromptTemplate,
+    },
+  });
+
+  useEffect(() => {
+    form.reset({
+      systemPrompt: initialSystemPrompt,
+      userPromptTemplate: initialUserPromptTemplate,
+    });
+  }, [initialSystemPrompt, initialUserPromptTemplate, form]);
+
+  const isDirty = form.formState.isDirty;
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="systemPrompt"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-body-sm font-semibold">
+                system prompt
+              </FormLabel>
+              <FormControl>
+                <Textarea
+                  {...field}
+                  disabled={saving}
+                  className="min-h-[240px] font-mono text-body-xs"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="userPromptTemplate"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-body-sm font-semibold">
+                user prompt template
+              </FormLabel>
+              <FormControl>
+                <Textarea
+                  {...field}
+                  disabled={saving}
+                  className="min-h-[240px] font-mono text-body-xs"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {saveError && (
+          <p className="text-body-sm text-destructive">
+            保存に失敗しました: {saveError.message}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <Button
+            type="submit"
+            variant="primary"
+            size="sm"
+            disabled={!isDirty || saving}
+          >
+            {saving ? "保存中..." : isDirty ? "保存" : "変更なし"}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/app/sysAdmin/features/system/templates/editor/components/VersionSelector.stories.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/VersionSelector.stories.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { VersionSelector } from "./VersionSelector";
+
+const meta: Meta<typeof VersionSelector> = {
+  title: "SysAdmin/System/Templates/VersionSelector",
+  component: VersionSelector,
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-xl p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof VersionSelector>;
+
+function StatefulSelector({
+  versions,
+  initialSelected,
+}: {
+  versions: number[];
+  initialSelected: number | null;
+}) {
+  const [selected, setSelected] = useState<number | null>(initialSelected);
+  return (
+    <VersionSelector versions={versions} selected={selected} onSelect={setSelected} />
+  );
+}
+
+export const Default: Story = {
+  render: () => <StatefulSelector versions={[3, 2, 1]} initialSelected={null} />,
+};
+
+export const SpecificVersionSelected: Story = {
+  render: () => <StatefulSelector versions={[3, 2, 1]} initialSelected={2} />,
+};
+
+export const SingleVersion: Story = {
+  render: () => <StatefulSelector versions={[1]} initialSelected={null} />,
+};
+
+export const Empty: Story = {
+  render: () => <StatefulSelector versions={[]} initialSelected={null} />,
+};

--- a/src/app/sysAdmin/features/system/templates/editor/components/VersionSelector.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/VersionSelector.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+
+type Props = {
+  versions: number[];
+  selected: number | null;
+  onSelect: (version: number | null) => void;
+};
+
+const ALL_VALUE = "all";
+
+/**
+ * version の chip selector。
+ * `selected = null` で「全 version 表示」を意味する。
+ *
+ * radix `ToggleGroup type="single"` で実装すると、roving tabindex /
+ * 矢印キー操作 / ARIA 属性が radix 任せになる。空 value (= 全部 deselect)
+ * は許可しないので、内部的には `"all"` を「全 version」値として扱う。
+ */
+export function VersionSelector({ versions, selected, onSelect }: Props) {
+  if (versions.length === 0) return null;
+
+  const value = selected == null ? ALL_VALUE : `v${selected}`;
+  const handleChange = (next: string) => {
+    if (next === "" || next === ALL_VALUE) {
+      onSelect(null);
+      return;
+    }
+    const num = Number(next.replace(/^v/, ""));
+    onSelect(Number.isFinite(num) ? num : null);
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-body-xs text-muted-foreground">version:</span>
+      <ToggleGroup
+        type="single"
+        value={value}
+        onValueChange={handleChange}
+        className="flex-wrap justify-start"
+        aria-label="表示する version"
+      >
+        <ToggleGroupItem value={ALL_VALUE} className="h-7 px-2 text-body-xs">
+          全て
+        </ToggleGroupItem>
+        {versions.map((v) => (
+          <ToggleGroupItem
+            key={v}
+            value={`v${v}`}
+            className="h-7 px-2 text-body-xs tabular-nums"
+          >
+            v{v}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+    </div>
+  );
+}

--- a/src/app/sysAdmin/features/system/templates/feedback/fixtures.ts
+++ b/src/app/sysAdmin/features/system/templates/feedback/fixtures.ts
@@ -1,0 +1,156 @@
+import {
+  GqlReportFeedbackType,
+  GqlReportVariant,
+  type GqlGetAdminTemplateFeedbackStatsQuery,
+  type GqlGetAdminTemplateFeedbacksQuery,
+  type GqlReportFeedbackWithReportFieldsFragment,
+} from "@/types/graphql";
+
+export type FeedbacksConnection = NonNullable<
+  GqlGetAdminTemplateFeedbacksQuery["adminTemplateFeedbacks"]
+>;
+
+export type FeedbackStats =
+  GqlGetAdminTemplateFeedbackStatsQuery["adminTemplateFeedbackStats"];
+
+/**
+ * Storybook 用 mock。
+ * 本番 component は backend の `adminTemplateFeedbacks` query から
+ * `ReportFeedbackWithReportFields` fragment 単位の data を受け取るので、
+ * mock もその型に揃えておく。
+ */
+export type FeedbackItem = GqlReportFeedbackWithReportFieldsFragment;
+
+const sampleComments = [
+  "導入が冗長で本題が遅い。もっと簡潔に始めてほしい。",
+  "数字が違う。先月の値が混ざっている可能性。",
+  "全体的に読みやすかった。次回も同じトーンで。",
+  "中盤の段落が冗長。箇条書きにした方が伝わる。",
+  "メンバーへの呼びかけが温かくて良い。",
+  "事実関係に誤りあり。確認が必要。",
+  "結びの一文が弱い。次のアクションを明示してほしい。",
+  null,
+  "全体は良いが、固有名詞の表記揺れが気になる。",
+  null,
+];
+
+const sampleNames = [
+  "田中太郎",
+  "佐藤花子",
+  "鈴木次郎",
+  "高橋三郎",
+  "山田四郎",
+  "中村美咲",
+  "小林優子",
+  "斎藤健太",
+];
+
+const feedbackTypes = [
+  GqlReportFeedbackType.Quality,
+  GqlReportFeedbackType.Accuracy,
+  GqlReportFeedbackType.Tone,
+  GqlReportFeedbackType.Structure,
+  GqlReportFeedbackType.Other,
+];
+
+const sectionKeys = ["intro", "highlight", "members", "cta", "closing", null];
+
+const sampleCommunities = [
+  { id: "c_kibotcha", name: "kibotcha" },
+  { id: "c_neoyamacle", name: "neo山くる" },
+  { id: "c_hopin", name: "Hopin" },
+];
+
+/**
+ * mock feedback 群 (variant 詳細ページ用)。
+ * rating は 2〜5 で散らばらせ、低評価 (= 改善の手がかり) も混ぜる。
+ */
+export function makeMockFeedbacks(count: number = 12): FeedbackItem[] {
+  const now = new Date("2026-04-27T12:00:00Z").getTime();
+  return Array.from({ length: count }, (_, i) => {
+    const rating = ((i * 7) % 4) + 2; // 2..5 を擬似ランダム
+    const daysAgo = i * 2 + 1;
+    const reportIdx = i % 5;
+    const community = sampleCommunities[reportIdx % sampleCommunities.length];
+    const periodTo = new Date(now - daysAgo * 24 * 60 * 60 * 1000);
+    const periodFrom = new Date(periodTo.getTime() - 7 * 24 * 60 * 60 * 1000);
+    return {
+      __typename: "ReportFeedback",
+      id: `fb_${i + 1}`,
+      rating,
+      comment: sampleComments[i % sampleComments.length],
+      feedbackType: feedbackTypes[i % feedbackTypes.length],
+      sectionKey: sectionKeys[i % sectionKeys.length],
+      createdAt: periodTo,
+      user: {
+        __typename: "User",
+        id: `u_${i + 1}`,
+        name: sampleNames[i % sampleNames.length],
+      },
+      report: {
+        __typename: "Report",
+        id: `r_${reportIdx + 1}`,
+        variant: GqlReportVariant.MemberNewsletter,
+        periodFrom,
+        periodTo,
+        community: {
+          __typename: "Community",
+          id: community.id,
+          name: community.name,
+        },
+      },
+    };
+  });
+}
+
+/**
+ * mock な `adminTemplateFeedbackStats` のレスポンス。
+ * Storybook で `RatingSummary` の動作確認に使う。
+ */
+export function makeMockFeedbackStats(
+  totalCount: number = 8,
+  distribution: { rating: number; count: number }[] = [
+    { rating: 1, count: 0 },
+    { rating: 2, count: 0 },
+    { rating: 3, count: 1 },
+    { rating: 4, count: 3 },
+    { rating: 5, count: 4 },
+  ],
+): FeedbackStats {
+  const sum = distribution.reduce((s, b) => s + b.rating * b.count, 0);
+  const totalRated = distribution.reduce((s, b) => s + b.count, 0);
+  const avgRating = totalRated > 0 ? sum / totalRated : null;
+  return {
+    __typename: "AdminTemplateFeedbackStats",
+    totalCount,
+    avgRating,
+    ratingDistribution: distribution.map((b) => ({
+      __typename: "ReportFeedbackRatingBucket",
+      ...b,
+    })),
+  };
+}
+
+/**
+ * mock feedbacks を `adminTemplateFeedbacks` Connection 形式にラップする
+ * helper。Storybook で Container / page を表示するときに使う。
+ */
+export function makeMockFeedbacksConnection(
+  count: number = 12,
+): FeedbacksConnection {
+  const items = makeMockFeedbacks(count);
+  return {
+    __typename: "ReportFeedbacksConnection",
+    edges: items.map((node, i) => ({
+      __typename: "ReportFeedbackEdge",
+      cursor: `cursor_${i + 1}`,
+      node,
+    })),
+    pageInfo: {
+      __typename: "PageInfo",
+      hasNextPage: false,
+      endCursor: items.length > 0 ? `cursor_${items.length}` : null,
+    },
+    totalCount: count,
+  };
+}

--- a/src/app/sysAdmin/features/system/templates/list/components/TemplateRow.stories.tsx
+++ b/src/app/sysAdmin/features/system/templates/list/components/TemplateRow.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { GqlReportVariant } from "@/types/graphql";
+import { TemplateRow } from "./TemplateRow";
+
+const meta: Meta<typeof TemplateRow> = {
+  title: "SysAdmin/System/Templates/TemplateRow",
+  component: TemplateRow,
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-xl p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof TemplateRow>;
+
+export const Default: Story = {
+  args: {
+    summary: {
+      variant: GqlReportVariant.MemberNewsletter,
+      currentVersion: 3,
+      activeTemplateCount: 2,
+      totalFeedbackCount: 47,
+      weightedAvgRating: 4.2,
+      hasWarning: false,
+    },
+    onClick: () => undefined,
+  },
+};
+
+export const WithWarning: Story = {
+  args: {
+    summary: {
+      variant: GqlReportVariant.WeeklySummary,
+      currentVersion: 2,
+      activeTemplateCount: 1,
+      totalFeedbackCount: 84,
+      weightedAvgRating: 3.6,
+      hasWarning: true,
+    },
+    onClick: () => undefined,
+  },
+};
+
+export const NoFeedback: Story = {
+  args: {
+    summary: {
+      variant: GqlReportVariant.GrantApplication,
+      currentVersion: 1,
+      activeTemplateCount: 1,
+      totalFeedbackCount: 0,
+      weightedAvgRating: null,
+      hasWarning: false,
+    },
+    onClick: () => undefined,
+  },
+};
+
+export const NoActiveTemplate: Story = {
+  args: {
+    summary: {
+      variant: GqlReportVariant.MediaPr,
+      currentVersion: 0,
+      activeTemplateCount: 0,
+      totalFeedbackCount: 0,
+      weightedAvgRating: null,
+      hasWarning: false,
+    },
+    onClick: () => undefined,
+  },
+};

--- a/src/app/sysAdmin/features/system/templates/list/components/TemplateRow.tsx
+++ b/src/app/sysAdmin/features/system/templates/list/components/TemplateRow.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { Item, ItemContent, ItemFooter, ItemTitle } from "@/components/ui/item";
+import { cn } from "@/lib/utils";
+import { type VariantSummary } from "@/app/sysAdmin/features/system/templates/shared/fixtures";
+
+type Props = {
+  summary: VariantSummary;
+  onClick?: () => void;
+};
+
+export function TemplateRow({ summary, onClick }: Props) {
+  return (
+    <Item
+      className={cn(
+        "flex flex-col items-start gap-1",
+        onClick &&
+          "cursor-pointer transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+      )}
+      onClick={onClick}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={(e) => {
+        if (!onClick) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+    >
+      <ItemContent>
+        <div className="flex w-full items-baseline justify-between gap-2">
+          <ItemTitle className="min-w-0 flex-1 truncate text-base font-mono font-semibold">
+            {summary.variant}
+          </ItemTitle>
+          {summary.currentVersion > 0 && (
+            <span className="shrink-0 rounded-full border border-border px-2 py-0.5 text-sm font-medium tabular-nums text-muted-foreground">
+              v{summary.currentVersion}
+            </span>
+          )}
+        </div>
+      </ItemContent>
+
+      <ItemFooter className="mt-0 w-full flex-row items-baseline gap-x-4 gap-y-1 text-body-sm text-muted-foreground tabular-nums">
+        <span>
+          評価{" "}
+          <span className="font-medium text-foreground">
+            {summary.weightedAvgRating != null
+              ? summary.weightedAvgRating.toFixed(2)
+              : "—"}
+          </span>{" "}
+          ({summary.totalFeedbackCount})
+        </span>
+        <span>
+          A/B{" "}
+          <span className="font-medium text-foreground">
+            {summary.activeTemplateCount}
+          </span>
+        </span>
+        {summary.hasWarning && (
+          <span className="ml-auto inline-flex items-center gap-1 text-destructive">
+            <AlertTriangle className="h-3 w-3" />
+            警告
+          </span>
+        )}
+      </ItemFooter>
+    </Item>
+  );
+}

--- a/src/app/sysAdmin/features/system/templates/shared/JudgeWarningModal.stories.tsx
+++ b/src/app/sysAdmin/features/system/templates/shared/JudgeWarningModal.stories.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Button } from "@/components/ui/button";
+import { JudgeWarningModal } from "./JudgeWarningModal";
+
+const meta: Meta<typeof JudgeWarningModal> = {
+  title: "SysAdmin/System/Templates/JudgeWarningModal",
+  component: JudgeWarningModal,
+  parameters: { layout: "centered" },
+};
+
+export default meta;
+type Story = StoryObj<typeof JudgeWarningModal>;
+
+function StatefulModalDemo({ saving = false }: { saving?: boolean }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="p-8">
+      <Button variant="tertiary" size="sm" onClick={() => setOpen(true)}>
+        modal を開く
+      </Button>
+      <JudgeWarningModal
+        open={open}
+        onOpenChange={setOpen}
+        onConfirm={() => setOpen(false)}
+        saving={saving}
+      />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <StatefulModalDemo />,
+};
+
+export const Saving: Story = {
+  render: () => <StatefulModalDemo saving />,
+};

--- a/src/app/sysAdmin/features/system/templates/shared/JudgeWarningModal.tsx
+++ b/src/app/sysAdmin/features/system/templates/shared/JudgeWarningModal.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  saving?: boolean;
+};
+
+/**
+ * JUDGE template 編集前に表示する警告 modal。
+ *
+ * JUDGE prompt を変更すると、過去の judgeScore (LLM-as-Judge 評価) と
+ * 新しい judgeScore が直接比較できなくなる (評価指標の不連続点が生まれる)。
+ * 編集者にこの含意を理解させてから confirm させる。
+ */
+export function JudgeWarningModal({ open, onOpenChange, onConfirm, saving }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-destructive">
+            <AlertTriangle className="h-5 w-5" />
+            JUDGE template の編集確認
+          </DialogTitle>
+          <DialogDescription className="space-y-2 pt-2">
+            <span className="block">
+              JUDGE prompt を変更すると、<strong>過去の judgeScore との比較が断絶</strong>します。
+            </span>
+            <span className="block text-body-xs">
+              新しい judgeScore は変更後の prompt で評価されたものとなり、
+              過去 version の評価データと直接比較するべきではありません。
+            </span>
+            <span className="block text-body-xs">
+              本番運用中の場合は、新 version として seed 投入し、
+              experimentKey で並列稼働させて段階移行することを推奨します。
+            </span>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="tertiary"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+          >
+            キャンセル
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={onConfirm}
+            disabled={saving}
+          >
+            {saving ? "保存中..." : "影響を理解した上で保存"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/sysAdmin/features/system/templates/shared/aggregate.ts
+++ b/src/app/sysAdmin/features/system/templates/shared/aggregate.ts
@@ -1,0 +1,76 @@
+import { GqlReportVariant } from "@/types/graphql";
+
+/**
+ * L1 list view 用の variant ごとサマリ。
+ * 複数 breakdown row (各 template 行) を 1 variant 分に集約した結果。
+ */
+export type VariantSummary = {
+  variant: GqlReportVariant;
+  currentVersion: number;
+  activeTemplateCount: number;
+  totalFeedbackCount: number;
+  weightedAvgRating: number | null;
+  hasWarning: boolean;
+};
+
+/**
+ * 集約に必要な breakdown row の最小形。
+ * - real query の `GqlReportTemplateStatsBreakdownRowFieldsFragment` も
+ * - mock fixtures の `TemplateBreakdownRow` も
+ * 同じ shape なのでこの型で扱える (structural typing)。
+ *
+ * 生成型では `avgRating` が `number | null | undefined` (optional + nullable)
+ * のため、ここも optional + nullable に揃える。
+ */
+export type AggregatableRow = {
+  version: number;
+  isActive: boolean;
+  isEnabled: boolean;
+  feedbackCount: number;
+  avgRating?: number | null;
+  correlationWarning: boolean;
+};
+
+/**
+ * 1 variant の breakdown row 群を VariantSummary に集約。
+ * 「現行 active 行」のみから avgRating / feedback を集約する
+ * (履歴を含めると平均が引きずられるため)。
+ */
+export function aggregateVariantSummary(
+  variant: GqlReportVariant,
+  rows: AggregatableRow[],
+): VariantSummary {
+  const activeRows = rows.filter((r) => r.isActive && r.isEnabled);
+  const currentVersion =
+    activeRows.length > 0 ? Math.max(...activeRows.map((r) => r.version)) : 0;
+
+  const totalFeedbackCount = activeRows.reduce(
+    (sum, r) => sum + r.feedbackCount,
+    0,
+  );
+  // 加重平均は avgRating を持つ行だけで計算する。
+  // 母数も同じく「avgRating を持つ行の feedbackCount 合計」にしないと、
+  // null avgRating の行の feedback 数で母数だけ膨らんで平均が低めに歪む。
+  const rowsWithRating = activeRows.filter((r) => r.avgRating != null);
+  const ratingFeedbackCount = rowsWithRating.reduce(
+    (sum, r) => sum + r.feedbackCount,
+    0,
+  );
+  const weightedSum = rowsWithRating.reduce(
+    (sum, r) => sum + (r.avgRating ?? 0) * r.feedbackCount,
+    0,
+  );
+  const weightedAvgRating =
+    ratingFeedbackCount > 0 ? weightedSum / ratingFeedbackCount : null;
+
+  const hasWarning = activeRows.some((r) => r.correlationWarning);
+
+  return {
+    variant,
+    currentVersion,
+    activeTemplateCount: activeRows.length,
+    totalFeedbackCount,
+    weightedAvgRating,
+    hasWarning,
+  };
+}

--- a/src/app/sysAdmin/features/system/templates/shared/fixtures.ts
+++ b/src/app/sysAdmin/features/system/templates/shared/fixtures.ts
@@ -1,0 +1,148 @@
+import {
+  GqlReportTemplateKind,
+  GqlReportTemplateScope,
+  GqlReportVariant,
+  type GqlReportTemplateFieldsFragment,
+  type GqlReportTemplateStatsBreakdownRowFieldsFragment,
+} from "@/types/graphql";
+import { aggregateVariantSummary, type VariantSummary } from "./aggregate";
+import { SUPPORTED_VARIANTS } from "./variantSlug";
+
+/**
+ * Breakdown row の alias。生成型をそのまま使う。
+ * 過去は local 型を持っていたが、`reportTemplateStatsBreakdown` query の
+ * landing 後は generated 型に統一。
+ */
+export type TemplateBreakdownRow = GqlReportTemplateStatsBreakdownRowFieldsFragment;
+
+/**
+ * 各 variant に対し、複数 version × 複数 experimentKey の組み合わせを mock。
+ * 「current active 行 + 過去 version 行 + 同 version 内 A/B」を含むシナリオを再現。
+ *
+ * Storybook / 単体テスト用。本番ページでは real query (`useTemplateBreakdown`)
+ * を使う。
+ */
+function makeBreakdownRows(variantPrefix: string): TemplateBreakdownRow[] {
+  return [
+    {
+      __typename: "ReportTemplateStatsBreakdownRow",
+      templateId: `tmpl_${variantPrefix}_v3_baseline`,
+      version: 3,
+      scope: GqlReportTemplateScope.System,
+      kind: GqlReportTemplateKind.Generation,
+      experimentKey: "baseline",
+      isActive: true,
+      isEnabled: true,
+      trafficWeight: 70,
+      feedbackCount: 47,
+      avgRating: 4.2,
+      avgJudgeScore: 4.0,
+      judgeHumanCorrelation: 0.81,
+      correlationWarning: false,
+    },
+    {
+      __typename: "ReportTemplateStatsBreakdownRow",
+      templateId: `tmpl_${variantPrefix}_v3_concise`,
+      version: 3,
+      scope: GqlReportTemplateScope.System,
+      kind: GqlReportTemplateKind.Generation,
+      experimentKey: "exp_concise",
+      isActive: true,
+      isEnabled: true,
+      trafficWeight: 30,
+      feedbackCount: 21,
+      avgRating: 4.5,
+      avgJudgeScore: 4.3,
+      judgeHumanCorrelation: 0.79,
+      correlationWarning: false,
+    },
+    {
+      __typename: "ReportTemplateStatsBreakdownRow",
+      templateId: `tmpl_${variantPrefix}_v2_baseline`,
+      version: 2,
+      scope: GqlReportTemplateScope.System,
+      kind: GqlReportTemplateKind.Generation,
+      experimentKey: "baseline",
+      isActive: false,
+      isEnabled: true,
+      trafficWeight: 0,
+      feedbackCount: 84,
+      avgRating: 3.9,
+      avgJudgeScore: 3.7,
+      judgeHumanCorrelation: 0.65,
+      correlationWarning: true,
+    },
+    {
+      __typename: "ReportTemplateStatsBreakdownRow",
+      templateId: `tmpl_${variantPrefix}_v1_baseline`,
+      version: 1,
+      scope: GqlReportTemplateScope.System,
+      kind: GqlReportTemplateKind.Generation,
+      experimentKey: null,
+      isActive: false,
+      isEnabled: false,
+      trafficWeight: 0,
+      feedbackCount: 12,
+      avgRating: 3.5,
+      avgJudgeScore: 3.2,
+      judgeHumanCorrelation: null,
+      correlationWarning: false,
+    },
+  ];
+}
+
+const PREFIX_BY_VARIANT: Record<GqlReportVariant, string> = {
+  [GqlReportVariant.MemberNewsletter]: "newsletter",
+  [GqlReportVariant.WeeklySummary]: "weekly",
+  [GqlReportVariant.GrantApplication]: "grant",
+  [GqlReportVariant.MediaPr]: "media",
+  [GqlReportVariant.PersonalRecap]: "recap",
+};
+
+/** Mock breakdown rows for a given variant. */
+export function mockBreakdown(variant: GqlReportVariant): TemplateBreakdownRow[] {
+  return makeBreakdownRows(PREFIX_BY_VARIANT[variant]);
+}
+
+export function mockVariantSummary(variant: GqlReportVariant): VariantSummary {
+  return aggregateVariantSummary(variant, mockBreakdown(variant));
+}
+
+/** L1 list view 用、4 variant 分のサマリ。 */
+export const MOCK_VARIANT_SUMMARIES: VariantSummary[] = SUPPORTED_VARIANTS.map(
+  mockVariantSummary,
+);
+
+export type { VariantSummary };
+
+/** PromptEditor / GenerationTemplateView 用の active template mock。 */
+export function mockActiveTemplate(
+  variant: GqlReportVariant,
+  kind: GqlReportTemplateKind = GqlReportTemplateKind.Generation,
+): GqlReportTemplateFieldsFragment {
+  return {
+    __typename: "ReportTemplate",
+    id: `tmpl_${variant}_v3_baseline`,
+    variant,
+    version: 3,
+    scope: GqlReportTemplateScope.System,
+    kind,
+    model: "claude-sonnet-4-5",
+    maxTokens: 8000,
+    temperature: 0.7,
+    systemPrompt:
+      "あなたは community 運営者向けのレポートを書く編集アシスタントです。\n以下の data を元に、簡潔で読みやすい日本語のニュースレターを生成してください。",
+    userPromptTemplate:
+      "以下が今週の community data です:\n{{data}}\n\n上記を元に、メンバーが読みたくなるニュースレターを書いてください。",
+    stopSequences: [],
+    trafficWeight: 70,
+    isActive: true,
+    isEnabled: true,
+    experimentKey: "baseline",
+    communityContext: null,
+    createdAt: new Date("2026-04-01T00:00:00Z"),
+    updatedAt: new Date("2026-04-15T00:00:00Z"),
+    community: null,
+    updatedByUser: { __typename: "User", id: "user_admin", name: "Admin" },
+  };
+}

--- a/src/app/sysAdmin/features/system/templates/shared/labels.ts
+++ b/src/app/sysAdmin/features/system/templates/shared/labels.ts
@@ -1,0 +1,59 @@
+import {
+  GqlReportFeedbackType,
+  GqlReportStatus,
+  GqlReportTemplateScope,
+  GqlReportVariant,
+} from "@/types/graphql";
+
+/** variant の日本語表示名。Phase 1 では PERSONAL_RECAP を扱わないが、API 上存在するので label は用意。 */
+export const VARIANT_LABELS: Record<GqlReportVariant, string> = {
+  [GqlReportVariant.MemberNewsletter]: "メンバーニュースレター",
+  [GqlReportVariant.WeeklySummary]: "週次サマリー",
+  [GqlReportVariant.GrantApplication]: "助成金申請",
+  [GqlReportVariant.MediaPr]: "メディア PR",
+  [GqlReportVariant.PersonalRecap]: "個人レキャップ",
+};
+
+export function variantLabel(variant: GqlReportVariant): string {
+  return VARIANT_LABELS[variant] ?? variant;
+}
+
+export const STATUS_LABELS: Record<GqlReportStatus, string> = {
+  [GqlReportStatus.Draft]: "下書き",
+  [GqlReportStatus.Approved]: "承認済み",
+  [GqlReportStatus.Published]: "公開済み",
+  [GqlReportStatus.Rejected]: "却下",
+  [GqlReportStatus.Skipped]: "スキップ",
+  [GqlReportStatus.Superseded]: "置き換え済み",
+};
+
+export function statusLabel(status: GqlReportStatus): string {
+  return STATUS_LABELS[status] ?? status;
+}
+
+export const SCOPE_LABELS: Record<GqlReportTemplateScope, string> = {
+  [GqlReportTemplateScope.System]: "全コミュニティ共通",
+  [GqlReportTemplateScope.Community]: "コミュニティ別",
+};
+
+export function scopeLabel(scope: GqlReportTemplateScope): string {
+  return SCOPE_LABELS[scope] ?? scope;
+}
+
+export const FEEDBACK_TYPE_LABELS: Record<GqlReportFeedbackType, string> = {
+  [GqlReportFeedbackType.Quality]: "品質",
+  [GqlReportFeedbackType.Accuracy]: "精度",
+  [GqlReportFeedbackType.Tone]: "トーン",
+  [GqlReportFeedbackType.Structure]: "構成",
+  [GqlReportFeedbackType.Other]: "その他",
+};
+
+export function feedbackTypeLabel(type: GqlReportFeedbackType): string {
+  return FEEDBACK_TYPE_LABELS[type] ?? type;
+}
+
+// TODO: backend PR landing 後、ReportTemplateKind 用 label を追加
+// export const KIND_LABELS: Record<GqlReportTemplateKind, string> = {
+//   GENERATION: "運営向け生成",
+//   JUDGE: "品質評価",
+// };

--- a/src/app/sysAdmin/features/system/templates/shared/variantSlug.ts
+++ b/src/app/sysAdmin/features/system/templates/shared/variantSlug.ts
@@ -1,0 +1,27 @@
+import { GqlReportVariant } from "@/types/graphql";
+
+/**
+ * URL に乗せる variant slug と GraphQL enum 値の双方向マップ。
+ * PERSONAL_RECAP は backend 未実装のため Phase 1 では除外。
+ */
+const SLUG_TO_VARIANT: Record<string, GqlReportVariant> = {
+  "member-newsletter": GqlReportVariant.MemberNewsletter,
+  "weekly-summary": GqlReportVariant.WeeklySummary,
+  "grant-application": GqlReportVariant.GrantApplication,
+  "media-pr": GqlReportVariant.MediaPr,
+};
+
+const VARIANT_TO_SLUG: Record<GqlReportVariant, string> = Object.fromEntries(
+  Object.entries(SLUG_TO_VARIANT).map(([slug, variant]) => [variant, slug]),
+) as Record<GqlReportVariant, string>;
+
+export function slugToVariant(slug: string): GqlReportVariant | null {
+  return SLUG_TO_VARIANT[slug] ?? null;
+}
+
+export function variantToSlug(variant: GqlReportVariant): string | null {
+  return VARIANT_TO_SLUG[variant] ?? null;
+}
+
+/** Phase 1 admin UI で扱う variant の集合 (PERSONAL_RECAP 除く) */
+export const SUPPORTED_VARIANTS: GqlReportVariant[] = Object.values(SLUG_TO_VARIANT);

--- a/src/app/sysAdmin/page.tsx
+++ b/src/app/sysAdmin/page.tsx
@@ -3,7 +3,6 @@ import { SysAdminPageClient } from "./SysAdminPageClient";
 
 // SSR で初期データを取得することで、初回ナビゲーション時の auth race
 // (Apollo link が idToken 取得前に発火して 401 になり ErrorState が出る) を解消する。
-// クライアント側のコントロール変更で再フェッチが必要になった時のみ Apollo client query が発火する。
 export default async function SysAdminPage() {
   const initialData = await fetchSysAdminDashboardServer({
     asOf: undefined,

--- a/src/app/sysAdmin/system/page.tsx
+++ b/src/app/sysAdmin/system/page.tsx
@@ -1,0 +1,15 @@
+import { redirect } from "next/navigation";
+
+/**
+ * `/sysAdmin/system` への直アクセスを `/sysAdmin/system/templates` に
+ * リダイレクトする。
+ *
+ * このファイルが無いと Next.js の動的ルート `[communityId]` が
+ * `/sysAdmin/system` を拾ってしまい、`sysAdminCommunityDetail({ communityId: "system" })`
+ * を叩いて `Community not found (id: system)` で 500 を吐く。
+ *
+ * システム設定 hub を将来追加する場合はこの redirect を hub ページに置き換える。
+ */
+export default function SysAdminSystemRedirectPage() {
+  redirect("/sysAdmin/system/templates");
+}

--- a/src/app/sysAdmin/system/templates/SysAdminSystemTemplatesPageClient.tsx
+++ b/src/app/sysAdmin/system/templates/SysAdminSystemTemplatesPageClient.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useMemo } from "react";
+import { useAppRouter } from "@/lib/navigation";
+import useHeaderConfig from "@/hooks/useHeaderConfig";
+import { TemplateRow } from "@/app/sysAdmin/features/system/templates/list/components/TemplateRow";
+import { variantToSlug } from "@/app/sysAdmin/features/system/templates/shared/variantSlug";
+import type { VariantSummary } from "@/app/sysAdmin/features/system/templates/shared/aggregate";
+
+type Props = {
+  /**
+   * variant 一覧は GENERATION のみ表示する。JUDGE は内部評価用で
+   * variant 詳細ページの [評価用] タブから確認する想定。
+   */
+  summaries: VariantSummary[];
+};
+
+export function SysAdminSystemTemplatesPageClient({ summaries }: Props) {
+  const router = useAppRouter();
+
+  const headerConfig = useMemo(
+    () => ({
+      title: "テンプレート",
+      showBackButton: true,
+      showLogo: false,
+    }),
+    [],
+  );
+  useHeaderConfig(headerConfig);
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      {summaries.every((s) => s.activeTemplateCount === 0) ? (
+        <p className="text-body-sm text-muted-foreground py-8 text-center">
+          登録されているテンプレートはありません
+        </p>
+      ) : (
+        <div className="flex flex-col">
+          {summaries.map((summary, idx) => {
+            const slug = variantToSlug(summary.variant);
+            return (
+              <div key={summary.variant}>
+                {idx !== 0 && <hr className="border-muted" />}
+                <TemplateRow
+                  summary={summary}
+                  onClick={
+                    slug
+                      ? () => router.push(`/sysAdmin/system/templates/${slug}`)
+                      : undefined
+                  }
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/sysAdmin/system/templates/[variant]/SysAdminTemplateDetailPageClient.tsx
+++ b/src/app/sysAdmin/system/templates/[variant]/SysAdminTemplateDetailPageClient.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useMemo } from "react";
+import useHeaderConfig from "@/hooks/useHeaderConfig";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type {
+  GqlGetAdminTemplateFeedbackStatsQuery,
+  GqlGetAdminTemplateFeedbacksQuery,
+  GqlReportTemplateFieldsFragment,
+  GqlReportTemplateStatsBreakdownRowFieldsFragment,
+  GqlReportVariant,
+} from "@/types/graphql";
+import { variantLabel } from "@/app/sysAdmin/features/system/templates/shared/labels";
+import { GenerationTemplateContainer } from "@/app/sysAdmin/features/system/templates/editor/components/GenerationTemplateContainer";
+import { JudgeTemplateContainer } from "@/app/sysAdmin/features/system/templates/editor/components/JudgeTemplateContainer";
+
+type FeedbacksConnection = NonNullable<
+  GqlGetAdminTemplateFeedbacksQuery["adminTemplateFeedbacks"]
+>;
+type FeedbackStats =
+  GqlGetAdminTemplateFeedbackStatsQuery["adminTemplateFeedbackStats"];
+
+type Props = {
+  variant: GqlReportVariant;
+  generationBreakdownRows: GqlReportTemplateStatsBreakdownRowFieldsFragment[];
+  generationTemplate: GqlReportTemplateFieldsFragment | null;
+  generationFeedbacks: FeedbacksConnection | null;
+  generationStats: FeedbackStats | null;
+  judgeBreakdownRows: GqlReportTemplateStatsBreakdownRowFieldsFragment[];
+  judgeTemplate: GqlReportTemplateFieldsFragment | null;
+  judgeFeedbacks: FeedbacksConnection | null;
+  judgeStats: FeedbackStats | null;
+};
+
+/**
+ * tabs UI + header config を持つ client wrapper。
+ * data 取得は page.tsx (RSC) 側で行い、初期 data として props で受ける。
+ */
+export function SysAdminTemplateDetailPageClient({
+  variant,
+  generationBreakdownRows,
+  generationTemplate,
+  generationFeedbacks,
+  generationStats,
+  judgeBreakdownRows,
+  judgeTemplate,
+  judgeFeedbacks,
+  judgeStats,
+}: Props) {
+  const headerConfig = useMemo(
+    () => ({
+      title: variantLabel(variant),
+      showBackButton: true,
+      showLogo: false,
+    }),
+    [variant],
+  );
+  useHeaderConfig(headerConfig);
+
+  return (
+    <div className="max-w-xl mx-auto mt-8 px-4">
+      <Tabs defaultValue="generation" className="w-full">
+        <TabsList className="grid w-full grid-cols-2 mb-6">
+          <TabsTrigger value="generation">生成用</TabsTrigger>
+          <TabsTrigger value="judge">評価用</TabsTrigger>
+        </TabsList>
+        <TabsContent value="generation">
+          <GenerationTemplateContainer
+            variant={variant}
+            initialBreakdownRows={generationBreakdownRows}
+            initialTemplate={generationTemplate}
+            initialFeedbacks={generationFeedbacks}
+            initialStats={generationStats}
+          />
+        </TabsContent>
+        <TabsContent value="judge">
+          <JudgeTemplateContainer
+            variant={variant}
+            initialBreakdownRows={judgeBreakdownRows}
+            initialJudgeTemplate={judgeTemplate}
+            initialFeedbacks={judgeFeedbacks}
+            initialStats={judgeStats}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/app/sysAdmin/system/templates/[variant]/page.stories.tsx
+++ b/src/app/sysAdmin/system/templates/[variant]/page.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { withApollo, withPageShell } from "../../../../../../.storybook/decorators";
+import {
+  mockActiveTemplate,
+  mockBreakdown,
+} from "@/app/sysAdmin/features/system/templates/shared/fixtures";
+import {
+  makeMockFeedbackStats,
+  makeMockFeedbacksConnection,
+} from "@/app/sysAdmin/features/system/templates/feedback/fixtures";
+import { GqlReportTemplateKind, GqlReportVariant } from "@/types/graphql";
+import { SysAdminTemplateDetailPageClient } from "./SysAdminTemplateDetailPageClient";
+
+const meta: Meta<typeof SysAdminTemplateDetailPageClient> = {
+  title: "SysAdmin/Pages/SystemTemplateDetail",
+  component: SysAdminTemplateDetailPageClient,
+  parameters: { layout: "fullscreen" },
+  decorators: [withPageShell, withApollo],
+};
+
+export default meta;
+type Story = StoryObj<typeof SysAdminTemplateDetailPageClient>;
+
+const generationTemplate = mockActiveTemplate(GqlReportVariant.MemberNewsletter);
+const generationRows = mockBreakdown(GqlReportVariant.MemberNewsletter);
+
+const judgeTemplate = mockActiveTemplate(
+  GqlReportVariant.MemberNewsletter,
+  GqlReportTemplateKind.Judge,
+);
+const judgeRows = mockBreakdown(GqlReportVariant.MemberNewsletter).map((r) => ({
+  ...r,
+  kind: GqlReportTemplateKind.Judge,
+}));
+
+const generationFeedbacks = makeMockFeedbacksConnection(8);
+const judgeFeedbacks = makeMockFeedbacksConnection(6);
+const generationStats = makeMockFeedbackStats(8);
+const judgeStats = makeMockFeedbackStats(6, [
+  { rating: 1, count: 0 },
+  { rating: 2, count: 1 },
+  { rating: 3, count: 2 },
+  { rating: 4, count: 2 },
+  { rating: 5, count: 1 },
+]);
+
+export const WithItems: Story = {
+  args: {
+    variant: GqlReportVariant.MemberNewsletter,
+    generationBreakdownRows: generationRows,
+    generationTemplate,
+    generationFeedbacks,
+    generationStats,
+    judgeBreakdownRows: judgeRows,
+    judgeTemplate,
+    judgeFeedbacks,
+    judgeStats,
+  },
+};
+
+export const TemplateMissing: Story = {
+  args: {
+    variant: GqlReportVariant.MemberNewsletter,
+    generationBreakdownRows: [],
+    generationTemplate: null,
+    generationFeedbacks: null,
+    generationStats: null,
+    judgeBreakdownRows: [],
+    judgeTemplate: null,
+    judgeFeedbacks: null,
+    judgeStats: null,
+  },
+};

--- a/src/app/sysAdmin/system/templates/[variant]/page.tsx
+++ b/src/app/sysAdmin/system/templates/[variant]/page.tsx
@@ -1,0 +1,80 @@
+import { notFound } from "next/navigation";
+import { fetchTemplateBreakdownServer } from "@/app/sysAdmin/_shared/server/fetchTemplateBreakdown";
+import {
+  fetchActiveGenerationTemplateServer,
+  fetchActiveJudgeTemplateServer,
+} from "@/app/sysAdmin/_shared/server/fetchActiveTemplate";
+import { fetchAdminTemplateFeedbacksServer } from "@/app/sysAdmin/_shared/server/fetchAdminTemplateFeedbacks";
+import { fetchAdminTemplateFeedbackStatsServer } from "@/app/sysAdmin/_shared/server/fetchAdminTemplateFeedbackStats";
+import { GqlReportTemplateKind } from "@/types/graphql";
+import { slugToVariant } from "@/app/sysAdmin/features/system/templates/shared/variantSlug";
+import { SysAdminTemplateDetailPageClient } from "./SysAdminTemplateDetailPageClient";
+
+type PageProps = {
+  params: Promise<{ variant: string }>;
+};
+
+/**
+ * テンプレート variant 詳細。
+ *
+ * GENERATION / JUDGE 各 breakdown + active template + feedback 1 ページ目 +
+ * feedback stats (avgRating / 件数 / 分布) を SSR + cookie で取得して
+ * client へ渡す。client-side fetch は auth race
+ * (`IsAdmin authorization FAILED`) の原因になるため SSR に統一。
+ *
+ * stats の引数は list と同じ filter object (`variant` / `kind`) から流す。
+ * `feedbackType` / `maxRating` は stats 側にあえて含めない (= 母集団の分布)。
+ */
+export default async function SysAdminSystemTemplateDetailPage({
+  params,
+}: PageProps) {
+  const { variant: slug } = await params;
+  const variant = slugToVariant(slug);
+  if (!variant) notFound();
+
+  const [
+    generationBreakdownRows,
+    judgeBreakdownRows,
+    generationTemplate,
+    judgeTemplate,
+    generationFeedbacks,
+    judgeFeedbacks,
+    generationStats,
+    judgeStats,
+  ] = await Promise.all([
+    fetchTemplateBreakdownServer(variant, GqlReportTemplateKind.Generation),
+    fetchTemplateBreakdownServer(variant, GqlReportTemplateKind.Judge),
+    fetchActiveGenerationTemplateServer(variant),
+    fetchActiveJudgeTemplateServer(variant),
+    fetchAdminTemplateFeedbacksServer({
+      variant,
+      kind: GqlReportTemplateKind.Generation,
+    }),
+    fetchAdminTemplateFeedbacksServer({
+      variant,
+      kind: GqlReportTemplateKind.Judge,
+    }),
+    fetchAdminTemplateFeedbackStatsServer({
+      variant,
+      kind: GqlReportTemplateKind.Generation,
+    }),
+    fetchAdminTemplateFeedbackStatsServer({
+      variant,
+      kind: GqlReportTemplateKind.Judge,
+    }),
+  ]);
+
+  return (
+    <SysAdminTemplateDetailPageClient
+      variant={variant}
+      generationBreakdownRows={generationBreakdownRows}
+      generationTemplate={generationTemplate}
+      generationFeedbacks={generationFeedbacks}
+      generationStats={generationStats}
+      judgeBreakdownRows={judgeBreakdownRows}
+      judgeTemplate={judgeTemplate}
+      judgeFeedbacks={judgeFeedbacks}
+      judgeStats={judgeStats}
+    />
+  );
+}

--- a/src/app/sysAdmin/system/templates/page.stories.tsx
+++ b/src/app/sysAdmin/system/templates/page.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { withApollo, withPageShell } from "../../../../../.storybook/decorators";
+import { mockBreakdown } from "@/app/sysAdmin/features/system/templates/shared/fixtures";
+import { aggregateVariantSummary } from "@/app/sysAdmin/features/system/templates/shared/aggregate";
+import { SUPPORTED_VARIANTS } from "@/app/sysAdmin/features/system/templates/shared/variantSlug";
+import { GqlReportVariant } from "@/types/graphql";
+import { SysAdminSystemTemplatesPageClient } from "./SysAdminSystemTemplatesPageClient";
+
+const meta: Meta<typeof SysAdminSystemTemplatesPageClient> = {
+  title: "SysAdmin/Pages/SystemTemplatesList",
+  component: SysAdminSystemTemplatesPageClient,
+  parameters: { layout: "fullscreen" },
+  decorators: [withPageShell, withApollo],
+};
+
+export default meta;
+type Story = StoryObj<typeof SysAdminSystemTemplatesPageClient>;
+
+const summaries = SUPPORTED_VARIANTS.map((variant) =>
+  aggregateVariantSummary(variant, mockBreakdown(variant)),
+);
+
+export const WithItems: Story = {
+  args: { summaries },
+};
+
+export const Empty: Story = {
+  args: {
+    summaries: SUPPORTED_VARIANTS.map((variant) => ({
+      variant,
+      currentVersion: 0,
+      activeTemplateCount: 0,
+      totalFeedbackCount: 0,
+      weightedAvgRating: null,
+      hasWarning: false,
+    })),
+  },
+};
+
+export const WithWarnings: Story = {
+  args: {
+    summaries: SUPPORTED_VARIANTS.map((variant, i) =>
+      i === 1 || i === 2
+        ? {
+            variant: variant as GqlReportVariant,
+            currentVersion: 2,
+            activeTemplateCount: 1,
+            totalFeedbackCount: 84,
+            weightedAvgRating: 3.6,
+            hasWarning: true,
+          }
+        : aggregateVariantSummary(variant, mockBreakdown(variant)),
+    ),
+  },
+};

--- a/src/app/sysAdmin/system/templates/page.tsx
+++ b/src/app/sysAdmin/system/templates/page.tsx
@@ -1,0 +1,27 @@
+import { fetchTemplateBreakdownServer } from "@/app/sysAdmin/_shared/server/fetchTemplateBreakdown";
+import { GqlReportTemplateKind } from "@/types/graphql";
+import { aggregateVariantSummary } from "@/app/sysAdmin/features/system/templates/shared/aggregate";
+import { SUPPORTED_VARIANTS } from "@/app/sysAdmin/features/system/templates/shared/variantSlug";
+import { SysAdminSystemTemplatesPageClient } from "./SysAdminSystemTemplatesPageClient";
+
+/**
+ * テンプレート一覧。GENERATION 4 variant のみ表示する。
+ * JUDGE は variant 詳細ページの [評価用] タブから確認する。
+ *
+ * SSR + cookie で breakdown を取得し client へ summaries として渡す。
+ * client-side fetch は auth race (`IsAdmin authorization FAILED`) の
+ * 原因になるため SSR に統一。
+ */
+export default async function SysAdminSystemTemplatesPage() {
+  const generationRowsByVariant = await Promise.all(
+    SUPPORTED_VARIANTS.map((variant) =>
+      fetchTemplateBreakdownServer(variant, GqlReportTemplateKind.Generation),
+    ),
+  );
+
+  const summaries = SUPPORTED_VARIANTS.map((variant, i) =>
+    aggregateVariantSummary(variant, generationRowsByVariant[i]),
+  );
+
+  return <SysAdminSystemTemplatesPageClient summaries={summaries} />;
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+));
+Alert.displayName = "Alert";
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+AlertTitle.displayName = "AlertTitle";
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+));
+AlertDescription.displayName = "AlertDescription";
+
+export { Alert, AlertTitle, AlertDescription };

--- a/src/graphql/account/adminReports/fragment.ts
+++ b/src/graphql/account/adminReports/fragment.ts
@@ -1,0 +1,33 @@
+import { gql } from "@apollo/client";
+
+export const ADMIN_REPORT_SUMMARY_ROW_FRAGMENT = gql`
+  fragment AdminReportSummaryRowFields on AdminReportSummaryRow {
+    community {
+      id
+      name
+    }
+    lastPublishedReport {
+      id
+      variant
+      status
+      publishedAt
+    }
+    lastPublishedAt
+    daysSinceLastPublish
+    publishedCountLast90Days
+  }
+`;
+
+export const ADMIN_BROWSE_REPORT_FIELDS = gql`
+  fragment AdminBrowseReportFields on Report {
+    id
+    variant
+    status
+    publishedAt
+    createdAt
+    community {
+      id
+      name
+    }
+  }
+`;

--- a/src/graphql/account/adminReports/query.ts
+++ b/src/graphql/account/adminReports/query.ts
@@ -1,0 +1,59 @@
+import { gql } from "@apollo/client";
+import {
+  ADMIN_BROWSE_REPORT_FIELDS,
+  ADMIN_REPORT_SUMMARY_ROW_FRAGMENT,
+} from "./fragment";
+
+export const GET_ADMIN_BROWSE_REPORTS = gql`
+  query GetAdminBrowseReports(
+    $communityId: ID
+    $status: ReportStatus
+    $variant: ReportVariant
+    $publishedAfter: Datetime
+    $publishedBefore: Datetime
+    $cursor: String
+    $first: Int
+  ) {
+    adminBrowseReports(
+      communityId: $communityId
+      status: $status
+      variant: $variant
+      publishedAfter: $publishedAfter
+      publishedBefore: $publishedBefore
+      cursor: $cursor
+      first: $first
+    ) {
+      edges {
+        cursor
+        node {
+          ...AdminBrowseReportFields
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+    }
+  }
+  ${ADMIN_BROWSE_REPORT_FIELDS}
+`;
+
+export const GET_ADMIN_REPORT_SUMMARY = gql`
+  query GetAdminReportSummary($cursor: String, $first: Int) {
+    adminReportSummary(cursor: $cursor, first: $first) {
+      edges {
+        cursor
+        node {
+          ...AdminReportSummaryRowFields
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+    }
+  }
+  ${ADMIN_REPORT_SUMMARY_ROW_FRAGMENT}
+`;

--- a/src/graphql/account/adminReports/server.ts
+++ b/src/graphql/account/adminReports/server.ts
@@ -1,0 +1,11 @@
+import { addTypenameToDocument } from "@apollo/client/utilities";
+import { print } from "graphql/language/printer";
+import { GetAdminBrowseReportsDocument } from "@/types/graphql";
+
+/**
+ * adminReports 用 server-side string query。
+ * 詳細は `graphql/account/sysAdmin/server.ts` のコメント参照。
+ */
+export const GET_ADMIN_BROWSE_REPORTS_SERVER_QUERY = print(
+  addTypenameToDocument(GetAdminBrowseReportsDocument),
+);

--- a/src/graphql/account/adminTemplateFeedbacks/query.ts
+++ b/src/graphql/account/adminTemplateFeedbacks/query.ts
@@ -1,0 +1,74 @@
+import { gql } from "@apollo/client";
+import {
+  REPORT_FEEDBACK_FIELDS,
+  REPORT_FEEDBACK_WITH_REPORT_FIELDS,
+} from "../reportFeedback/fragment";
+
+/**
+ * テンプレ詳細の feedback feed 用 query。
+ * variant + version + kind で絞り込み、各 feedback には `report` を含めて
+ * card から元のレポートへ飛べるようにする。
+ */
+export const GET_ADMIN_TEMPLATE_FEEDBACKS = gql`
+  query GetAdminTemplateFeedbacks(
+    $variant: ReportVariant!
+    $version: Int
+    $kind: ReportTemplateKind
+    $feedbackType: ReportFeedbackType
+    $maxRating: Int
+    $cursor: String
+    $first: Int
+  ) {
+    adminTemplateFeedbacks(
+      variant: $variant
+      version: $version
+      kind: $kind
+      feedbackType: $feedbackType
+      maxRating: $maxRating
+      cursor: $cursor
+      first: $first
+    ) {
+      edges {
+        cursor
+        node {
+          ...ReportFeedbackWithReportFields
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+    }
+  }
+  ${REPORT_FEEDBACK_WITH_REPORT_FIELDS}
+  ${REPORT_FEEDBACK_FIELDS}
+`;
+
+/**
+ * テンプレ詳細の summary (avgRating / 件数 / rating 分布) 用 query。
+ *
+ * `adminTemplateFeedbacks` (list) と引数を揃えてあるので、frontend 側で
+ * 1 つの filter object から両方に流せる。`feedbackType` / `maxRating` は
+ * stats 側にはあえて含めない (= 母集団の分布を出す)。
+ */
+export const GET_ADMIN_TEMPLATE_FEEDBACK_STATS = gql`
+  query GetAdminTemplateFeedbackStats(
+    $variant: ReportVariant!
+    $version: Int
+    $kind: ReportTemplateKind
+  ) {
+    adminTemplateFeedbackStats(
+      variant: $variant
+      version: $version
+      kind: $kind
+    ) {
+      totalCount
+      avgRating
+      ratingDistribution {
+        rating
+        count
+      }
+    }
+  }
+`;

--- a/src/graphql/account/adminTemplateFeedbacks/server.ts
+++ b/src/graphql/account/adminTemplateFeedbacks/server.ts
@@ -1,0 +1,18 @@
+import { addTypenameToDocument } from "@apollo/client/utilities";
+import { print } from "graphql/language/printer";
+import {
+  GetAdminTemplateFeedbackStatsDocument,
+  GetAdminTemplateFeedbacksDocument,
+} from "@/types/graphql";
+
+/**
+ * adminTemplateFeedbacks の SSR 用 string query。
+ * 詳細は `graphql/account/sysAdmin/server.ts` のコメント参照。
+ */
+export const GET_ADMIN_TEMPLATE_FEEDBACKS_SERVER_QUERY = print(
+  addTypenameToDocument(GetAdminTemplateFeedbacksDocument),
+);
+
+export const GET_ADMIN_TEMPLATE_FEEDBACK_STATS_SERVER_QUERY = print(
+  addTypenameToDocument(GetAdminTemplateFeedbackStatsDocument),
+);

--- a/src/graphql/account/report/fragment.ts
+++ b/src/graphql/account/report/fragment.ts
@@ -1,0 +1,52 @@
+import { gql } from "@apollo/client";
+import { REPORT_FEEDBACK_FIELDS } from "../reportFeedback/fragment";
+
+/**
+ * Report detail page 用の詳細 fragment。
+ *
+ * 一覧用の `AdminBrowseReportFields` に対し、本文 + 期間 + テンプレリンク +
+ * currentUser (= sysAdmin) の自分の feedback を含む。
+ *
+ * `myFeedback` は admin が代行投稿した最新の自分の feedback。
+ * 投稿フォームの初期値や「投稿済み」表示の判定に使う。
+ */
+export const ADMIN_REPORT_DETAIL_FIELDS = gql`
+  fragment AdminReportDetailFields on Report {
+    id
+    variant
+    status
+    publishedAt
+    createdAt
+    updatedAt
+    periodFrom
+    periodTo
+    outputMarkdown
+    finalContent
+    skipReason
+    regenerateCount
+    community {
+      id
+      name
+    }
+    template {
+      id
+      variant
+      version
+      kind
+      experimentKey
+      trafficWeight
+    }
+    generatedByUser {
+      id
+      name
+    }
+    publishedByUser {
+      id
+      name
+    }
+    myFeedback {
+      ...ReportFeedbackFields
+    }
+  }
+  ${REPORT_FEEDBACK_FIELDS}
+`;

--- a/src/graphql/account/report/mutation.ts
+++ b/src/graphql/account/report/mutation.ts
@@ -1,0 +1,24 @@
+import { gql } from "@apollo/client";
+import { REPORT_FEEDBACK_FIELDS } from "../reportFeedback/fragment";
+
+/**
+ * Report detail page から admin が代行で投稿する feedback。
+ * permission は `CheckCommunityPermissionInput` (community owner 必須)、
+ * sysAdmin は全 community のオーナーなので任意の community のレポートに
+ * 投稿可能。
+ */
+export const SUBMIT_REPORT_FEEDBACK = gql`
+  mutation SubmitReportFeedback(
+    $input: SubmitReportFeedbackInput!
+    $permission: CheckCommunityPermissionInput!
+  ) {
+    submitReportFeedback(input: $input, permission: $permission) {
+      ... on SubmitReportFeedbackSuccess {
+        feedback {
+          ...ReportFeedbackFields
+        }
+      }
+    }
+  }
+  ${REPORT_FEEDBACK_FIELDS}
+`;

--- a/src/graphql/account/report/query.ts
+++ b/src/graphql/account/report/query.ts
@@ -1,0 +1,44 @@
+import { gql } from "@apollo/client";
+import { ADMIN_REPORT_DETAIL_FIELDS } from "./fragment";
+import { REPORT_FEEDBACK_FIELDS } from "../reportFeedback/fragment";
+
+/**
+ * Report detail page 用に Report 単票を取得する query。
+ * sysAdmin はすべての community のオーナー扱いなので `report(id)` で
+ * 任意のコミュニティのレポートにアクセスできる。
+ */
+export const GET_ADMIN_REPORT = gql`
+  query GetAdminReport($id: ID!) {
+    report(id: $id) {
+      ...AdminReportDetailFields
+    }
+  }
+  ${ADMIN_REPORT_DETAIL_FIELDS}
+`;
+
+/**
+ * Report detail page で「このレポートに付けられた feedback 一覧」を
+ * cursor pagination で取得する query。
+ * 投稿フォームから submit 後の cache 更新用にも使う。
+ */
+export const GET_ADMIN_REPORT_FEEDBACKS = gql`
+  query GetAdminReportFeedbacks($id: ID!, $cursor: String, $first: Int) {
+    report(id: $id) {
+      id
+      feedbacks(after: $cursor, first: $first) {
+        edges {
+          cursor
+          node {
+            ...ReportFeedbackFields
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        totalCount
+      }
+    }
+  }
+  ${REPORT_FEEDBACK_FIELDS}
+`;

--- a/src/graphql/account/report/server.ts
+++ b/src/graphql/account/report/server.ts
@@ -1,0 +1,23 @@
+import { addTypenameToDocument } from "@apollo/client/utilities";
+import { print } from "graphql/language/printer";
+import {
+  GetAdminReportDocument,
+  GetAdminReportFeedbacksDocument,
+} from "@/types/graphql";
+
+/**
+ * Report detail page 用の SSR 用 string query。
+ * 詳細は `graphql/account/sysAdmin/server.ts` のコメント参照。
+ *
+ * Report 単票と feedbacks Connection は分離してある。
+ * 同じ document に nested で持たせると Apollo Armor の cost limit を
+ * 超過するため (1 root call につき高い weight が乗る)、独立 query にして
+ * SSR でも並行で叩く。
+ */
+export const GET_ADMIN_REPORT_SERVER_QUERY = print(
+  addTypenameToDocument(GetAdminReportDocument),
+);
+
+export const GET_ADMIN_REPORT_FEEDBACKS_SERVER_QUERY = print(
+  addTypenameToDocument(GetAdminReportFeedbacksDocument),
+);

--- a/src/graphql/account/reportFeedback/fragment.ts
+++ b/src/graphql/account/reportFeedback/fragment.ts
@@ -1,0 +1,45 @@
+import { gql } from "@apollo/client";
+
+/**
+ * `ReportFeedback` の基本 fragment。
+ * レポート detail / フィードバック投稿後の payload など、
+ * Report との関連を辿らない文脈で使う。
+ */
+export const REPORT_FEEDBACK_FIELDS = gql`
+  fragment ReportFeedbackFields on ReportFeedback {
+    id
+    rating
+    comment
+    feedbackType
+    sectionKey
+    createdAt
+    user {
+      id
+      name
+    }
+  }
+`;
+
+/**
+ * テンプレ詳細の feedback feed 用拡張版。
+ * 各 feedback の card から Report detail に飛ぶための link 情報
+ * (community / variant / 期間) を含む。
+ *
+ * `ReportFeedback.report` field は backend Phase 1.5 で追加済み。
+ */
+export const REPORT_FEEDBACK_WITH_REPORT_FIELDS = gql`
+  fragment ReportFeedbackWithReportFields on ReportFeedback {
+    ...ReportFeedbackFields
+    report {
+      id
+      variant
+      periodFrom
+      periodTo
+      community {
+        id
+        name
+      }
+    }
+  }
+  ${REPORT_FEEDBACK_FIELDS}
+`;

--- a/src/graphql/account/reportTemplate/fragment.ts
+++ b/src/graphql/account/reportTemplate/fragment.ts
@@ -1,0 +1,62 @@
+import { gql } from "@apollo/client";
+
+export const REPORT_TEMPLATE_FRAGMENT = gql`
+  fragment ReportTemplateFields on ReportTemplate {
+    id
+    variant
+    version
+    scope
+    kind
+    model
+    maxTokens
+    temperature
+    systemPrompt
+    userPromptTemplate
+    stopSequences
+    trafficWeight
+    isActive
+    isEnabled
+    experimentKey
+    communityContext
+    createdAt
+    updatedAt
+    community {
+      id
+      name
+    }
+    updatedByUser {
+      id
+      name
+    }
+  }
+`;
+
+export const REPORT_TEMPLATE_STATS_FRAGMENT = gql`
+  fragment ReportTemplateStatsFields on ReportTemplateStats {
+    variant
+    version
+    feedbackCount
+    avgRating
+    avgJudgeScore
+    judgeHumanCorrelation
+    correlationWarning
+  }
+`;
+
+export const REPORT_TEMPLATE_STATS_BREAKDOWN_ROW_FRAGMENT = gql`
+  fragment ReportTemplateStatsBreakdownRowFields on ReportTemplateStatsBreakdownRow {
+    templateId
+    version
+    scope
+    kind
+    experimentKey
+    isActive
+    isEnabled
+    trafficWeight
+    feedbackCount
+    avgRating
+    avgJudgeScore
+    judgeHumanCorrelation
+    correlationWarning
+  }
+`;

--- a/src/graphql/account/reportTemplate/mutation.ts
+++ b/src/graphql/account/reportTemplate/mutation.ts
@@ -1,0 +1,23 @@
+import { gql } from "@apollo/client";
+import { REPORT_TEMPLATE_FRAGMENT } from "./fragment";
+
+export const UPDATE_REPORT_TEMPLATE = gql`
+  mutation UpdateReportTemplate(
+    $variant: ReportVariant!
+    $input: UpdateReportTemplateInput!
+    $communityId: ID
+  ) {
+    updateReportTemplate(
+      variant: $variant
+      input: $input
+      communityId: $communityId
+    ) {
+      ... on UpdateReportTemplateSuccess {
+        reportTemplate {
+          ...ReportTemplateFields
+        }
+      }
+    }
+  }
+  ${REPORT_TEMPLATE_FRAGMENT}
+`;

--- a/src/graphql/account/reportTemplate/query.ts
+++ b/src/graphql/account/reportTemplate/query.ts
@@ -1,0 +1,77 @@
+import { gql } from "@apollo/client";
+import {
+  REPORT_TEMPLATE_FRAGMENT,
+  REPORT_TEMPLATE_STATS_BREAKDOWN_ROW_FRAGMENT,
+  REPORT_TEMPLATE_STATS_FRAGMENT,
+} from "./fragment";
+
+export const GET_REPORT_TEMPLATE = gql`
+  query GetReportTemplate($variant: ReportVariant!, $communityId: ID) {
+    reportTemplate(variant: $variant, communityId: $communityId) {
+      ...ReportTemplateFields
+    }
+  }
+  ${REPORT_TEMPLATE_FRAGMENT}
+`;
+
+export const GET_REPORT_TEMPLATE_STATS = gql`
+  query GetReportTemplateStats($variant: ReportVariant!, $version: Int) {
+    reportTemplateStats(variant: $variant, version: $version) {
+      ...ReportTemplateStatsFields
+    }
+  }
+  ${REPORT_TEMPLATE_STATS_FRAGMENT}
+`;
+
+export const GET_REPORT_TEMPLATES = gql`
+  query GetReportTemplates(
+    $variant: ReportVariant!
+    $communityId: ID
+    $kind: ReportTemplateKind
+    $includeInactive: Boolean
+  ) {
+    reportTemplates(
+      variant: $variant
+      communityId: $communityId
+      kind: $kind
+      includeInactive: $includeInactive
+    ) {
+      ...ReportTemplateFields
+    }
+  }
+  ${REPORT_TEMPLATE_FRAGMENT}
+`;
+
+export const GET_REPORT_TEMPLATE_STATS_BREAKDOWN = gql`
+  query GetReportTemplateStatsBreakdown(
+    $variant: ReportVariant!
+    $version: Int
+    $kind: ReportTemplateKind
+    $includeInactive: Boolean
+    $cursor: String
+    $first: Int
+  ) {
+    reportTemplateStatsBreakdown(
+      variant: $variant
+      version: $version
+      kind: $kind
+      includeInactive: $includeInactive
+      cursor: $cursor
+      first: $first
+    ) {
+      edges {
+        cursor
+        node {
+          ...ReportTemplateStatsBreakdownRowFields
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+    }
+  }
+  ${REPORT_TEMPLATE_STATS_BREAKDOWN_ROW_FRAGMENT}
+`;
+

--- a/src/graphql/account/reportTemplate/server.ts
+++ b/src/graphql/account/reportTemplate/server.ts
@@ -1,0 +1,28 @@
+import { addTypenameToDocument } from "@apollo/client/utilities";
+import { print } from "graphql/language/printer";
+import {
+  GetReportTemplateDocument,
+  GetReportTemplateStatsBreakdownDocument,
+  GetReportTemplateStatsDocument,
+  GetReportTemplatesDocument,
+} from "@/types/graphql";
+
+/**
+ * reportTemplate 系 server-side string query。
+ * 詳細は `graphql/account/sysAdmin/server.ts` のコメント参照。
+ */
+export const GET_REPORT_TEMPLATE_SERVER_QUERY = print(
+  addTypenameToDocument(GetReportTemplateDocument),
+);
+
+export const GET_REPORT_TEMPLATE_STATS_SERVER_QUERY = print(
+  addTypenameToDocument(GetReportTemplateStatsDocument),
+);
+
+export const GET_REPORT_TEMPLATES_SERVER_QUERY = print(
+  addTypenameToDocument(GetReportTemplatesDocument),
+);
+
+export const GET_REPORT_TEMPLATE_STATS_BREAKDOWN_SERVER_QUERY = print(
+  addTypenameToDocument(GetReportTemplateStatsBreakdownDocument),
+);

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -33,6 +33,35 @@ export type GqlAccumulatedPointView = {
   walletId?: Maybe<Scalars["String"]["output"]>;
 };
 
+export type GqlAdminReportSummaryConnection = {
+  __typename?: "AdminReportSummaryConnection";
+  edges?: Maybe<Array<Maybe<GqlAdminReportSummaryEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars["Int"]["output"];
+};
+
+export type GqlAdminReportSummaryEdge = GqlEdge & {
+  __typename?: "AdminReportSummaryEdge";
+  cursor: Scalars["String"]["output"];
+  node?: Maybe<GqlAdminReportSummaryRow>;
+};
+
+export type GqlAdminReportSummaryRow = {
+  __typename?: "AdminReportSummaryRow";
+  community: GqlCommunity;
+  daysSinceLastPublish?: Maybe<Scalars["Int"]["output"]>;
+  lastPublishedAt?: Maybe<Scalars["Datetime"]["output"]>;
+  lastPublishedReport?: Maybe<GqlReport>;
+  publishedCountLast90Days: Scalars["Int"]["output"];
+};
+
+export type GqlAdminTemplateFeedbackStats = {
+  __typename?: "AdminTemplateFeedbackStats";
+  avgRating?: Maybe<Scalars["Float"]["output"]>;
+  ratingDistribution: Array<GqlReportFeedbackRatingBucket>;
+  totalCount: Scalars["Int"]["output"];
+};
+
 export type GqlApproveReportPayload = GqlApproveReportSuccess;
 
 export type GqlApproveReportSuccess = {
@@ -2074,6 +2103,10 @@ export const GqlPublishStatus = {
 export type GqlPublishStatus = (typeof GqlPublishStatus)[keyof typeof GqlPublishStatus];
 export type GqlQuery = {
   __typename?: "Query";
+  adminBrowseReports: GqlReportsConnection;
+  adminReportSummary: GqlAdminReportSummaryConnection;
+  adminTemplateFeedbackStats: GqlAdminTemplateFeedbackStats;
+  adminTemplateFeedbacks: GqlReportFeedbacksConnection;
   article?: Maybe<GqlArticle>;
   articles: GqlArticlesConnection;
   cities: GqlCitiesConnection;
@@ -2115,6 +2148,8 @@ export type GqlQuery = {
   report?: Maybe<GqlReport>;
   reportTemplate?: Maybe<GqlReportTemplate>;
   reportTemplateStats: GqlReportTemplateStats;
+  reportTemplateStatsBreakdown: GqlReportTemplateStatsBreakdownConnection;
+  reportTemplates: Array<GqlReportTemplate>;
   reports: GqlReportsConnection;
   reservation?: Maybe<GqlReservation>;
   reservationHistories: GqlReservationHistoriesConnection;
@@ -2170,6 +2205,37 @@ export type GqlQuery = {
   voteTopics: GqlVoteTopicsConnection;
   wallet?: Maybe<GqlWallet>;
   wallets: GqlWalletsConnection;
+};
+
+export type GqlQueryAdminBrowseReportsArgs = {
+  communityId?: InputMaybe<Scalars["ID"]["input"]>;
+  cursor?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  publishedAfter?: InputMaybe<Scalars["Datetime"]["input"]>;
+  publishedBefore?: InputMaybe<Scalars["Datetime"]["input"]>;
+  status?: InputMaybe<GqlReportStatus>;
+  variant?: InputMaybe<GqlReportVariant>;
+};
+
+export type GqlQueryAdminReportSummaryArgs = {
+  cursor?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
+export type GqlQueryAdminTemplateFeedbackStatsArgs = {
+  kind?: InputMaybe<GqlReportTemplateKind>;
+  variant: GqlReportVariant;
+  version?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
+export type GqlQueryAdminTemplateFeedbacksArgs = {
+  cursor?: InputMaybe<Scalars["String"]["input"]>;
+  feedbackType?: InputMaybe<GqlReportFeedbackType>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  kind?: InputMaybe<GqlReportTemplateKind>;
+  maxRating?: InputMaybe<Scalars["Int"]["input"]>;
+  variant: GqlReportVariant;
+  version?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type GqlQueryArticleArgs = {
@@ -2351,6 +2417,22 @@ export type GqlQueryReportTemplateArgs = {
 export type GqlQueryReportTemplateStatsArgs = {
   variant: GqlReportVariant;
   version?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
+export type GqlQueryReportTemplateStatsBreakdownArgs = {
+  cursor?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  includeInactive?: InputMaybe<Scalars["Boolean"]["input"]>;
+  kind?: InputMaybe<GqlReportTemplateKind>;
+  variant: GqlReportVariant;
+  version?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
+export type GqlQueryReportTemplatesArgs = {
+  communityId?: InputMaybe<Scalars["ID"]["input"]>;
+  includeInactive?: InputMaybe<Scalars["Boolean"]["input"]>;
+  kind?: InputMaybe<GqlReportTemplateKind>;
+  variant: GqlReportVariant;
 };
 
 export type GqlQueryReportsArgs = {
@@ -2570,6 +2652,7 @@ export type GqlReportFeedback = {
   feedbackType?: Maybe<GqlReportFeedbackType>;
   id: Scalars["ID"]["output"];
   rating: Scalars["Int"]["output"];
+  report: GqlReport;
   reportId: Scalars["ID"]["output"];
   sectionKey?: Maybe<Scalars["String"]["output"]>;
   user: GqlUser;
@@ -2579,6 +2662,12 @@ export type GqlReportFeedbackEdge = GqlEdge & {
   __typename?: "ReportFeedbackEdge";
   cursor: Scalars["String"]["output"];
   node?: Maybe<GqlReportFeedback>;
+};
+
+export type GqlReportFeedbackRatingBucket = {
+  __typename?: "ReportFeedbackRatingBucket";
+  count: Scalars["Int"]["output"];
+  rating: Scalars["Int"]["output"];
 };
 
 export const GqlReportFeedbackType = {
@@ -2617,6 +2706,7 @@ export type GqlReportTemplate = {
   id: Scalars["ID"]["output"];
   isActive: Scalars["Boolean"]["output"];
   isEnabled: Scalars["Boolean"]["output"];
+  kind: GqlReportTemplateKind;
   maxTokens: Scalars["Int"]["output"];
   model: Scalars["String"]["output"];
   scope: GqlReportTemplateScope;
@@ -2631,6 +2721,13 @@ export type GqlReportTemplate = {
   version: Scalars["Int"]["output"];
 };
 
+export const GqlReportTemplateKind = {
+  Generation: "GENERATION",
+  Judge: "JUDGE",
+} as const;
+
+export type GqlReportTemplateKind =
+  (typeof GqlReportTemplateKind)[keyof typeof GqlReportTemplateKind];
 export const GqlReportTemplateScope = {
   Community: "COMMUNITY",
   System: "SYSTEM",
@@ -2647,6 +2744,36 @@ export type GqlReportTemplateStats = {
   judgeHumanCorrelation?: Maybe<Scalars["Float"]["output"]>;
   variant: GqlReportVariant;
   version?: Maybe<Scalars["Int"]["output"]>;
+};
+
+export type GqlReportTemplateStatsBreakdownConnection = {
+  __typename?: "ReportTemplateStatsBreakdownConnection";
+  edges?: Maybe<Array<Maybe<GqlReportTemplateStatsBreakdownEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars["Int"]["output"];
+};
+
+export type GqlReportTemplateStatsBreakdownEdge = GqlEdge & {
+  __typename?: "ReportTemplateStatsBreakdownEdge";
+  cursor: Scalars["String"]["output"];
+  node?: Maybe<GqlReportTemplateStatsBreakdownRow>;
+};
+
+export type GqlReportTemplateStatsBreakdownRow = {
+  __typename?: "ReportTemplateStatsBreakdownRow";
+  avgJudgeScore?: Maybe<Scalars["Float"]["output"]>;
+  avgRating?: Maybe<Scalars["Float"]["output"]>;
+  correlationWarning: Scalars["Boolean"]["output"];
+  experimentKey?: Maybe<Scalars["String"]["output"]>;
+  feedbackCount: Scalars["Int"]["output"];
+  isActive: Scalars["Boolean"]["output"];
+  isEnabled: Scalars["Boolean"]["output"];
+  judgeHumanCorrelation?: Maybe<Scalars["Float"]["output"]>;
+  kind: GqlReportTemplateKind;
+  scope: GqlReportTemplateScope;
+  templateId: Scalars["ID"]["output"];
+  trafficWeight: Scalars["Int"]["output"];
+  version: Scalars["Int"]["output"];
 };
 
 export const GqlReportVariant = {
@@ -5029,6 +5156,156 @@ export type GqlGetCitiesQuery = {
   };
 };
 
+export type GqlAdminReportSummaryRowFieldsFragment = {
+  __typename?: "AdminReportSummaryRow";
+  lastPublishedAt?: Date | null;
+  daysSinceLastPublish?: number | null;
+  publishedCountLast90Days: number;
+  community: { __typename?: "Community"; id: string; name?: string | null };
+  lastPublishedReport?: {
+    __typename?: "Report";
+    id: string;
+    variant: GqlReportVariant;
+    status: GqlReportStatus;
+    publishedAt?: Date | null;
+  } | null;
+};
+
+export type GqlAdminBrowseReportFieldsFragment = {
+  __typename?: "Report";
+  id: string;
+  variant: GqlReportVariant;
+  status: GqlReportStatus;
+  publishedAt?: Date | null;
+  createdAt: Date;
+  community: { __typename?: "Community"; id: string; name?: string | null };
+};
+
+export type GqlGetAdminBrowseReportsQueryVariables = Exact<{
+  communityId?: InputMaybe<Scalars["ID"]["input"]>;
+  status?: InputMaybe<GqlReportStatus>;
+  variant?: InputMaybe<GqlReportVariant>;
+  publishedAfter?: InputMaybe<Scalars["Datetime"]["input"]>;
+  publishedBefore?: InputMaybe<Scalars["Datetime"]["input"]>;
+  cursor?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+}>;
+
+export type GqlGetAdminBrowseReportsQuery = {
+  __typename?: "Query";
+  adminBrowseReports: {
+    __typename?: "ReportsConnection";
+    totalCount: number;
+    edges?: Array<{
+      __typename?: "ReportEdge";
+      cursor: string;
+      node?: {
+        __typename?: "Report";
+        id: string;
+        variant: GqlReportVariant;
+        status: GqlReportStatus;
+        publishedAt?: Date | null;
+        createdAt: Date;
+        community: { __typename?: "Community"; id: string; name?: string | null };
+      } | null;
+    } | null> | null;
+    pageInfo: { __typename?: "PageInfo"; hasNextPage: boolean; endCursor?: string | null };
+  };
+};
+
+export type GqlGetAdminReportSummaryQueryVariables = Exact<{
+  cursor?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+}>;
+
+export type GqlGetAdminReportSummaryQuery = {
+  __typename?: "Query";
+  adminReportSummary: {
+    __typename?: "AdminReportSummaryConnection";
+    totalCount: number;
+    edges?: Array<{
+      __typename?: "AdminReportSummaryEdge";
+      cursor: string;
+      node?: {
+        __typename?: "AdminReportSummaryRow";
+        lastPublishedAt?: Date | null;
+        daysSinceLastPublish?: number | null;
+        publishedCountLast90Days: number;
+        community: { __typename?: "Community"; id: string; name?: string | null };
+        lastPublishedReport?: {
+          __typename?: "Report";
+          id: string;
+          variant: GqlReportVariant;
+          status: GqlReportStatus;
+          publishedAt?: Date | null;
+        } | null;
+      } | null;
+    } | null> | null;
+    pageInfo: { __typename?: "PageInfo"; hasNextPage: boolean; endCursor?: string | null };
+  };
+};
+
+export type GqlGetAdminTemplateFeedbacksQueryVariables = Exact<{
+  variant: GqlReportVariant;
+  version?: InputMaybe<Scalars["Int"]["input"]>;
+  kind?: InputMaybe<GqlReportTemplateKind>;
+  feedbackType?: InputMaybe<GqlReportFeedbackType>;
+  maxRating?: InputMaybe<Scalars["Int"]["input"]>;
+  cursor?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+}>;
+
+export type GqlGetAdminTemplateFeedbacksQuery = {
+  __typename?: "Query";
+  adminTemplateFeedbacks: {
+    __typename?: "ReportFeedbacksConnection";
+    totalCount: number;
+    edges?: Array<{
+      __typename?: "ReportFeedbackEdge";
+      cursor: string;
+      node?: {
+        __typename?: "ReportFeedback";
+        id: string;
+        rating: number;
+        comment?: string | null;
+        feedbackType?: GqlReportFeedbackType | null;
+        sectionKey?: string | null;
+        createdAt: Date;
+        report: {
+          __typename?: "Report";
+          id: string;
+          variant: GqlReportVariant;
+          periodFrom: Date;
+          periodTo: Date;
+          community: { __typename?: "Community"; id: string; name?: string | null };
+        };
+        user: { __typename?: "User"; id: string; name: string };
+      } | null;
+    } | null> | null;
+    pageInfo: { __typename?: "PageInfo"; hasNextPage: boolean; endCursor?: string | null };
+  };
+};
+
+export type GqlGetAdminTemplateFeedbackStatsQueryVariables = Exact<{
+  variant: GqlReportVariant;
+  version?: InputMaybe<Scalars["Int"]["input"]>;
+  kind?: InputMaybe<GqlReportTemplateKind>;
+}>;
+
+export type GqlGetAdminTemplateFeedbackStatsQuery = {
+  __typename?: "Query";
+  adminTemplateFeedbackStats: {
+    __typename?: "AdminTemplateFeedbackStats";
+    totalCount: number;
+    avgRating?: number | null;
+    ratingDistribution: Array<{
+      __typename?: "ReportFeedbackRatingBucket";
+      rating: number;
+      count: number;
+    }>;
+  };
+};
+
 export type GqlCommunityFieldsFragment = {
   __typename?: "Community";
   id: string;
@@ -5642,6 +5919,385 @@ export type GqlGetNftInstanceWithDidQuery = {
       };
     } | null;
   } | null;
+};
+
+export type GqlAdminReportDetailFieldsFragment = {
+  __typename?: "Report";
+  id: string;
+  variant: GqlReportVariant;
+  status: GqlReportStatus;
+  publishedAt?: Date | null;
+  createdAt: Date;
+  updatedAt?: Date | null;
+  periodFrom: Date;
+  periodTo: Date;
+  outputMarkdown?: string | null;
+  finalContent?: string | null;
+  skipReason?: string | null;
+  regenerateCount: number;
+  community: { __typename?: "Community"; id: string; name?: string | null };
+  template?: {
+    __typename?: "ReportTemplate";
+    id: string;
+    variant: GqlReportVariant;
+    version: number;
+    kind: GqlReportTemplateKind;
+    experimentKey?: string | null;
+    trafficWeight: number;
+  } | null;
+  generatedByUser?: { __typename?: "User"; id: string; name: string } | null;
+  publishedByUser?: { __typename?: "User"; id: string; name: string } | null;
+  myFeedback?: {
+    __typename?: "ReportFeedback";
+    id: string;
+    rating: number;
+    comment?: string | null;
+    feedbackType?: GqlReportFeedbackType | null;
+    sectionKey?: string | null;
+    createdAt: Date;
+    user: { __typename?: "User"; id: string; name: string };
+  } | null;
+};
+
+export type GqlSubmitReportFeedbackMutationVariables = Exact<{
+  input: GqlSubmitReportFeedbackInput;
+  permission: GqlCheckCommunityPermissionInput;
+}>;
+
+export type GqlSubmitReportFeedbackMutation = {
+  __typename?: "Mutation";
+  submitReportFeedback?: {
+    __typename?: "SubmitReportFeedbackSuccess";
+    feedback: {
+      __typename?: "ReportFeedback";
+      id: string;
+      rating: number;
+      comment?: string | null;
+      feedbackType?: GqlReportFeedbackType | null;
+      sectionKey?: string | null;
+      createdAt: Date;
+      user: { __typename?: "User"; id: string; name: string };
+    };
+  } | null;
+};
+
+export type GqlGetAdminReportQueryVariables = Exact<{
+  id: Scalars["ID"]["input"];
+}>;
+
+export type GqlGetAdminReportQuery = {
+  __typename?: "Query";
+  report?: {
+    __typename?: "Report";
+    id: string;
+    variant: GqlReportVariant;
+    status: GqlReportStatus;
+    publishedAt?: Date | null;
+    createdAt: Date;
+    updatedAt?: Date | null;
+    periodFrom: Date;
+    periodTo: Date;
+    outputMarkdown?: string | null;
+    finalContent?: string | null;
+    skipReason?: string | null;
+    regenerateCount: number;
+    community: { __typename?: "Community"; id: string; name?: string | null };
+    template?: {
+      __typename?: "ReportTemplate";
+      id: string;
+      variant: GqlReportVariant;
+      version: number;
+      kind: GqlReportTemplateKind;
+      experimentKey?: string | null;
+      trafficWeight: number;
+    } | null;
+    generatedByUser?: { __typename?: "User"; id: string; name: string } | null;
+    publishedByUser?: { __typename?: "User"; id: string; name: string } | null;
+    myFeedback?: {
+      __typename?: "ReportFeedback";
+      id: string;
+      rating: number;
+      comment?: string | null;
+      feedbackType?: GqlReportFeedbackType | null;
+      sectionKey?: string | null;
+      createdAt: Date;
+      user: { __typename?: "User"; id: string; name: string };
+    } | null;
+  } | null;
+};
+
+export type GqlGetAdminReportFeedbacksQueryVariables = Exact<{
+  id: Scalars["ID"]["input"];
+  cursor?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+}>;
+
+export type GqlGetAdminReportFeedbacksQuery = {
+  __typename?: "Query";
+  report?: {
+    __typename?: "Report";
+    id: string;
+    feedbacks: {
+      __typename?: "ReportFeedbacksConnection";
+      totalCount: number;
+      edges?: Array<{
+        __typename?: "ReportFeedbackEdge";
+        cursor: string;
+        node?: {
+          __typename?: "ReportFeedback";
+          id: string;
+          rating: number;
+          comment?: string | null;
+          feedbackType?: GqlReportFeedbackType | null;
+          sectionKey?: string | null;
+          createdAt: Date;
+          user: { __typename?: "User"; id: string; name: string };
+        } | null;
+      } | null> | null;
+      pageInfo: { __typename?: "PageInfo"; hasNextPage: boolean; endCursor?: string | null };
+    };
+  } | null;
+};
+
+export type GqlReportFeedbackFieldsFragment = {
+  __typename?: "ReportFeedback";
+  id: string;
+  rating: number;
+  comment?: string | null;
+  feedbackType?: GqlReportFeedbackType | null;
+  sectionKey?: string | null;
+  createdAt: Date;
+  user: { __typename?: "User"; id: string; name: string };
+};
+
+export type GqlReportFeedbackWithReportFieldsFragment = {
+  __typename?: "ReportFeedback";
+  id: string;
+  rating: number;
+  comment?: string | null;
+  feedbackType?: GqlReportFeedbackType | null;
+  sectionKey?: string | null;
+  createdAt: Date;
+  report: {
+    __typename?: "Report";
+    id: string;
+    variant: GqlReportVariant;
+    periodFrom: Date;
+    periodTo: Date;
+    community: { __typename?: "Community"; id: string; name?: string | null };
+  };
+  user: { __typename?: "User"; id: string; name: string };
+};
+
+export type GqlReportTemplateFieldsFragment = {
+  __typename?: "ReportTemplate";
+  id: string;
+  variant: GqlReportVariant;
+  version: number;
+  scope: GqlReportTemplateScope;
+  kind: GqlReportTemplateKind;
+  model: string;
+  maxTokens: number;
+  temperature?: number | null;
+  systemPrompt: string;
+  userPromptTemplate: string;
+  stopSequences: Array<string>;
+  trafficWeight: number;
+  isActive: boolean;
+  isEnabled: boolean;
+  experimentKey?: string | null;
+  communityContext?: string | null;
+  createdAt: Date;
+  updatedAt?: Date | null;
+  community?: { __typename?: "Community"; id: string; name?: string | null } | null;
+  updatedByUser?: { __typename?: "User"; id: string; name: string } | null;
+};
+
+export type GqlReportTemplateStatsFieldsFragment = {
+  __typename?: "ReportTemplateStats";
+  variant: GqlReportVariant;
+  version?: number | null;
+  feedbackCount: number;
+  avgRating?: number | null;
+  avgJudgeScore?: number | null;
+  judgeHumanCorrelation?: number | null;
+  correlationWarning: boolean;
+};
+
+export type GqlReportTemplateStatsBreakdownRowFieldsFragment = {
+  __typename?: "ReportTemplateStatsBreakdownRow";
+  templateId: string;
+  version: number;
+  scope: GqlReportTemplateScope;
+  kind: GqlReportTemplateKind;
+  experimentKey?: string | null;
+  isActive: boolean;
+  isEnabled: boolean;
+  trafficWeight: number;
+  feedbackCount: number;
+  avgRating?: number | null;
+  avgJudgeScore?: number | null;
+  judgeHumanCorrelation?: number | null;
+  correlationWarning: boolean;
+};
+
+export type GqlUpdateReportTemplateMutationVariables = Exact<{
+  variant: GqlReportVariant;
+  input: GqlUpdateReportTemplateInput;
+  communityId?: InputMaybe<Scalars["ID"]["input"]>;
+}>;
+
+export type GqlUpdateReportTemplateMutation = {
+  __typename?: "Mutation";
+  updateReportTemplate?: {
+    __typename?: "UpdateReportTemplateSuccess";
+    reportTemplate: {
+      __typename?: "ReportTemplate";
+      id: string;
+      variant: GqlReportVariant;
+      version: number;
+      scope: GqlReportTemplateScope;
+      kind: GqlReportTemplateKind;
+      model: string;
+      maxTokens: number;
+      temperature?: number | null;
+      systemPrompt: string;
+      userPromptTemplate: string;
+      stopSequences: Array<string>;
+      trafficWeight: number;
+      isActive: boolean;
+      isEnabled: boolean;
+      experimentKey?: string | null;
+      communityContext?: string | null;
+      createdAt: Date;
+      updatedAt?: Date | null;
+      community?: { __typename?: "Community"; id: string; name?: string | null } | null;
+      updatedByUser?: { __typename?: "User"; id: string; name: string } | null;
+    };
+  } | null;
+};
+
+export type GqlGetReportTemplateQueryVariables = Exact<{
+  variant: GqlReportVariant;
+  communityId?: InputMaybe<Scalars["ID"]["input"]>;
+}>;
+
+export type GqlGetReportTemplateQuery = {
+  __typename?: "Query";
+  reportTemplate?: {
+    __typename?: "ReportTemplate";
+    id: string;
+    variant: GqlReportVariant;
+    version: number;
+    scope: GqlReportTemplateScope;
+    kind: GqlReportTemplateKind;
+    model: string;
+    maxTokens: number;
+    temperature?: number | null;
+    systemPrompt: string;
+    userPromptTemplate: string;
+    stopSequences: Array<string>;
+    trafficWeight: number;
+    isActive: boolean;
+    isEnabled: boolean;
+    experimentKey?: string | null;
+    communityContext?: string | null;
+    createdAt: Date;
+    updatedAt?: Date | null;
+    community?: { __typename?: "Community"; id: string; name?: string | null } | null;
+    updatedByUser?: { __typename?: "User"; id: string; name: string } | null;
+  } | null;
+};
+
+export type GqlGetReportTemplateStatsQueryVariables = Exact<{
+  variant: GqlReportVariant;
+  version?: InputMaybe<Scalars["Int"]["input"]>;
+}>;
+
+export type GqlGetReportTemplateStatsQuery = {
+  __typename?: "Query";
+  reportTemplateStats: {
+    __typename?: "ReportTemplateStats";
+    variant: GqlReportVariant;
+    version?: number | null;
+    feedbackCount: number;
+    avgRating?: number | null;
+    avgJudgeScore?: number | null;
+    judgeHumanCorrelation?: number | null;
+    correlationWarning: boolean;
+  };
+};
+
+export type GqlGetReportTemplatesQueryVariables = Exact<{
+  variant: GqlReportVariant;
+  communityId?: InputMaybe<Scalars["ID"]["input"]>;
+  kind?: InputMaybe<GqlReportTemplateKind>;
+  includeInactive?: InputMaybe<Scalars["Boolean"]["input"]>;
+}>;
+
+export type GqlGetReportTemplatesQuery = {
+  __typename?: "Query";
+  reportTemplates: Array<{
+    __typename?: "ReportTemplate";
+    id: string;
+    variant: GqlReportVariant;
+    version: number;
+    scope: GqlReportTemplateScope;
+    kind: GqlReportTemplateKind;
+    model: string;
+    maxTokens: number;
+    temperature?: number | null;
+    systemPrompt: string;
+    userPromptTemplate: string;
+    stopSequences: Array<string>;
+    trafficWeight: number;
+    isActive: boolean;
+    isEnabled: boolean;
+    experimentKey?: string | null;
+    communityContext?: string | null;
+    createdAt: Date;
+    updatedAt?: Date | null;
+    community?: { __typename?: "Community"; id: string; name?: string | null } | null;
+    updatedByUser?: { __typename?: "User"; id: string; name: string } | null;
+  }>;
+};
+
+export type GqlGetReportTemplateStatsBreakdownQueryVariables = Exact<{
+  variant: GqlReportVariant;
+  version?: InputMaybe<Scalars["Int"]["input"]>;
+  kind?: InputMaybe<GqlReportTemplateKind>;
+  includeInactive?: InputMaybe<Scalars["Boolean"]["input"]>;
+  cursor?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+}>;
+
+export type GqlGetReportTemplateStatsBreakdownQuery = {
+  __typename?: "Query";
+  reportTemplateStatsBreakdown: {
+    __typename?: "ReportTemplateStatsBreakdownConnection";
+    totalCount: number;
+    edges?: Array<{
+      __typename?: "ReportTemplateStatsBreakdownEdge";
+      cursor: string;
+      node?: {
+        __typename?: "ReportTemplateStatsBreakdownRow";
+        templateId: string;
+        version: number;
+        scope: GqlReportTemplateScope;
+        kind: GqlReportTemplateKind;
+        experimentKey?: string | null;
+        isActive: boolean;
+        isEnabled: boolean;
+        trafficWeight: number;
+        feedbackCount: number;
+        avgRating?: number | null;
+        avgJudgeScore?: number | null;
+        judgeHumanCorrelation?: number | null;
+        correlationWarning: boolean;
+      } | null;
+    } | null> | null;
+    pageInfo: { __typename?: "PageInfo"; hasNextPage: boolean; endCursor?: string | null };
+  };
 };
 
 export type GqlSysAdminSegmentCountsFieldsFragment = {
@@ -9373,6 +10029,36 @@ export type GqlGetVoteTopicQuery = {
   } | null;
 };
 
+export const AdminReportSummaryRowFieldsFragmentDoc = gql`
+  fragment AdminReportSummaryRowFields on AdminReportSummaryRow {
+    community {
+      id
+      name
+    }
+    lastPublishedReport {
+      id
+      variant
+      status
+      publishedAt
+    }
+    lastPublishedAt
+    daysSinceLastPublish
+    publishedCountLast90Days
+  }
+`;
+export const AdminBrowseReportFieldsFragmentDoc = gql`
+  fragment AdminBrowseReportFields on Report {
+    id
+    variant
+    status
+    publishedAt
+    createdAt
+    community {
+      id
+      name
+    }
+  }
+`;
 export const CommunityFieldsFragmentDoc = gql`
   fragment CommunityFields on Community {
     id
@@ -9395,6 +10081,134 @@ export const MembershipFieldsFragmentDoc = gql`
     role
     status
     reason
+  }
+`;
+export const ReportFeedbackFieldsFragmentDoc = gql`
+  fragment ReportFeedbackFields on ReportFeedback {
+    id
+    rating
+    comment
+    feedbackType
+    sectionKey
+    createdAt
+    user {
+      id
+      name
+    }
+  }
+`;
+export const AdminReportDetailFieldsFragmentDoc = gql`
+  fragment AdminReportDetailFields on Report {
+    id
+    variant
+    status
+    publishedAt
+    createdAt
+    updatedAt
+    periodFrom
+    periodTo
+    outputMarkdown
+    finalContent
+    skipReason
+    regenerateCount
+    community {
+      id
+      name
+    }
+    template {
+      id
+      variant
+      version
+      kind
+      experimentKey
+      trafficWeight
+    }
+    generatedByUser {
+      id
+      name
+    }
+    publishedByUser {
+      id
+      name
+    }
+    myFeedback {
+      ...ReportFeedbackFields
+    }
+  }
+  ${ReportFeedbackFieldsFragmentDoc}
+`;
+export const ReportFeedbackWithReportFieldsFragmentDoc = gql`
+  fragment ReportFeedbackWithReportFields on ReportFeedback {
+    ...ReportFeedbackFields
+    report {
+      id
+      variant
+      periodFrom
+      periodTo
+      community {
+        id
+        name
+      }
+    }
+  }
+  ${ReportFeedbackFieldsFragmentDoc}
+`;
+export const ReportTemplateFieldsFragmentDoc = gql`
+  fragment ReportTemplateFields on ReportTemplate {
+    id
+    variant
+    version
+    scope
+    kind
+    model
+    maxTokens
+    temperature
+    systemPrompt
+    userPromptTemplate
+    stopSequences
+    trafficWeight
+    isActive
+    isEnabled
+    experimentKey
+    communityContext
+    createdAt
+    updatedAt
+    community {
+      id
+      name
+    }
+    updatedByUser {
+      id
+      name
+    }
+  }
+`;
+export const ReportTemplateStatsFieldsFragmentDoc = gql`
+  fragment ReportTemplateStatsFields on ReportTemplateStats {
+    variant
+    version
+    feedbackCount
+    avgRating
+    avgJudgeScore
+    judgeHumanCorrelation
+    correlationWarning
+  }
+`;
+export const ReportTemplateStatsBreakdownRowFieldsFragmentDoc = gql`
+  fragment ReportTemplateStatsBreakdownRowFields on ReportTemplateStatsBreakdownRow {
+    templateId
+    version
+    scope
+    kind
+    experimentKey
+    isActive
+    isEnabled
+    trafficWeight
+    feedbackCount
+    avgRating
+    avgJudgeScore
+    judgeHumanCorrelation
+    correlationWarning
   }
 `;
 export const SysAdminPlatformSummaryFieldsFragmentDoc = gql`
@@ -9979,6 +10793,400 @@ export type GetCitiesSuspenseQueryHookResult = ReturnType<typeof useGetCitiesSus
 export type GetCitiesQueryResult = Apollo.QueryResult<
   GqlGetCitiesQuery,
   GqlGetCitiesQueryVariables
+>;
+export const GetAdminBrowseReportsDocument = gql`
+  query GetAdminBrowseReports(
+    $communityId: ID
+    $status: ReportStatus
+    $variant: ReportVariant
+    $publishedAfter: Datetime
+    $publishedBefore: Datetime
+    $cursor: String
+    $first: Int
+  ) {
+    adminBrowseReports(
+      communityId: $communityId
+      status: $status
+      variant: $variant
+      publishedAfter: $publishedAfter
+      publishedBefore: $publishedBefore
+      cursor: $cursor
+      first: $first
+    ) {
+      edges {
+        cursor
+        node {
+          ...AdminBrowseReportFields
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+    }
+  }
+  ${AdminBrowseReportFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetAdminBrowseReportsQuery__
+ *
+ * To run a query within a React component, call `useGetAdminBrowseReportsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetAdminBrowseReportsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetAdminBrowseReportsQuery({
+ *   variables: {
+ *      communityId: // value for 'communityId'
+ *      status: // value for 'status'
+ *      variant: // value for 'variant'
+ *      publishedAfter: // value for 'publishedAfter'
+ *      publishedBefore: // value for 'publishedBefore'
+ *      cursor: // value for 'cursor'
+ *      first: // value for 'first'
+ *   },
+ * });
+ */
+export function useGetAdminBrowseReportsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GqlGetAdminBrowseReportsQuery,
+    GqlGetAdminBrowseReportsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GqlGetAdminBrowseReportsQuery, GqlGetAdminBrowseReportsQueryVariables>(
+    GetAdminBrowseReportsDocument,
+    options,
+  );
+}
+export function useGetAdminBrowseReportsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GqlGetAdminBrowseReportsQuery,
+    GqlGetAdminBrowseReportsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GqlGetAdminBrowseReportsQuery, GqlGetAdminBrowseReportsQueryVariables>(
+    GetAdminBrowseReportsDocument,
+    options,
+  );
+}
+export function useGetAdminBrowseReportsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GqlGetAdminBrowseReportsQuery,
+        GqlGetAdminBrowseReportsQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken ? baseOptions : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GqlGetAdminBrowseReportsQuery,
+    GqlGetAdminBrowseReportsQueryVariables
+  >(GetAdminBrowseReportsDocument, options);
+}
+export type GetAdminBrowseReportsQueryHookResult = ReturnType<typeof useGetAdminBrowseReportsQuery>;
+export type GetAdminBrowseReportsLazyQueryHookResult = ReturnType<
+  typeof useGetAdminBrowseReportsLazyQuery
+>;
+export type GetAdminBrowseReportsSuspenseQueryHookResult = ReturnType<
+  typeof useGetAdminBrowseReportsSuspenseQuery
+>;
+export type GetAdminBrowseReportsQueryResult = Apollo.QueryResult<
+  GqlGetAdminBrowseReportsQuery,
+  GqlGetAdminBrowseReportsQueryVariables
+>;
+export const GetAdminReportSummaryDocument = gql`
+  query GetAdminReportSummary($cursor: String, $first: Int) {
+    adminReportSummary(cursor: $cursor, first: $first) {
+      edges {
+        cursor
+        node {
+          ...AdminReportSummaryRowFields
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+    }
+  }
+  ${AdminReportSummaryRowFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetAdminReportSummaryQuery__
+ *
+ * To run a query within a React component, call `useGetAdminReportSummaryQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetAdminReportSummaryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetAdminReportSummaryQuery({
+ *   variables: {
+ *      cursor: // value for 'cursor'
+ *      first: // value for 'first'
+ *   },
+ * });
+ */
+export function useGetAdminReportSummaryQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GqlGetAdminReportSummaryQuery,
+    GqlGetAdminReportSummaryQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GqlGetAdminReportSummaryQuery, GqlGetAdminReportSummaryQueryVariables>(
+    GetAdminReportSummaryDocument,
+    options,
+  );
+}
+export function useGetAdminReportSummaryLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GqlGetAdminReportSummaryQuery,
+    GqlGetAdminReportSummaryQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GqlGetAdminReportSummaryQuery, GqlGetAdminReportSummaryQueryVariables>(
+    GetAdminReportSummaryDocument,
+    options,
+  );
+}
+export function useGetAdminReportSummarySuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GqlGetAdminReportSummaryQuery,
+        GqlGetAdminReportSummaryQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken ? baseOptions : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GqlGetAdminReportSummaryQuery,
+    GqlGetAdminReportSummaryQueryVariables
+  >(GetAdminReportSummaryDocument, options);
+}
+export type GetAdminReportSummaryQueryHookResult = ReturnType<typeof useGetAdminReportSummaryQuery>;
+export type GetAdminReportSummaryLazyQueryHookResult = ReturnType<
+  typeof useGetAdminReportSummaryLazyQuery
+>;
+export type GetAdminReportSummarySuspenseQueryHookResult = ReturnType<
+  typeof useGetAdminReportSummarySuspenseQuery
+>;
+export type GetAdminReportSummaryQueryResult = Apollo.QueryResult<
+  GqlGetAdminReportSummaryQuery,
+  GqlGetAdminReportSummaryQueryVariables
+>;
+export const GetAdminTemplateFeedbacksDocument = gql`
+  query GetAdminTemplateFeedbacks(
+    $variant: ReportVariant!
+    $version: Int
+    $kind: ReportTemplateKind
+    $feedbackType: ReportFeedbackType
+    $maxRating: Int
+    $cursor: String
+    $first: Int
+  ) {
+    adminTemplateFeedbacks(
+      variant: $variant
+      version: $version
+      kind: $kind
+      feedbackType: $feedbackType
+      maxRating: $maxRating
+      cursor: $cursor
+      first: $first
+    ) {
+      edges {
+        cursor
+        node {
+          ...ReportFeedbackWithReportFields
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+    }
+  }
+  ${ReportFeedbackWithReportFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetAdminTemplateFeedbacksQuery__
+ *
+ * To run a query within a React component, call `useGetAdminTemplateFeedbacksQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetAdminTemplateFeedbacksQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetAdminTemplateFeedbacksQuery({
+ *   variables: {
+ *      variant: // value for 'variant'
+ *      version: // value for 'version'
+ *      kind: // value for 'kind'
+ *      feedbackType: // value for 'feedbackType'
+ *      maxRating: // value for 'maxRating'
+ *      cursor: // value for 'cursor'
+ *      first: // value for 'first'
+ *   },
+ * });
+ */
+export function useGetAdminTemplateFeedbacksQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GqlGetAdminTemplateFeedbacksQuery,
+    GqlGetAdminTemplateFeedbacksQueryVariables
+  > &
+    ({ variables: GqlGetAdminTemplateFeedbacksQueryVariables; skip?: boolean } | { skip: boolean }),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GqlGetAdminTemplateFeedbacksQuery,
+    GqlGetAdminTemplateFeedbacksQueryVariables
+  >(GetAdminTemplateFeedbacksDocument, options);
+}
+export function useGetAdminTemplateFeedbacksLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GqlGetAdminTemplateFeedbacksQuery,
+    GqlGetAdminTemplateFeedbacksQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GqlGetAdminTemplateFeedbacksQuery,
+    GqlGetAdminTemplateFeedbacksQueryVariables
+  >(GetAdminTemplateFeedbacksDocument, options);
+}
+export function useGetAdminTemplateFeedbacksSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GqlGetAdminTemplateFeedbacksQuery,
+        GqlGetAdminTemplateFeedbacksQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken ? baseOptions : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GqlGetAdminTemplateFeedbacksQuery,
+    GqlGetAdminTemplateFeedbacksQueryVariables
+  >(GetAdminTemplateFeedbacksDocument, options);
+}
+export type GetAdminTemplateFeedbacksQueryHookResult = ReturnType<
+  typeof useGetAdminTemplateFeedbacksQuery
+>;
+export type GetAdminTemplateFeedbacksLazyQueryHookResult = ReturnType<
+  typeof useGetAdminTemplateFeedbacksLazyQuery
+>;
+export type GetAdminTemplateFeedbacksSuspenseQueryHookResult = ReturnType<
+  typeof useGetAdminTemplateFeedbacksSuspenseQuery
+>;
+export type GetAdminTemplateFeedbacksQueryResult = Apollo.QueryResult<
+  GqlGetAdminTemplateFeedbacksQuery,
+  GqlGetAdminTemplateFeedbacksQueryVariables
+>;
+export const GetAdminTemplateFeedbackStatsDocument = gql`
+  query GetAdminTemplateFeedbackStats(
+    $variant: ReportVariant!
+    $version: Int
+    $kind: ReportTemplateKind
+  ) {
+    adminTemplateFeedbackStats(variant: $variant, version: $version, kind: $kind) {
+      totalCount
+      avgRating
+      ratingDistribution {
+        rating
+        count
+      }
+    }
+  }
+`;
+
+/**
+ * __useGetAdminTemplateFeedbackStatsQuery__
+ *
+ * To run a query within a React component, call `useGetAdminTemplateFeedbackStatsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetAdminTemplateFeedbackStatsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetAdminTemplateFeedbackStatsQuery({
+ *   variables: {
+ *      variant: // value for 'variant'
+ *      version: // value for 'version'
+ *      kind: // value for 'kind'
+ *   },
+ * });
+ */
+export function useGetAdminTemplateFeedbackStatsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GqlGetAdminTemplateFeedbackStatsQuery,
+    GqlGetAdminTemplateFeedbackStatsQueryVariables
+  > &
+    (
+      | { variables: GqlGetAdminTemplateFeedbackStatsQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GqlGetAdminTemplateFeedbackStatsQuery,
+    GqlGetAdminTemplateFeedbackStatsQueryVariables
+  >(GetAdminTemplateFeedbackStatsDocument, options);
+}
+export function useGetAdminTemplateFeedbackStatsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GqlGetAdminTemplateFeedbackStatsQuery,
+    GqlGetAdminTemplateFeedbackStatsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GqlGetAdminTemplateFeedbackStatsQuery,
+    GqlGetAdminTemplateFeedbackStatsQueryVariables
+  >(GetAdminTemplateFeedbackStatsDocument, options);
+}
+export function useGetAdminTemplateFeedbackStatsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GqlGetAdminTemplateFeedbackStatsQuery,
+        GqlGetAdminTemplateFeedbackStatsQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken ? baseOptions : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GqlGetAdminTemplateFeedbackStatsQuery,
+    GqlGetAdminTemplateFeedbackStatsQueryVariables
+  >(GetAdminTemplateFeedbackStatsDocument, options);
+}
+export type GetAdminTemplateFeedbackStatsQueryHookResult = ReturnType<
+  typeof useGetAdminTemplateFeedbackStatsQuery
+>;
+export type GetAdminTemplateFeedbackStatsLazyQueryHookResult = ReturnType<
+  typeof useGetAdminTemplateFeedbackStatsLazyQuery
+>;
+export type GetAdminTemplateFeedbackStatsSuspenseQueryHookResult = ReturnType<
+  typeof useGetAdminTemplateFeedbackStatsSuspenseQuery
+>;
+export type GetAdminTemplateFeedbackStatsQueryResult = Apollo.QueryResult<
+  GqlGetAdminTemplateFeedbackStatsQuery,
+  GqlGetAdminTemplateFeedbackStatsQueryVariables
 >;
 export const CommunityCreateDocument = gql`
   mutation CommunityCreate($input: CommunityCreateInput!) {
@@ -11679,6 +12887,640 @@ export type GetNftInstanceWithDidSuspenseQueryHookResult = ReturnType<
 export type GetNftInstanceWithDidQueryResult = Apollo.QueryResult<
   GqlGetNftInstanceWithDidQuery,
   GqlGetNftInstanceWithDidQueryVariables
+>;
+export const SubmitReportFeedbackDocument = gql`
+  mutation SubmitReportFeedback(
+    $input: SubmitReportFeedbackInput!
+    $permission: CheckCommunityPermissionInput!
+  ) {
+    submitReportFeedback(input: $input, permission: $permission) {
+      ... on SubmitReportFeedbackSuccess {
+        feedback {
+          ...ReportFeedbackFields
+        }
+      }
+    }
+  }
+  ${ReportFeedbackFieldsFragmentDoc}
+`;
+export type GqlSubmitReportFeedbackMutationFn = Apollo.MutationFunction<
+  GqlSubmitReportFeedbackMutation,
+  GqlSubmitReportFeedbackMutationVariables
+>;
+
+/**
+ * __useSubmitReportFeedbackMutation__
+ *
+ * To run a mutation, you first call `useSubmitReportFeedbackMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useSubmitReportFeedbackMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [submitReportFeedbackMutation, { data, loading, error }] = useSubmitReportFeedbackMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *      permission: // value for 'permission'
+ *   },
+ * });
+ */
+export function useSubmitReportFeedbackMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    GqlSubmitReportFeedbackMutation,
+    GqlSubmitReportFeedbackMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    GqlSubmitReportFeedbackMutation,
+    GqlSubmitReportFeedbackMutationVariables
+  >(SubmitReportFeedbackDocument, options);
+}
+export type SubmitReportFeedbackMutationHookResult = ReturnType<
+  typeof useSubmitReportFeedbackMutation
+>;
+export type SubmitReportFeedbackMutationResult =
+  Apollo.MutationResult<GqlSubmitReportFeedbackMutation>;
+export type SubmitReportFeedbackMutationOptions = Apollo.BaseMutationOptions<
+  GqlSubmitReportFeedbackMutation,
+  GqlSubmitReportFeedbackMutationVariables
+>;
+export const GetAdminReportDocument = gql`
+  query GetAdminReport($id: ID!) {
+    report(id: $id) {
+      ...AdminReportDetailFields
+    }
+  }
+  ${AdminReportDetailFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetAdminReportQuery__
+ *
+ * To run a query within a React component, call `useGetAdminReportQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetAdminReportQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetAdminReportQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useGetAdminReportQuery(
+  baseOptions: Apollo.QueryHookOptions<GqlGetAdminReportQuery, GqlGetAdminReportQueryVariables> &
+    ({ variables: GqlGetAdminReportQueryVariables; skip?: boolean } | { skip: boolean }),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GqlGetAdminReportQuery, GqlGetAdminReportQueryVariables>(
+    GetAdminReportDocument,
+    options,
+  );
+}
+export function useGetAdminReportLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GqlGetAdminReportQuery,
+    GqlGetAdminReportQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GqlGetAdminReportQuery, GqlGetAdminReportQueryVariables>(
+    GetAdminReportDocument,
+    options,
+  );
+}
+export function useGetAdminReportSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<GqlGetAdminReportQuery, GqlGetAdminReportQueryVariables>,
+) {
+  const options =
+    baseOptions === Apollo.skipToken ? baseOptions : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<GqlGetAdminReportQuery, GqlGetAdminReportQueryVariables>(
+    GetAdminReportDocument,
+    options,
+  );
+}
+export type GetAdminReportQueryHookResult = ReturnType<typeof useGetAdminReportQuery>;
+export type GetAdminReportLazyQueryHookResult = ReturnType<typeof useGetAdminReportLazyQuery>;
+export type GetAdminReportSuspenseQueryHookResult = ReturnType<
+  typeof useGetAdminReportSuspenseQuery
+>;
+export type GetAdminReportQueryResult = Apollo.QueryResult<
+  GqlGetAdminReportQuery,
+  GqlGetAdminReportQueryVariables
+>;
+export const GetAdminReportFeedbacksDocument = gql`
+  query GetAdminReportFeedbacks($id: ID!, $cursor: String, $first: Int) {
+    report(id: $id) {
+      id
+      feedbacks(after: $cursor, first: $first) {
+        edges {
+          cursor
+          node {
+            ...ReportFeedbackFields
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        totalCount
+      }
+    }
+  }
+  ${ReportFeedbackFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetAdminReportFeedbacksQuery__
+ *
+ * To run a query within a React component, call `useGetAdminReportFeedbacksQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetAdminReportFeedbacksQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetAdminReportFeedbacksQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *      cursor: // value for 'cursor'
+ *      first: // value for 'first'
+ *   },
+ * });
+ */
+export function useGetAdminReportFeedbacksQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GqlGetAdminReportFeedbacksQuery,
+    GqlGetAdminReportFeedbacksQueryVariables
+  > &
+    ({ variables: GqlGetAdminReportFeedbacksQueryVariables; skip?: boolean } | { skip: boolean }),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GqlGetAdminReportFeedbacksQuery, GqlGetAdminReportFeedbacksQueryVariables>(
+    GetAdminReportFeedbacksDocument,
+    options,
+  );
+}
+export function useGetAdminReportFeedbacksLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GqlGetAdminReportFeedbacksQuery,
+    GqlGetAdminReportFeedbacksQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GqlGetAdminReportFeedbacksQuery,
+    GqlGetAdminReportFeedbacksQueryVariables
+  >(GetAdminReportFeedbacksDocument, options);
+}
+export function useGetAdminReportFeedbacksSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GqlGetAdminReportFeedbacksQuery,
+        GqlGetAdminReportFeedbacksQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken ? baseOptions : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GqlGetAdminReportFeedbacksQuery,
+    GqlGetAdminReportFeedbacksQueryVariables
+  >(GetAdminReportFeedbacksDocument, options);
+}
+export type GetAdminReportFeedbacksQueryHookResult = ReturnType<
+  typeof useGetAdminReportFeedbacksQuery
+>;
+export type GetAdminReportFeedbacksLazyQueryHookResult = ReturnType<
+  typeof useGetAdminReportFeedbacksLazyQuery
+>;
+export type GetAdminReportFeedbacksSuspenseQueryHookResult = ReturnType<
+  typeof useGetAdminReportFeedbacksSuspenseQuery
+>;
+export type GetAdminReportFeedbacksQueryResult = Apollo.QueryResult<
+  GqlGetAdminReportFeedbacksQuery,
+  GqlGetAdminReportFeedbacksQueryVariables
+>;
+export const UpdateReportTemplateDocument = gql`
+  mutation UpdateReportTemplate(
+    $variant: ReportVariant!
+    $input: UpdateReportTemplateInput!
+    $communityId: ID
+  ) {
+    updateReportTemplate(variant: $variant, input: $input, communityId: $communityId) {
+      ... on UpdateReportTemplateSuccess {
+        reportTemplate {
+          ...ReportTemplateFields
+        }
+      }
+    }
+  }
+  ${ReportTemplateFieldsFragmentDoc}
+`;
+export type GqlUpdateReportTemplateMutationFn = Apollo.MutationFunction<
+  GqlUpdateReportTemplateMutation,
+  GqlUpdateReportTemplateMutationVariables
+>;
+
+/**
+ * __useUpdateReportTemplateMutation__
+ *
+ * To run a mutation, you first call `useUpdateReportTemplateMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateReportTemplateMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateReportTemplateMutation, { data, loading, error }] = useUpdateReportTemplateMutation({
+ *   variables: {
+ *      variant: // value for 'variant'
+ *      input: // value for 'input'
+ *      communityId: // value for 'communityId'
+ *   },
+ * });
+ */
+export function useUpdateReportTemplateMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    GqlUpdateReportTemplateMutation,
+    GqlUpdateReportTemplateMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    GqlUpdateReportTemplateMutation,
+    GqlUpdateReportTemplateMutationVariables
+  >(UpdateReportTemplateDocument, options);
+}
+export type UpdateReportTemplateMutationHookResult = ReturnType<
+  typeof useUpdateReportTemplateMutation
+>;
+export type UpdateReportTemplateMutationResult =
+  Apollo.MutationResult<GqlUpdateReportTemplateMutation>;
+export type UpdateReportTemplateMutationOptions = Apollo.BaseMutationOptions<
+  GqlUpdateReportTemplateMutation,
+  GqlUpdateReportTemplateMutationVariables
+>;
+export const GetReportTemplateDocument = gql`
+  query GetReportTemplate($variant: ReportVariant!, $communityId: ID) {
+    reportTemplate(variant: $variant, communityId: $communityId) {
+      ...ReportTemplateFields
+    }
+  }
+  ${ReportTemplateFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetReportTemplateQuery__
+ *
+ * To run a query within a React component, call `useGetReportTemplateQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetReportTemplateQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetReportTemplateQuery({
+ *   variables: {
+ *      variant: // value for 'variant'
+ *      communityId: // value for 'communityId'
+ *   },
+ * });
+ */
+export function useGetReportTemplateQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GqlGetReportTemplateQuery,
+    GqlGetReportTemplateQueryVariables
+  > &
+    ({ variables: GqlGetReportTemplateQueryVariables; skip?: boolean } | { skip: boolean }),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GqlGetReportTemplateQuery, GqlGetReportTemplateQueryVariables>(
+    GetReportTemplateDocument,
+    options,
+  );
+}
+export function useGetReportTemplateLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GqlGetReportTemplateQuery,
+    GqlGetReportTemplateQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GqlGetReportTemplateQuery, GqlGetReportTemplateQueryVariables>(
+    GetReportTemplateDocument,
+    options,
+  );
+}
+export function useGetReportTemplateSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GqlGetReportTemplateQuery,
+        GqlGetReportTemplateQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken ? baseOptions : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<GqlGetReportTemplateQuery, GqlGetReportTemplateQueryVariables>(
+    GetReportTemplateDocument,
+    options,
+  );
+}
+export type GetReportTemplateQueryHookResult = ReturnType<typeof useGetReportTemplateQuery>;
+export type GetReportTemplateLazyQueryHookResult = ReturnType<typeof useGetReportTemplateLazyQuery>;
+export type GetReportTemplateSuspenseQueryHookResult = ReturnType<
+  typeof useGetReportTemplateSuspenseQuery
+>;
+export type GetReportTemplateQueryResult = Apollo.QueryResult<
+  GqlGetReportTemplateQuery,
+  GqlGetReportTemplateQueryVariables
+>;
+export const GetReportTemplateStatsDocument = gql`
+  query GetReportTemplateStats($variant: ReportVariant!, $version: Int) {
+    reportTemplateStats(variant: $variant, version: $version) {
+      ...ReportTemplateStatsFields
+    }
+  }
+  ${ReportTemplateStatsFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetReportTemplateStatsQuery__
+ *
+ * To run a query within a React component, call `useGetReportTemplateStatsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetReportTemplateStatsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetReportTemplateStatsQuery({
+ *   variables: {
+ *      variant: // value for 'variant'
+ *      version: // value for 'version'
+ *   },
+ * });
+ */
+export function useGetReportTemplateStatsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GqlGetReportTemplateStatsQuery,
+    GqlGetReportTemplateStatsQueryVariables
+  > &
+    ({ variables: GqlGetReportTemplateStatsQueryVariables; skip?: boolean } | { skip: boolean }),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GqlGetReportTemplateStatsQuery, GqlGetReportTemplateStatsQueryVariables>(
+    GetReportTemplateStatsDocument,
+    options,
+  );
+}
+export function useGetReportTemplateStatsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GqlGetReportTemplateStatsQuery,
+    GqlGetReportTemplateStatsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GqlGetReportTemplateStatsQuery,
+    GqlGetReportTemplateStatsQueryVariables
+  >(GetReportTemplateStatsDocument, options);
+}
+export function useGetReportTemplateStatsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GqlGetReportTemplateStatsQuery,
+        GqlGetReportTemplateStatsQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken ? baseOptions : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GqlGetReportTemplateStatsQuery,
+    GqlGetReportTemplateStatsQueryVariables
+  >(GetReportTemplateStatsDocument, options);
+}
+export type GetReportTemplateStatsQueryHookResult = ReturnType<
+  typeof useGetReportTemplateStatsQuery
+>;
+export type GetReportTemplateStatsLazyQueryHookResult = ReturnType<
+  typeof useGetReportTemplateStatsLazyQuery
+>;
+export type GetReportTemplateStatsSuspenseQueryHookResult = ReturnType<
+  typeof useGetReportTemplateStatsSuspenseQuery
+>;
+export type GetReportTemplateStatsQueryResult = Apollo.QueryResult<
+  GqlGetReportTemplateStatsQuery,
+  GqlGetReportTemplateStatsQueryVariables
+>;
+export const GetReportTemplatesDocument = gql`
+  query GetReportTemplates(
+    $variant: ReportVariant!
+    $communityId: ID
+    $kind: ReportTemplateKind
+    $includeInactive: Boolean
+  ) {
+    reportTemplates(
+      variant: $variant
+      communityId: $communityId
+      kind: $kind
+      includeInactive: $includeInactive
+    ) {
+      ...ReportTemplateFields
+    }
+  }
+  ${ReportTemplateFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetReportTemplatesQuery__
+ *
+ * To run a query within a React component, call `useGetReportTemplatesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetReportTemplatesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetReportTemplatesQuery({
+ *   variables: {
+ *      variant: // value for 'variant'
+ *      communityId: // value for 'communityId'
+ *      kind: // value for 'kind'
+ *      includeInactive: // value for 'includeInactive'
+ *   },
+ * });
+ */
+export function useGetReportTemplatesQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GqlGetReportTemplatesQuery,
+    GqlGetReportTemplatesQueryVariables
+  > &
+    ({ variables: GqlGetReportTemplatesQueryVariables; skip?: boolean } | { skip: boolean }),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GqlGetReportTemplatesQuery, GqlGetReportTemplatesQueryVariables>(
+    GetReportTemplatesDocument,
+    options,
+  );
+}
+export function useGetReportTemplatesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GqlGetReportTemplatesQuery,
+    GqlGetReportTemplatesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GqlGetReportTemplatesQuery, GqlGetReportTemplatesQueryVariables>(
+    GetReportTemplatesDocument,
+    options,
+  );
+}
+export function useGetReportTemplatesSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GqlGetReportTemplatesQuery,
+        GqlGetReportTemplatesQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken ? baseOptions : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<GqlGetReportTemplatesQuery, GqlGetReportTemplatesQueryVariables>(
+    GetReportTemplatesDocument,
+    options,
+  );
+}
+export type GetReportTemplatesQueryHookResult = ReturnType<typeof useGetReportTemplatesQuery>;
+export type GetReportTemplatesLazyQueryHookResult = ReturnType<
+  typeof useGetReportTemplatesLazyQuery
+>;
+export type GetReportTemplatesSuspenseQueryHookResult = ReturnType<
+  typeof useGetReportTemplatesSuspenseQuery
+>;
+export type GetReportTemplatesQueryResult = Apollo.QueryResult<
+  GqlGetReportTemplatesQuery,
+  GqlGetReportTemplatesQueryVariables
+>;
+export const GetReportTemplateStatsBreakdownDocument = gql`
+  query GetReportTemplateStatsBreakdown(
+    $variant: ReportVariant!
+    $version: Int
+    $kind: ReportTemplateKind
+    $includeInactive: Boolean
+    $cursor: String
+    $first: Int
+  ) {
+    reportTemplateStatsBreakdown(
+      variant: $variant
+      version: $version
+      kind: $kind
+      includeInactive: $includeInactive
+      cursor: $cursor
+      first: $first
+    ) {
+      edges {
+        cursor
+        node {
+          ...ReportTemplateStatsBreakdownRowFields
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+    }
+  }
+  ${ReportTemplateStatsBreakdownRowFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetReportTemplateStatsBreakdownQuery__
+ *
+ * To run a query within a React component, call `useGetReportTemplateStatsBreakdownQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetReportTemplateStatsBreakdownQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetReportTemplateStatsBreakdownQuery({
+ *   variables: {
+ *      variant: // value for 'variant'
+ *      version: // value for 'version'
+ *      kind: // value for 'kind'
+ *      includeInactive: // value for 'includeInactive'
+ *      cursor: // value for 'cursor'
+ *      first: // value for 'first'
+ *   },
+ * });
+ */
+export function useGetReportTemplateStatsBreakdownQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GqlGetReportTemplateStatsBreakdownQuery,
+    GqlGetReportTemplateStatsBreakdownQueryVariables
+  > &
+    (
+      | { variables: GqlGetReportTemplateStatsBreakdownQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GqlGetReportTemplateStatsBreakdownQuery,
+    GqlGetReportTemplateStatsBreakdownQueryVariables
+  >(GetReportTemplateStatsBreakdownDocument, options);
+}
+export function useGetReportTemplateStatsBreakdownLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GqlGetReportTemplateStatsBreakdownQuery,
+    GqlGetReportTemplateStatsBreakdownQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GqlGetReportTemplateStatsBreakdownQuery,
+    GqlGetReportTemplateStatsBreakdownQueryVariables
+  >(GetReportTemplateStatsBreakdownDocument, options);
+}
+export function useGetReportTemplateStatsBreakdownSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GqlGetReportTemplateStatsBreakdownQuery,
+        GqlGetReportTemplateStatsBreakdownQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken ? baseOptions : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GqlGetReportTemplateStatsBreakdownQuery,
+    GqlGetReportTemplateStatsBreakdownQueryVariables
+  >(GetReportTemplateStatsBreakdownDocument, options);
+}
+export type GetReportTemplateStatsBreakdownQueryHookResult = ReturnType<
+  typeof useGetReportTemplateStatsBreakdownQuery
+>;
+export type GetReportTemplateStatsBreakdownLazyQueryHookResult = ReturnType<
+  typeof useGetReportTemplateStatsBreakdownLazyQuery
+>;
+export type GetReportTemplateStatsBreakdownSuspenseQueryHookResult = ReturnType<
+  typeof useGetReportTemplateStatsBreakdownSuspenseQuery
+>;
+export type GetReportTemplateStatsBreakdownQueryResult = Apollo.QueryResult<
+  GqlGetReportTemplateStatsBreakdownQuery,
+  GqlGetReportTemplateStatsBreakdownQueryVariables
 >;
 export const GetSysAdminDashboardDocument = gql`
   query GetSysAdminDashboard($input: SysAdminDashboardInput) {


### PR DESCRIPTION
develop の最新コミットを master に反映するリリース PR。

## 含まれる内容
- #1187 — feat(sysAdmin): レポートテンプレート管理 + Phase 2 レポート観察画面の追加
  - Phase 1.5 swap: テンプレ詳細ページの mock を `adminTemplateFeedbacks` 本クエリに差し替え
  - Phase 2: Report 詳細ページ (`/sysAdmin/[communityId]/reports/[reportId]`) を新設、admin による代行フィードバック投稿に対応
  - コミュニティ詳細のレポートタブで行クリック → Report 詳細へ遷移 (variant 列はもともと表示済み)
  - shadcnblocks の Customer Reviews レイアウトを参考に `<FeedbackCard>` / `<FeedbackList>` / `<RatingSummary>` を shadcn primitives で統一実装
  - `RatingSummary` を backend の新 query `adminTemplateFeedbackStats` (avg / 件数 / 5★…1★ 分布) と接続
  - `ReportFeedbackForm` を shadcn Form (react-hook-form + zod) + ToggleGroup で書き直し
  - sysAdmin 配下の自前ウィジェット (`VersionSelector` / InlineHeader chips / `ExperimentSection` / `CommunityReportsTab` / `PromptEditor`) を shadcn primitives と共通の `MetadataChips` ラッパーに置き換え
  - Devin が指摘した `CommunityReportsTabContainer` の `totalCount` ドリフトを修正 (state 化 + 各 fetchMore で更新)

## 検証手順
- [ ] sysAdmin コミュニティ詳細: タブの上下余白が直近のデザインと合っている
- [ ] レポートタブ: 行クリックで Report 詳細に遷移する / variant 列が見える
- [ ] Report 詳細: ヘッダー chip / 本文 markdown / フィードバック一覧 / 投稿フォーム (sectionKey なし) が動作する
- [ ] テンプレ詳細: backend stats を反映した RatingSummary の分布バーが描画される
- [ ] Storybook: `SysAdmin/Pages/*` の各 story がエラーなく表示される