### PR TITLE
refactor(sysAdmin): centralize cursor pagination state in useCursorPagination

### DIFF
--- a/src/app/sysAdmin/_shared/hooks/useCursorPagination.ts
+++ b/src/app/sysAdmin/_shared/hooks/useCursorPagination.ts
@@ -165,12 +165,13 @@ export function useCursorPagination<TItem>({
       const nextHasNextPage = next.pageInfo.hasNextPage;
       endCursorRef.current = nextEndCursor;
       hasNextPageRef.current = nextHasNextPage;
-      setItems((prev) => {
-        const appended = [...prev, ...extractItems(next)];
-        // backend が totalCount を返さないケースは累積件数で代替。
-        setTotalCount(next.totalCount ?? appended.length);
-        return appended;
-      });
+      const nextItems = extractItems(next);
+      setItems((prev) => [...prev, ...nextItems]);
+      // backend が totalCount を返さないケースは累積件数で代替。
+      // setItems の updater は純粋関数として保つため、setTotalCount は外側で
+      // 独立に呼ぶ (Strict Mode で updater が二重実行されても副作用が
+      // 漏れないように)。
+      setTotalCount((prev) => next.totalCount ?? prev + nextItems.length);
       setEndCursor(nextEndCursor);
       setHasNextPage(nextHasNextPage);
     } catch (err) {

--- a/src/app/sysAdmin/_shared/hooks/useCursorPagination.ts
+++ b/src/app/sysAdmin/_shared/hooks/useCursorPagination.ts
@@ -48,6 +48,10 @@ type Result<TItem> = {
   items: TItem[];
   hasNextPage: boolean;
   loading: boolean;
+  /** 母集団件数。SSR initial と各 fetchMore レスポンスから常に最新を保つ。 */
+  totalCount: number;
+  /** 直近の loadMore で発生した例外。次回成功時に null に戻る。 */
+  error: unknown;
   loadMore: () => Promise<void>;
   reset: (next: ConnectionLike<TItem>) => void;
 };
@@ -66,7 +70,7 @@ function extractItems<TItem>(conn: ConnectionLike<TItem>): TItem[] {
  * 以下の流れを抽象化:
  *   1. 初期 Connection を items にバラす
  *   2. loadMore 呼び出しで fetchMore(cursor) → 結果を items に append
- *   3. hasNextPage / endCursor を内部 state で管理
+ *   3. hasNextPage / endCursor / totalCount / error を内部 state で管理
  *
  * Apollo の useQuery + fetchMore パターンに被せる場合は、
  * fetchMore コールバック内で client.query などを使って次ページを取得する
@@ -94,6 +98,10 @@ export function useCursorPagination<TItem>({
     initial.pageInfo.hasNextPage,
   );
   const [loading, setLoading] = useState(false);
+  const [totalCount, setTotalCount] = useState<number>(
+    initial.totalCount ?? extractItems(initial).length,
+  );
+  const [error, setError] = useState<unknown>(null);
 
   // 同期的な並行制御用 ref。setLoading は非同期反映のため、
   // rapid loadMore() 呼び出し (例: スクロール / 連打) で重複 fetch が
@@ -123,20 +131,30 @@ export function useCursorPagination<TItem>({
     // 対する次の loadMore が「まだ読み込み中」と誤判定されてブロックされる。
     // generation でレスポンスは捨てられるので、guard も明示的にリセットする。
     loadingRef.current = false;
-    setItems(extractItems(latest));
+    const latestItems = extractItems(latest);
+    setItems(latestItems);
     setEndCursor(latest.pageInfo.endCursor ?? null);
     setHasNextPage(latest.pageInfo.hasNextPage);
     setLoading(false);
+    setTotalCount(latest.totalCount ?? latestItems.length);
+    setError(null);
     endCursorRef.current = latest.pageInfo.endCursor ?? null;
     hasNextPageRef.current = latest.pageInfo.hasNextPage;
   }, [depKey]);
 
   const loadMore = useCallback(async () => {
-    if (loadingRef.current || !hasNextPageRef.current || !endCursorRef.current) {
+    // 空文字 cursor も「終端」ではなく有効値として扱うため、null/undefined を
+    // 明示的にチェックする (`!cursor` だと "" が偽になる)。
+    if (
+      loadingRef.current ||
+      !hasNextPageRef.current ||
+      endCursorRef.current == null
+    ) {
       return;
     }
     loadingRef.current = true;
     setLoading(true);
+    setError(null);
     const cursor = endCursorRef.current;
     const requestGeneration = generationRef.current;
     try {
@@ -147,11 +165,17 @@ export function useCursorPagination<TItem>({
       const nextHasNextPage = next.pageInfo.hasNextPage;
       endCursorRef.current = nextEndCursor;
       hasNextPageRef.current = nextHasNextPage;
-      setItems((prev) => [...prev, ...extractItems(next)]);
+      setItems((prev) => {
+        const appended = [...prev, ...extractItems(next)];
+        // backend が totalCount を返さないケースは累積件数で代替。
+        setTotalCount(next.totalCount ?? appended.length);
+        return appended;
+      });
       setEndCursor(nextEndCursor);
       setHasNextPage(nextHasNextPage);
     } catch (err) {
       if (requestGeneration === generationRef.current) {
+        setError(err);
         onError?.(err);
       }
     } finally {
@@ -172,11 +196,22 @@ export function useCursorPagination<TItem>({
     const nextHasNextPage = next.pageInfo.hasNextPage;
     endCursorRef.current = nextEndCursor;
     hasNextPageRef.current = nextHasNextPage;
-    setItems(extractItems(next));
+    const nextItems = extractItems(next);
+    setItems(nextItems);
     setEndCursor(nextEndCursor);
     setHasNextPage(nextHasNextPage);
     setLoading(false);
+    setTotalCount(next.totalCount ?? nextItems.length);
+    setError(null);
   }, []);
 
-  return { items, hasNextPage, loading, loadMore, reset };
+  return {
+    items,
+    hasNextPage,
+    loading,
+    totalCount,
+    error,
+    loadMore,
+    reset,
+  };
 }

--- a/src/app/sysAdmin/features/communityDetail/components/CommunityReportsTabContainer.tsx
+++ b/src/app/sysAdmin/features/communityDetail/components/CommunityReportsTabContainer.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback } from "react";
 import { useApolloClient } from "@apollo/client";
 import { GET_ADMIN_BROWSE_REPORTS } from "@/graphql/account/adminReports/query";
 import type {
   GqlGetAdminBrowseReportsQuery,
   GqlGetAdminBrowseReportsQueryVariables,
 } from "@/types/graphql";
+import { useCursorPagination } from "@/app/sysAdmin/_shared/hooks/useCursorPagination";
 import {
   CommunityReportsTab,
   type ReportRow,
@@ -14,101 +15,88 @@ import {
 
 const PAGE_SIZE = 20;
 
+type ReportsConnection = NonNullable<
+  GqlGetAdminBrowseReportsQuery["adminBrowseReports"]
+>;
+
 type Props = {
   communityId: string;
-  initialReports: GqlGetAdminBrowseReportsQuery["adminBrowseReports"] | null;
+  initialReports: ReportsConnection | null;
+};
+
+const EMPTY_CONNECTION: ReportsConnection = {
+  __typename: "ReportsConnection",
+  edges: [],
+  pageInfo: {
+    __typename: "PageInfo",
+    hasNextPage: false,
+    endCursor: null,
+  },
+  totalCount: 0,
 };
 
 /**
  * `CommunityReportsTab` (View) のための data wiring。
  *
  * 初期 1 ページは SSR (`fetchAdminBrowseReportsServer`) で取得して props で
- * 受け取る。「もっと見る」での追加ページは Apollo client.query で fetch して
- * local state に append する。
+ * 受け取る。以降は generic な `useCursorPagination` フックに任せ、totalCount /
+ * error / loading / loadMore を一括管理する (= テンプレ詳細の Container と
+ * 同じパターン)。
  *
- * Apollo の `useQuery` 経路を使わない理由: SSR と整合させたいので Apollo
- * cache を経由せず、SSR data を一次ソースとして扱う。
+ * `useCursorPagination` を使う方針: SSR と整合させたいので Apollo cache を
+ * 経由せず、SSR data を `initial` として hook に渡す。fetchMore は client.query
+ * で都度叩く。
+ *
+ * `resetKey={communityId}` でコミュニティ切替 (= 同コンポーネントが別 community
+ * 用に再利用される) 時に内部 state を再同期する。
  */
 export function CommunityReportsTabContainer({
   communityId,
   initialReports,
 }: Props) {
   const apollo = useApolloClient();
-  const [reports, setReports] = useState<ReportRow[]>(
-    () => extractReports(initialReports),
-  );
-  const [endCursor, setEndCursor] = useState<string | null>(
-    initialReports?.pageInfo.endCursor ?? null,
-  );
-  const [hasNextPage, setHasNextPage] = useState<boolean>(
-    initialReports?.pageInfo.hasNextPage ?? false,
-  );
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [loadError, setLoadError] = useState<unknown>(null);
-  // totalCount は initial で SSR 値を入れ、各 fetchMore レスポンスでも更新する。
-  // backend が「全体件数」を返す前提で、追加ロード中に totalCount が増減しても
-  // 表示と一致させるため (= "48 / 47 件" のような stale 表示を防ぐ)。
-  const [totalCount, setTotalCount] = useState<number>(
-    initialReports?.totalCount ?? 0,
-  );
 
-  // setLoadingMore / setEndCursor / setHasNextPage は state なので非同期で反映
-  // される。rapid に「もっと見る」を連打した時に同じ cursor で重複 fetch しない
-  // よう、同期的な ref で guard する (useCursorPagination と同じパターン)。
-  // Relay 実装によっては最終ページでも `endCursor` が non-null で返ることが
-  // あるので、`hasNextPageRef` を必ず併用する。
-  const loadingRef = useRef(false);
-  const endCursorRef = useRef<string | null>(
-    initialReports?.pageInfo.endCursor ?? null,
-  );
-  const hasNextPageRef = useRef<boolean>(
-    initialReports?.pageInfo.hasNextPage ?? false,
-  );
-
-  const handleLoadMore = useCallback(async () => {
-    if (
-      loadingRef.current ||
-      !hasNextPageRef.current ||
-      !endCursorRef.current
-    ) {
-      return;
-    }
-    const cursor = endCursorRef.current;
-    loadingRef.current = true;
-    setLoadingMore(true);
-    setLoadError(null);
-    try {
+  const fetchMoreReports = useCallback(
+    async (cursor: string, first: number) => {
       const result = await apollo.query<
         GqlGetAdminBrowseReportsQuery,
         GqlGetAdminBrowseReportsQueryVariables
       >({
         query: GET_ADMIN_BROWSE_REPORTS,
-        variables: { communityId, cursor, first: PAGE_SIZE },
+        variables: { communityId, cursor, first },
         fetchPolicy: "network-only",
       });
-      const next = result.data.adminBrowseReports;
-      const nextEndCursor = next.pageInfo.endCursor ?? null;
-      const nextHasNextPage = next.pageInfo.hasNextPage;
-      endCursorRef.current = nextEndCursor;
-      hasNextPageRef.current = nextHasNextPage;
-      setReports((prev) => [...prev, ...extractReports(next)]);
-      setEndCursor(nextEndCursor);
-      setHasNextPage(nextHasNextPage);
-      setTotalCount(next.totalCount);
-    } catch (err) {
-      // catch しないと button onClick で発火する promise が unhandled rejection に
-      // なる。View 側は error prop を表示できるので state にセットして渡す。
-      setLoadError(err);
-    } finally {
-      loadingRef.current = false;
-      setLoadingMore(false);
-    }
-  }, [apollo, communityId]);
+      return result.data.adminBrowseReports ?? EMPTY_CONNECTION;
+    },
+    [apollo, communityId],
+  );
+
+  const {
+    items: reports,
+    totalCount,
+    hasNextPage,
+    loading: loadingMore,
+    error: loadError,
+    loadMore,
+  } = useCursorPagination({
+    initial: initialReports ?? EMPTY_CONNECTION,
+    fetchMore: fetchMoreReports,
+    pageSize: PAGE_SIZE,
+    resetKey: communityId,
+  });
+
+  const handleLoadMore = useCallback(() => {
+    void loadMore();
+  }, [loadMore]);
+
+  // backend fragment (`AdminBrowseReportFields`) は ReportRow の super set
+  // (id/variant/status/publishedAt + community{id,name}) なので構造的に互換。
+  const reportRows: ReportRow[] = reports;
 
   return (
     <CommunityReportsTab
       communityId={communityId}
-      reports={reports}
+      reports={reportRows}
       totalCount={totalCount}
       hasNextPage={hasNextPage}
       loading={false}
@@ -116,16 +104,5 @@ export function CommunityReportsTabContainer({
       loadingMore={loadingMore}
       onLoadMore={handleLoadMore}
     />
-  );
-}
-
-function extractReports(
-  conn: GqlGetAdminBrowseReportsQuery["adminBrowseReports"] | null | undefined,
-): ReportRow[] {
-  if (!conn) return [];
-  return (
-    conn.edges
-      ?.map((e) => e?.node)
-      .filter(<T,>(n: T | null | undefined): n is T => n != null) ?? []
   );
 }

--- a/src/app/sysAdmin/features/system/templates/editor/components/GenerationTemplateContainer.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/GenerationTemplateContainer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useApolloClient } from "@apollo/client";
 import {
@@ -68,9 +68,6 @@ export function GenerationTemplateContainer({
 }: Props) {
   const router = useRouter();
   const apollo = useApolloClient();
-  const [feedbackTotalCount, setFeedbackTotalCount] = useState(
-    initialFeedbacks?.totalCount ?? 0,
-  );
 
   const [save, { loading: saving, error: saveError }] =
     useUpdateReportTemplateMutation();
@@ -129,15 +126,14 @@ export function GenerationTemplateContainer({
         },
         fetchPolicy: "network-only",
       });
-      const conn = result.data.adminTemplateFeedbacks ?? EMPTY_CONNECTION;
-      setFeedbackTotalCount(conn.totalCount);
-      return conn;
+      return result.data.adminTemplateFeedbacks ?? EMPTY_CONNECTION;
     },
     [apollo, variant],
   );
 
   const {
     items: feedbacks,
+    totalCount: feedbackTotalCount,
     hasNextPage: feedbacksHasNextPage,
     loading: feedbacksLoadingMore,
     loadMore: loadMoreFeedbacks,

--- a/src/app/sysAdmin/features/system/templates/editor/components/JudgeTemplateContainer.tsx
+++ b/src/app/sysAdmin/features/system/templates/editor/components/JudgeTemplateContainer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { useApolloClient } from "@apollo/client";
 import {
   GqlReportTemplateKind,
@@ -57,9 +57,6 @@ export function JudgeTemplateContainer({
   initialStats,
 }: Props) {
   const apollo = useApolloClient();
-  const [feedbackTotalCount, setFeedbackTotalCount] = useState(
-    initialFeedbacks?.totalCount ?? 0,
-  );
 
   const fetchMoreFeedbacks = useCallback(
     async (cursor: string, first: number) => {
@@ -76,15 +73,14 @@ export function JudgeTemplateContainer({
         },
         fetchPolicy: "network-only",
       });
-      const conn = result.data.adminTemplateFeedbacks ?? EMPTY_CONNECTION;
-      setFeedbackTotalCount(conn.totalCount);
-      return conn;
+      return result.data.adminTemplateFeedbacks ?? EMPTY_CONNECTION;
     },
     [apollo, variant],
   );
 
   const {
     items: feedbacks,
+    totalCount: feedbackTotalCount,
     hasNextPage: feedbacksHasNextPage,
     loading: feedbacksLoadingMore,
     loadMore: loadMoreFeedbacks,


### PR DESCRIPTION
PR #1188 への gemini-code-assist のレビュー指摘 (medium ×3) を解消するクリーンアップ。

## 含まれる変更

### `useCursorPagination` に `totalCount` / `error` を集約 (gemini point 1)
- `Result<TItem>` に `totalCount` と `error` を追加。`initial.totalCount ?? 累積件数` で初期化
- `loadMore` 成功時に `next.totalCount` で更新、失敗時に `error` に詰める
- `useEffect` (initial 切替) / `reset()` でも同様に sync

### cursor の null チェックを厳密化 (gemini point 2)
- `useCursorPagination` の loadMore guard を `!endCursorRef.current` → `endCursorRef.current == null` に
- 空文字 `""` を有効な cursor として扱えるように

### `CommunityReportsTabContainer` を hook に統合 (gemini point 3)
- 手動の useState × 6 / useRef × 3 / try-finally を撤去
- `useCursorPagination` に置き換え、`resetKey={communityId}` で community 切替時の再同期に対応
- View への contract (props) は変更なし — 純粋な内部リファクタ

### Generation / Judge Container の重複 state 削除
- `feedbackTotalCount` の useState と `setFeedbackTotalCount(conn.totalCount)` を削除
- hook の `totalCount` をそのまま View に流す

## 検証手順
- [ ] テンプレ詳細 (生成 / 評価): 「もっと見る」で feedbacks が追加読み込みされ、件数表示が更新される
- [ ] コミュニティ詳細レポートタブ: 「もっと見る」が動作し、新規発行で totalCount がドリフトしない
- [ ] コミュニティ切替: `key={communityId}` + `resetKey` で SSR initial に再同期される
- [ ] Storybook: 既存の各 story がエラーなく描画される

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKqFwHa4CxrJiXeR5jGtq9)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
