### PR TITLE
fix(icons): repair default favicon and OG image, drop dead apple-touch-icon

### DIFF
--- a/src/app/community/[communityId]/layout.tsx
+++ b/src/app/community/[communityId]/layout.tsx
@@ -43,7 +43,6 @@ export async function generateMetadata({
     description: config.description,
     icons: {
       icon: [{ url: DEFAULT_ASSET_PATHS.FAVICON }],
-      apple: [{ url: DEFAULT_ASSET_PATHS.APPLE_TOUCH_ICON }],
     },
     openGraph: {
       title: config.title,

--- a/src/lib/communities/constants.ts
+++ b/src/lib/communities/constants.ts
@@ -5,7 +5,7 @@ export const DEFAULT_ASSET_PATHS = {
   SQUARE_LOGO: "/communities/default/logo-square.jpg",
   FAVICON: "https://storage.googleapis.com/prod-civicship-storage-public/communities/default/favicon.ico",
   APPLE_TOUCH_ICON: "/communities/default/apple-touch-icon.png",
-  OG_IMAGE: "/communities/default/ogp.png",
+  OG_IMAGE: "https://storage.googleapis.com/prod-civicship-storage-public/communities/default/ogp.jpg",
 } as const;
 
 export const ACTIVE_COMMUNITY_IDS = [

--- a/src/lib/communities/constants.ts
+++ b/src/lib/communities/constants.ts
@@ -3,7 +3,7 @@ import { CommunityPortalConfig } from "@/lib/communities/config";
 export const DEFAULT_ASSET_PATHS = {
   LOGO: "/communities/default/logo.jpg",
   SQUARE_LOGO: "/communities/default/logo-square.jpg",
-  FAVICON: "/communities/default/favicon.ico",
+  FAVICON: "https://storage.googleapis.com/prod-civicship-storage-public/communities/default/favicon.ico",
   APPLE_TOUCH_ICON: "/communities/default/apple-touch-icon.png",
   OG_IMAGE: "/communities/default/ogp.png",
 } as const;

--- a/src/lib/communities/constants.ts
+++ b/src/lib/communities/constants.ts
@@ -4,7 +4,6 @@ export const DEFAULT_ASSET_PATHS = {
   LOGO: "/communities/default/logo.jpg",
   SQUARE_LOGO: "/communities/default/logo-square.jpg",
   FAVICON: "https://storage.googleapis.com/prod-civicship-storage-public/communities/default/favicon.ico",
-  APPLE_TOUCH_ICON: "/communities/default/apple-touch-icon.png",
   OG_IMAGE: "https://storage.googleapis.com/prod-civicship-storage-public/communities/default/ogp.jpg",
 } as const;
 


### PR DESCRIPTION
## Summary

- `DEFAULT_ASSET_PATHS.FAVICON` と `OG_IMAGE` がローカルに存在しないパス (`/communities/default/...`) を指していて、全コミュニティで favicon / OGP画像が 404 になっていたのを、prod GCS の実在URLに差し替え
- `APPLE_TOUCH_ICON` は実ファイルが無く、アップする予定もないため、定数と `community/[communityId]/layout.tsx` の `apple` 行ごと削除（iOS Safari は favicon にフォールバックするので機能影響なし）

## Test plan

- [ ] ブラウザで任意のコミュニティページを開き、タブの favicon が表示されることを確認
- [ ] ページURLをSlack / LINE / X 等に貼って、OGPプレビュー画像が表示されることを確認
- [ ] iOS Safari で「ホーム画面に追加」した際にアイコンが表示されること（favicon フォールバック）

https://claude.ai/code/session_01WPfJwuBuUy4RrJjdStLs98

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPfJwuBuUy4RrJjdStLs98)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
