### PR TITLE
refactor(MarkdownContent): #1191 のレビュー指摘 4 件を反映

### DIFF
--- a/src/app/sysAdmin/[communityId]/reports/[reportId]/page.tsx
+++ b/src/app/sysAdmin/[communityId]/reports/[reportId]/page.tsx
@@ -14,7 +14,9 @@ type PageProps = {
  *
  * SSR + cookie で `report(id)` と `report.feedbacks` を並行取得して
  * client wrapper に渡す。本文 markdown は client 側で `react-markdown` が
- * パース + React 側のエスケープでサニタイズされる。
+ * パースする。`react-markdown` はデフォルトで生 HTML をレンダリングせず、
+ * リンク / 画像 URL について `javascript:` 等の危険プロトコルを除外する
+ * ため、別途 sanitize ライブラリは不要。
  *
  * Report と feedbacks Connection を別 query にしているのは Armor の cost
  * limit 回避のため (`graphql/account/report/server.ts` のコメント参照)。

--- a/src/components/shared/MarkdownContent.tsx
+++ b/src/components/shared/MarkdownContent.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { ExternalLink } from "lucide-react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -18,6 +16,9 @@ type Props = {
   children: string;
   className?: string;
 };
+
+// `http://`, `https://`, プロトコル相対 (`//`) のいずれも外部リンクとして扱う。
+const EXTERNAL_HREF = /^(https?:)?\/\//;
 
 const components: Components = {
   h1: ({ className, ...props }) => (
@@ -75,7 +76,7 @@ const components: Components = {
     />
   ),
   a: ({ className, children, ...props }) => {
-    const isExternal = props.href?.startsWith("http") ?? false;
+    const isExternal = EXTERNAL_HREF.test(props.href ?? "");
     return (
       <a
         className={cn(
@@ -150,12 +151,36 @@ const components: Components = {
       {...props}
     />
   ),
-  table: ({ children }) => <Table className="my-4">{children}</Table>,
-  thead: ({ children }) => <TableHeader>{children}</TableHeader>,
-  tbody: ({ children }) => <TableBody>{children}</TableBody>,
-  tr: ({ children }) => <TableRow>{children}</TableRow>,
-  th: ({ children, style }) => <TableHead style={style}>{children}</TableHead>,
-  td: ({ children, style }) => <TableCell style={style}>{children}</TableCell>,
+  table: ({ className, children, ...props }) => (
+    <Table className={cn("my-4", className)} {...props}>
+      {children}
+    </Table>
+  ),
+  thead: ({ className, children, ...props }) => (
+    <TableHeader className={className} {...props}>
+      {children}
+    </TableHeader>
+  ),
+  tbody: ({ className, children, ...props }) => (
+    <TableBody className={className} {...props}>
+      {children}
+    </TableBody>
+  ),
+  tr: ({ className, children, ...props }) => (
+    <TableRow className={className} {...props}>
+      {children}
+    </TableRow>
+  ),
+  th: ({ className, children, ...props }) => (
+    <TableHead className={className} {...props}>
+      {children}
+    </TableHead>
+  ),
+  td: ({ className, children, ...props }) => (
+    <TableCell className={className} {...props}>
+      {children}
+    </TableCell>
+  ),
   img: ({ className, alt, ...props }) => (
     // eslint-disable-next-line @next/next/no-img-element
     <img


### PR DESCRIPTION
#1191（develop → master のリリース PR）に Copilot / gemini から付いたレビュー指摘のうち、actionable な 4 件をまとめて反映するフォローアップ。

## 含まれる変更

### `MarkdownContent` から `"use client"` を撤去
[#1191 の指摘](https://github.com/Hopin-inc/civicship-portal/pull/1191#discussion_r3154576017)。`MarkdownContent` 本体は hooks / browser API を一切使っていないため、`"use client"` を外して RSC でも使えるようにする。既存 callers（`ReportContentSection` / `ArticleDetail` / `TermsPageClient` / `PrivacyPageClient`）は全て自前で `"use client"` を持つため、この変更で挙動は変わらないが、将来 server component から直接使う構成（特に長文の Terms / Privacy）に開く。

### 外部リンク判定をプロトコル相対 URL にも対応
[#1191 の指摘](https://github.com/Hopin-inc/civicship-portal/pull/1191#discussion_r3154523153)。`startsWith("http")` だと `//example.com` 形式が外部扱いされず `target="_blank"` + `ExternalLink` アイコンが付かない。`/^(https?:)?\/\//` の正規表現に切替。

### `table` 系 renderer で `className` / `...props` をスルーで渡す
[#1191 の指摘](https://github.com/Hopin-inc/civicship-portal/pull/1191#discussion_r3154575901)。`table/thead/tbody/tr/th/td` の renderer が `children`（と一部 `style`）しか受け取っておらず、`react-markdown` 側が付与する属性が落ちていた。`{ className, ...props }` を受けて shadcn コンポーネントへ素通しする形へ。

### sysAdmin report page の XSS コメントを正しい説明へ
[#1191 の指摘](https://github.com/Hopin-inc/civicship-portal/pull/1191#discussion_r3154575990)。「React 側のエスケープでサニタイズ」は不正確。実際は `react-markdown` がデフォルトで生 HTML を描画しないこと + リンク / 画像の危険プロトコル（`javascript:` 等）を除外することで XSS リスクを下げているので、その旨へ書き換え。

## 含めない変更

- 言語指定なしの fenced code block を inline 判定してしまう件（[#1191](https://github.com/Hopin-inc/civicship-portal/pull/1191#discussion_r3154575848)）：`react-markdown@^10.1.0` では `inline` prop が廃止済みなので Copilot / gemini の提案どおりには直せず、`pre` 内の `code` をリセットする CSS 重ね方式など別のパターンへ書き直しが必要。スコープが膨らむため別 PR で対応する。

## 検証手順

- [ ] レポート詳細 / Article / Terms / Privacy が引き続き正しく描画される
- [ ] 外部リンク（`https://...` および `//...`）に `ExternalLink` アイコンが付き、新しいタブで開く
- [ ] 内部リンク（`/foo` 等）には外部リンク扱いの装飾が付かない
- [ ] markdown テーブルが従来通り描画される（`align` 由来の `style` も保持される）

## 関連
- #1191（develop → master、レビュー対応元）

https://claude.ai/code/session_013rEiJHLdP3G8Vj39PPiEss

---
_Generated by [Claude Code](https://claude.ai/code/session_013rEiJHLdP3G8Vj39PPiEss)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
