### PR TITLE
fix(votes): ApolloError 型安全化 + requiredRole 翻訳

### DIFF
--- a/src/app/community/[communityId]/admin/votes/features/editor/hooks/useVoteTopicSave.ts
+++ b/src/app/community/[communityId]/admin/votes/features/editor/hooks/useVoteTopicSave.ts
@@ -3,6 +3,7 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
 import { toast } from "react-toastify";
+import { ApolloError } from "@apollo/client";
 import { useTranslations } from "next-intl";
 import {
   GqlVoteGateType,
@@ -110,9 +111,7 @@ export function useVoteTopicSave({
           component: "useVoteTopicSave",
         });
         const gqlErrors =
-          error && typeof error === "object" && "graphQLErrors" in error
-            ? (error as { graphQLErrors: Array<{ extensions?: { code?: string } }> }).graphQLErrors
-            : [];
+          error instanceof ApolloError ? error.graphQLErrors : [];
         const isNotEditable = gqlErrors.some(
           (e) => e.extensions?.code === "VOTE_TOPIC_NOT_EDITABLE",
         );

--- a/src/app/community/[communityId]/votes/features/cast/components/VoteEligibilityNotice.tsx
+++ b/src/app/community/[communityId]/votes/features/cast/components/VoteEligibilityNotice.tsx
@@ -3,8 +3,23 @@
 import { useTranslations } from "next-intl";
 import { ShieldX } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
+import { GqlRole } from "@/types/graphql";
 import { REASON_I18N_MAP } from "../constants/ineligibleReason";
 import type { VoteGateInfo } from "../types/VoteCastViewModel";
+
+type Translator = ReturnType<typeof useTranslations>;
+
+function translateRole(role: string, t: Translator): string {
+  switch (role) {
+    case GqlRole.Owner:
+      return t("adminVotes.form.gate.requiredRole.OWNER");
+    case GqlRole.Manager:
+      return t("adminVotes.form.gate.requiredRole.MANAGER");
+    case GqlRole.Member:
+    default:
+      return t("adminVotes.form.gate.requiredRole.MEMBER");
+  }
+}
 
 interface VoteEligibilityNoticeProps {
   reason: string | null;
@@ -21,7 +36,7 @@ export function VoteEligibilityNotice({
     if (!reason) return null;
     if (reason === "INSUFFICIENT_ROLE" && gate.requiredRoleLabel) {
       return t("votes.eligibility.reason.INSUFFICIENT_ROLE", {
-        role: gate.requiredRoleLabel,
+        role: translateRole(gate.requiredRoleLabel, t),
       });
     }
     if (reason === "REQUIRED_NFT_NOT_FOUND" && gate.nftTokenName) {
@@ -41,7 +56,7 @@ export function VoteEligibilityNotice({
     }
     if (gate.type === "membership" && gate.requiredRoleLabel) {
       return t("votes.eligibility.requirement.membershipWithRole", {
-        role: gate.requiredRoleLabel,
+        role: translateRole(gate.requiredRoleLabel, t),
       });
     }
     return t("votes.eligibility.requirement.membership");

--- a/src/app/community/[communityId]/votes/features/cast/components/VoteEligibilityNotice.tsx
+++ b/src/app/community/[communityId]/votes/features/cast/components/VoteEligibilityNotice.tsx
@@ -3,23 +3,9 @@
 import { useTranslations } from "next-intl";
 import { ShieldX } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
-import { GqlRole } from "@/types/graphql";
 import { REASON_I18N_MAP } from "../constants/ineligibleReason";
+import { translateRole } from "../utils/translateRole";
 import type { VoteGateInfo } from "../types/VoteCastViewModel";
-
-type Translator = ReturnType<typeof useTranslations>;
-
-function translateRole(role: string, t: Translator): string {
-  switch (role) {
-    case GqlRole.Owner:
-      return t("adminVotes.form.gate.requiredRole.OWNER");
-    case GqlRole.Manager:
-      return t("adminVotes.form.gate.requiredRole.MANAGER");
-    case GqlRole.Member:
-    default:
-      return t("adminVotes.form.gate.requiredRole.MEMBER");
-  }
-}
 
 interface VoteEligibilityNoticeProps {
   reason: string | null;

--- a/src/app/community/[communityId]/votes/features/cast/components/VoteGateInfoBanner.tsx
+++ b/src/app/community/[communityId]/votes/features/cast/components/VoteGateInfoBanner.tsx
@@ -2,7 +2,22 @@
 
 import { useTranslations } from "next-intl";
 import { ShieldCheck } from "lucide-react";
+import { GqlRole } from "@/types/graphql";
 import type { VoteGateInfo } from "../types/VoteCastViewModel";
+
+type Translator = ReturnType<typeof useTranslations>;
+
+function translateRole(role: string, t: Translator): string {
+  switch (role) {
+    case GqlRole.Owner:
+      return t("adminVotes.form.gate.requiredRole.OWNER");
+    case GqlRole.Manager:
+      return t("adminVotes.form.gate.requiredRole.MANAGER");
+    case GqlRole.Member:
+    default:
+      return t("adminVotes.form.gate.requiredRole.MEMBER");
+  }
+}
 
 interface VoteGateInfoBannerProps {
   gate: VoteGateInfo;
@@ -19,7 +34,7 @@ export function VoteGateInfoBanner({ gate }: VoteGateInfoBannerProps) {
     }
     if (gate.type === "membership" && gate.requiredRoleLabel) {
       return t("votes.eligibility.requirement.membershipWithRole", {
-        role: gate.requiredRoleLabel,
+        role: translateRole(gate.requiredRoleLabel, t),
       });
     }
     return t("votes.eligibility.requirement.membership");

--- a/src/app/community/[communityId]/votes/features/cast/components/VoteGateInfoBanner.tsx
+++ b/src/app/community/[communityId]/votes/features/cast/components/VoteGateInfoBanner.tsx
@@ -2,22 +2,8 @@
 
 import { useTranslations } from "next-intl";
 import { ShieldCheck } from "lucide-react";
-import { GqlRole } from "@/types/graphql";
+import { translateRole } from "../utils/translateRole";
 import type { VoteGateInfo } from "../types/VoteCastViewModel";
-
-type Translator = ReturnType<typeof useTranslations>;
-
-function translateRole(role: string, t: Translator): string {
-  switch (role) {
-    case GqlRole.Owner:
-      return t("adminVotes.form.gate.requiredRole.OWNER");
-    case GqlRole.Manager:
-      return t("adminVotes.form.gate.requiredRole.MANAGER");
-    case GqlRole.Member:
-    default:
-      return t("adminVotes.form.gate.requiredRole.MEMBER");
-  }
-}
 
 interface VoteGateInfoBannerProps {
   gate: VoteGateInfo;

--- a/src/app/community/[communityId]/votes/features/cast/utils/translateRole.ts
+++ b/src/app/community/[communityId]/votes/features/cast/utils/translateRole.ts
@@ -1,0 +1,16 @@
+import { useTranslations } from "next-intl";
+import { GqlRole } from "@/types/graphql";
+
+export type Translator = ReturnType<typeof useTranslations>;
+
+export function translateRole(role: string, t: Translator): string {
+  switch (role) {
+    case GqlRole.Owner:
+      return t("adminVotes.form.gate.requiredRole.OWNER");
+    case GqlRole.Manager:
+      return t("adminVotes.form.gate.requiredRole.MANAGER");
+    case GqlRole.Member:
+    default:
+      return t("adminVotes.form.gate.requiredRole.MEMBER");
+  }
+}


### PR DESCRIPTION
## Summary

PR #1197 のレビュー指摘 2 件を修正。

1. **ApolloError 型安全化** (gemini): エラー判定を `error instanceof ApolloError` に改善
2. **requiredRoleLabel 翻訳** (Devin): raw enum "MANAGER" → 翻訳済み「マネージャー」に。VoteEligibilityNotice + VoteGateInfoBanner に `translateRole` ヘルパー追加

## Test plan
- [ ] `pnpm typecheck` 通過
- [ ] 投票資格表示に「マネージャー 以上の権限が必要です」と表示される（"MANAGER" ではない）

https://claude.ai/code/session_01GTNLW5bKXQAQjYUmudAxDb

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTNLW5bKXQAQjYUmudAxDb)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
