### PR TITLE
release: CI/CDパイプライン高速化を本番反映

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,35 @@
 node_modules
+.next
+.git
+.github
+.vscode
+.idea
+
+# Tests / dev tooling not needed in production image
+e2e
+playwright.config.ts
+playwright-report
+test-results
+coverage
+**/*.test.ts
+**/*.test.tsx
+**/*.spec.ts
+**/*.spec.tsx
+**/__tests__
+**/__mocks__
+
+# Storybook artifacts
+storybook-static
+.storybook
+
+# Local env files (build-time vars come from --build-arg)
+.env
+.env.local
+.env.*.local
+
+# Miscellaneous
+*.log
+.DS_Store
+README.md
+LICENSE
+docs

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -1,0 +1,111 @@
+name: Deploy to Cloud Run (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: GitHub Environment to load secrets/vars from
+        required: true
+        type: string
+      app_env_build_arg:
+        description: Value passed as ENV build-arg (e.g. "staging" for dev; empty for prod)
+        required: false
+        type: string
+        default: ""
+      runtime_env_vars:
+        description: Multiline KEY=VALUE pairs forwarded to Cloud Run as env vars
+        required: true
+        type: string
+      image_tag:
+        description: Additional image tag (typically the commit SHA)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 30
+
+    env:
+      GCP_REGION: ${{ secrets.GCP_REGION }}
+      ARTIFACT_REGISTRY: ${{ secrets.ARTIFACT_REGISTRY }}
+      APPLICATION_NAME: ${{ secrets.APPLICATION_NAME }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - id: auth
+        name: Authenticate to Google Cloud (Workload Identity Federation)
+        uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          token_format: access_token
+
+      - name: Set up gcloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Login to Artifact Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ env.GCP_REGION }}-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+
+      - name: Compute image references
+        id: image
+        run: |
+          BASE="${ARTIFACT_REGISTRY}/${APPLICATION_NAME}"
+          {
+            echo "base=${BASE}"
+            echo "latest=${BASE}:latest"
+            echo "sha=${BASE}:${{ inputs.image_tag }}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v6.7.0
+        with:
+          context: .
+          push: true
+          provenance: false
+          tags: |
+            ${{ steps.image.outputs.latest }}
+            ${{ steps.image.outputs.sha }}
+          cache-from: |
+            type=gha,scope=${{ inputs.environment }}
+            type=registry,ref=${{ steps.image.outputs.base }}:buildcache
+          cache-to: |
+            type=gha,mode=max,scope=${{ inputs.environment }}
+            type=registry,ref=${{ steps.image.outputs.base }}:buildcache,mode=max
+          build-args: |
+            NEXT_PUBLIC_FIREBASE_PROJECT_ID=${{ secrets.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}
+            NEXT_PUBLIC_FIREBASE_API_KEY=${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
+            NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${{ secrets.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}
+            NEXT_PUBLIC_FIREBASE_APP_ID=${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
+            NEXT_PUBLIC_DOMAIN=${{ secrets.NEXT_PUBLIC_DOMAIN }}
+            NEXT_PUBLIC_API_ENDPOINT=${{ secrets.NEXT_PUBLIC_API_ENDPOINT }}
+            NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT=${{ secrets.NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT }}
+            NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
+            NEXT_PUBLIC_LOG_LEVEL=${{ vars.NEXT_PUBLIC_LOG_LEVEL }}
+            NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS=${{ vars.NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS }}
+            ENV=${{ inputs.app_env_build_arg }}
+
+      - name: Deploy to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.APPLICATION_NAME }}
+          image: ${{ steps.image.outputs.sha }}
+          region: ${{ env.GCP_REGION }}
+          env_vars: ${{ inputs.runtime_env_vars }}
+          flags: >
+            --min-instances=0
+            --max-instances=10

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -31,7 +31,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        with:
+          version: 9
 
       - name: Set up Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
@@ -40,7 +42,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Publish to Chromatic
         env:

--- a/.github/workflows/deploy-to-cloud-run-dev.yml
+++ b/.github/workflows/deploy-to-cloud-run-dev.yml
@@ -1,46 +1,33 @@
 name: Build and Deploy (Dev)
+
 on:
   push:
     branches:
       - develop
       - hotfix/**
       - epic/**
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
-  build-and-deploy:
+  lint:
+    name: Lint (GraphQL depth)
     runs-on: ubuntu-latest
-    environment: kyoso-dev
-    timeout-minutes: 30
-
-    permissions:
-      id-token: write
-      contents: read
-
-    env:
-      GCP_REGION: ${{ secrets.GCP_REGION }}
-      ARTIFACT_REGISTRY: ${{ secrets.ARTIFACT_REGISTRY }}
-      APPLICATION_NAME: ${{ secrets.APPLICATION_NAME }}
-      NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}
-      NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
-      NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{ secrets.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}
-      NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
-      NEXT_PUBLIC_DOMAIN: ${{ secrets.NEXT_PUBLIC_DOMAIN }}
-      NEXT_PUBLIC_API_ENDPOINT: ${{ secrets.NEXT_PUBLIC_API_ENDPOINT }}
-      NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT: ${{ secrets.NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT }}
-      NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
-      NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
-      NEXT_PUBLIC_LOG_LEVEL: ${{ vars.NEXT_PUBLIC_LOG_LEVEL }}
-      NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS: ${{ vars.NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS }}
-
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        with:
+          version: 9
 
       - name: Set up Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
@@ -49,52 +36,19 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Run GraphQL depth limit check
         run: pnpm run lint:graphql
 
-      - name: Authenticate to Google Cloud (Workload Identity Federation)
-        uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-
-      - name: Set up gcloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Configure Docker for Artifact Registry
-        run: |
-          gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY }}
-          gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
-
-      - name: Build Docker image
-        run: |
-          docker build -t ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest . \
-            --build-arg NEXT_PUBLIC_FIREBASE_PROJECT_ID=${{ env.NEXT_PUBLIC_FIREBASE_PROJECT_ID }} \
-            --build-arg NEXT_PUBLIC_FIREBASE_API_KEY=${{ env.NEXT_PUBLIC_FIREBASE_API_KEY }} \
-            --build-arg NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${{ env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }} \
-            --build-arg NEXT_PUBLIC_FIREBASE_APP_ID=${{ env.NEXT_PUBLIC_FIREBASE_APP_ID }} \
-            --build-arg NEXT_PUBLIC_DOMAIN=${{ env.NEXT_PUBLIC_DOMAIN }} \
-            --build-arg NEXT_PUBLIC_API_ENDPOINT=${{ env.NEXT_PUBLIC_API_ENDPOINT }} \
-            --build-arg NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT=${{ env.NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT }} \
-            --build-arg NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${{ env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }} \
-            --build-arg NEXT_PUBLIC_LOG_LEVEL=${{ env.NEXT_PUBLIC_LOG_LEVEL }} \
-            --build-arg NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS="${{ env.NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS }}" \
-            --build-arg ENV=staging
-
-      - name: Push image to Artifact Registry
-        run: |
-          docker push ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
-
-      - name: Deploy to Cloud Run
-        uses: google-github-actions/deploy-cloudrun@v2 # v2.8.1
-        with:
-          service: ${{ env.APPLICATION_NAME }}
-          image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
-          region: ${{ env.GCP_REGION }}
-          env_vars: |
-            ENV=staging
-          flags: >
-            --min-instances=0
-            --max-instances=10
+  deploy:
+    name: Build & Deploy
+    needs: lint
+    uses: ./.github/workflows/_deploy-cloud-run.yml
+    secrets: inherit
+    with:
+      environment: kyoso-dev
+      app_env_build_arg: staging
+      runtime_env_vars: |
+        ENV=staging
+      image_tag: ${{ github.sha }}

--- a/.github/workflows/deploy-to-cloud-run-prod.yml
+++ b/.github/workflows/deploy-to-cloud-run-prod.yml
@@ -1,94 +1,26 @@
 name: Build and Deploy (Prd)
+
 on:
   push:
     branches:
       - master
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
-  build-and-deploy:
-    runs-on: ubuntu-latest
-    environment: co-creation-dao-prod
-    timeout-minutes: 30
-
-    permissions:
-      id-token: write
-      contents: read
-
-    env:
-      GCP_REGION: ${{ secrets.GCP_REGION }}
-      ARTIFACT_REGISTRY: ${{ secrets.ARTIFACT_REGISTRY }}
-      APPLICATION_NAME: ${{ secrets.APPLICATION_NAME }}
-      NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}
-      NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
-      NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{ secrets.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}
-      NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
-      NEXT_PUBLIC_DOMAIN: ${{ secrets.NEXT_PUBLIC_DOMAIN }}
-      NEXT_PUBLIC_API_ENDPOINT: ${{ secrets.NEXT_PUBLIC_API_ENDPOINT }}
-      NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT: ${{ secrets.NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT }}
-      NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
-      NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
-      NEXT_PUBLIC_LOG_LEVEL: ${{ vars.NEXT_PUBLIC_LOG_LEVEL }}
-      NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS: ${{ vars.NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Install pnpm
-        run: npm install -g pnpm
-
-      - name: Set up Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version: "20.18"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Authenticate to Google Cloud (Workload Identity Federation)
-        uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-
-      - name: Set up gcloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Configure Docker for Artifact Registry
-        run: |
-          gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY }}
-          gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
-
-      - name: Build Docker image
-        run: |
-          docker build -t ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest . \
-            --build-arg NEXT_PUBLIC_FIREBASE_PROJECT_ID=${{ env.NEXT_PUBLIC_FIREBASE_PROJECT_ID }} \
-            --build-arg NEXT_PUBLIC_FIREBASE_API_KEY=${{ env.NEXT_PUBLIC_FIREBASE_API_KEY }} \
-            --build-arg NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${{ env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }} \
-            --build-arg NEXT_PUBLIC_FIREBASE_APP_ID=${{ env.NEXT_PUBLIC_FIREBASE_APP_ID }} \
-            --build-arg NEXT_PUBLIC_DOMAIN=${{ env.NEXT_PUBLIC_DOMAIN }} \
-            --build-arg NEXT_PUBLIC_API_ENDPOINT=${{ env.NEXT_PUBLIC_API_ENDPOINT }} \
-            --build-arg NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT=${{ env.NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT }} \
-            --build-arg NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${{ env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }} \
-            --build-arg NEXT_PUBLIC_LOG_LEVEL=${{ env.NEXT_PUBLIC_LOG_LEVEL }} \
-            --build-arg NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS="${{ env.NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS }}"
-
-      - name: Push image to Artifact Registry
-        run: |
-          docker push ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
-
-      - name: Deploy to Cloud Run
-        uses: google-github-actions/deploy-cloudrun@v2 # v2.8.1
-        with:
-          service: ${{ env.APPLICATION_NAME }}
-          image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
-          region: ${{ env.GCP_REGION }}
-          env_vars: |
-            NODE_ENV=production
-          flags: >
-            --min-instances=0
-            --max-instances=10
+  deploy:
+    name: Build & Deploy
+    uses: ./.github/workflows/_deploy-cloud-run.yml
+    secrets: inherit
+    with:
+      environment: co-creation-dao-prod
+      app_env_build_arg: ""
+      runtime_env_vars: |
+        NODE_ENV=production
+      image_tag: ${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,27 @@
-FROM node:20.18
+# syntax=docker/dockerfile:1.7
 
+ARG NODE_VERSION=20.18.1
+ARG PNPM_VERSION=9.15.4
+
+# ---- base: shared toolchain ----
+FROM node:${NODE_VERSION}-alpine AS base
+ARG PNPM_VERSION
+RUN apk add --no-cache libc6-compat \
+    && corepack enable \
+    && corepack prepare pnpm@${PNPM_VERSION} --activate
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# ---- deps: install dependencies (cached while lockfile/patches don't change) ----
+FROM base AS deps
+COPY package.json pnpm-lock.yaml ./
+COPY patches ./patches
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm config set store-dir /root/.local/share/pnpm/store \
+    && pnpm install --frozen-lockfile --prefer-offline
+
+# ---- builder: build the Next.js app (standalone output) ----
+FROM base AS builder
 ARG NEXT_PUBLIC_FIREBASE_PROJECT_ID
 ARG NEXT_PUBLIC_FIREBASE_API_KEY
 ARG NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
@@ -12,37 +34,43 @@ ARG NEXT_PUBLIC_LOG_LEVEL
 ARG NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS
 ARG ENV
 
-# NOTE: NEXT_PUBLIC_ 変数は、Next.jsビルド時に組み込まれるため、.envファイルを作って参照する必要がある
-RUN touch .env
-RUN echo "NEXT_PUBLIC_FIREBASE_PROJECT_ID=$NEXT_PUBLIC_FIREBASE_PROJECT_ID" >> .env
-RUN echo "NEXT_PUBLIC_FIREBASE_API_KEY=$NEXT_PUBLIC_FIREBASE_API_KEY" >> .env
-RUN echo "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=$NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN" >> .env
-RUN echo "NEXT_PUBLIC_FIREBASE_APP_ID=$NEXT_PUBLIC_FIREBASE_APP_ID" >> .env
-RUN echo "NEXT_PUBLIC_DOMAIN=$NEXT_PUBLIC_DOMAIN" >> .env
-RUN echo "NEXT_PUBLIC_API_ENDPOINT=$NEXT_PUBLIC_API_ENDPOINT" >> .env
-RUN echo "NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT=$NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT" >> .env
-RUN echo "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=$NEXT_PUBLIC_GOOGLE_MAPS_API_KEY" >> .env
-RUN echo "NEXT_PUBLIC_LOG_LEVEL=$NEXT_PUBLIC_LOG_LEVEL" >> .env
-RUN echo "NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS=$NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS" >> .env
-RUN echo "ENV=$ENV" >> .env
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
 
-# グローバルに pnpm をインストール
-RUN npm install -g pnpm
+# Next.js は NEXT_PUBLIC_* をビルド時に静的に埋め込むため .env 経由で渡す
+RUN printf "%s\n" \
+    "NEXT_PUBLIC_FIREBASE_PROJECT_ID=${NEXT_PUBLIC_FIREBASE_PROJECT_ID}" \
+    "NEXT_PUBLIC_FIREBASE_API_KEY=${NEXT_PUBLIC_FIREBASE_API_KEY}" \
+    "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN}" \
+    "NEXT_PUBLIC_FIREBASE_APP_ID=${NEXT_PUBLIC_FIREBASE_APP_ID}" \
+    "NEXT_PUBLIC_DOMAIN=${NEXT_PUBLIC_DOMAIN}" \
+    "NEXT_PUBLIC_API_ENDPOINT=${NEXT_PUBLIC_API_ENDPOINT}" \
+    "NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT=${NEXT_PUBLIC_LIFF_LOGIN_ENDPOINT}" \
+    "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}" \
+    "NEXT_PUBLIC_LOG_LEVEL=${NEXT_PUBLIC_LOG_LEVEL}" \
+    "NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS=${NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS}" \
+    "ENV=${ENV}" \
+    > .env
 
-# アプリケーションディレクトリを作成
+RUN --mount=type=cache,id=next-cache,target=/app/.next/cache \
+    pnpm build
+
+# ---- runner: minimal production image ----
+FROM node:${NODE_VERSION}-alpine AS runner
 WORKDIR /app
 
-# 依存関係の定義ファイルを先にコピー (キャッシュのため)
-COPY package.json pnpm-lock.yaml ./
+ENV NODE_ENV=production
+ENV PORT=8000
+ENV HOSTNAME=0.0.0.0
+ENV NEXT_TELEMETRY_DISABLED=1
 
-# 依存関係をインストール
-RUN pnpm install
+RUN addgroup --system --gid 1001 nodejs \
+    && adduser --system --uid 1001 nextjs
 
-# 残りのソースコードをコピー
-COPY . ./
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-# ビルド
-RUN pnpm build
-
-# アプリケーション起動
-CMD ["pnpm", "start"]
+USER nextjs
+EXPOSE 8000
+CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ ENV HOSTNAME=0.0.0.0
 ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN addgroup --system --gid 1001 nodejs \
-    && adduser --system --uid 1001 nextjs
+    && adduser --system --uid 1001 -G nodejs nextjs
 
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
     && pnpm install --frozen-lockfile --prefer-offline
 
 # ---- builder: build the Next.js app (standalone output) ----
-FROM base AS builder
+FROM deps AS builder
 ARG NEXT_PUBLIC_FIREBASE_PROJECT_ID
 ARG NEXT_PUBLIC_FIREBASE_API_KEY
 ARG NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
@@ -34,7 +34,6 @@ ARG NEXT_PUBLIC_LOG_LEVEL
 ARG NEXT_PUBLIC_ALLOWED_FRAME_ANCESTORS
 ARG ENV
 
-COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 # Next.js は NEXT_PUBLIC_* をビルド時に静的に埋め込むため .env 経由で渡す
@@ -58,6 +57,10 @@ RUN --mount=type=cache,id=next-cache,target=/app/.next/cache \
 # ---- runner: minimal production image ----
 FROM node:${NODE_VERSION}-alpine AS runner
 WORKDIR /app
+
+# Next.js standalone bundles native modules (sharp, next-swc) that need
+# glibc-compat shims on Alpine.
+RUN apk add --no-cache libc6-compat
 
 ENV NODE_ENV=production
 ENV PORT=8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,8 @@ ENV PORT=8000
 ENV HOSTNAME=0.0.0.0
 ENV NEXT_TELEMETRY_DISABLED=1
 
-RUN addgroup --system --gid 1001 nodejs \
-    && adduser --system --uid 1001 -G nodejs nextjs
+RUN addgroup -S -g 1001 nodejs \
+    && adduser -S -u 1001 -G nodejs nextjs
 
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,7 @@ const withBundleAnalyzer = bundleAnalyzer({
 });
 
 const nextConfig = {
+  output: "standalone",
   env: {
     ENV: process.env.ENV,
   },

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "retry": "^0.13.1",
+    "sharp": "^0.34.5",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "undici": "^7.22.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "retry": "^0.13.1",
-    "sharp": "^0.34.5",
+    "sharp": "0.34.5",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "undici": "^7.22.0",
@@ -164,7 +164,10 @@
       "lodash": ">=4.17.23",
       "mdast-util-to-hast": ">=13.2.1",
       "axios": "1.14.0"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "sharp"
+    ]
   },
   "engines": {
     "node": ">=20.18.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
       retry:
         specifier: ^0.13.1
         version: 0.13.1
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
@@ -11179,8 +11182,7 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
-  '@img/colour@1.0.0':
-    optional: true
+  '@img/colour@1.0.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -14907,8 +14909,7 @@ snapshots:
   detect-libc@1.0.3:
     optional: true
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
@@ -15180,7 +15181,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -15214,7 +15215,7 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.7.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15229,7 +15230,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -18144,7 +18145,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,7 +223,7 @@ importers:
         specifier: ^0.13.1
         version: 0.13.1
       sharp:
-        specifier: ^0.34.5
+        specifier: 0.34.5
         version: 0.34.5
       tailwind-merge:
         specifier: ^2.6.0


### PR DESCRIPTION
## 概要

`develop` を `master` に取り込み、CI/CD 最適化を本番環境に反映するためのプロモート PR です。

## 含まれる変更

PR #1196 で develop に統合済みの内容のみ（3コミット）:

- **Dockerfile**: マルチステージ化 + Next.js standalone 出力 + alpine runner（非rootユーザー実行、libc6-compat 同梱）
- **build-push-action 化**: GHA + Artifact Registry buildcache の二重キャッシュ。`:latest` と `:${sha}` の二重タグでロールバック容易性を確保
- **Reusable workflow** `_deploy-cloud-run.yml`: dev / prod の build & deploy ロジックを共通化
- **並列化**: dev workflow で GraphQL depth lint を独立ジョブ化、prod の不要だったホスト側 `pnpm install` を削除
- **ツール更新**: `pnpm/action-setup@v4` 採用、`--prefer-offline`、`.dockerignore` 拡張

## 期待効果

- 依存変化なしの PR: build + deploy が **3〜6分 → 1〜2分**（cache hit 時）
- イメージサイズ: 数百MB → 数十MB
- Cloud Run cold start 短縮

## 本番デプロイ前の確認事項

- [x] dev 環境で動作確認済み（PR #1196 マージ後に develop でデプロイ済みであることを前提）
- [ ] 初回 master push は cache miss でフルビルドになるため、通常より時間がかかる点を周知
- [ ] prod の runtime env は `NODE_ENV=production` のみで既存挙動と等価
- [ ] Cloud Run のポート設定（8000）は既存のまま維持
- [ ] master マージ直後に Cloud Run service の health / 主要ページの動作確認を推奨

## ロールバック手順

問題発生時は Artifact Registry の前バージョン SHA タグで Cloud Run を revert 可能:
```
gcloud run deploy ${APPLICATION_NAME} \
  --image=${ARTIFACT_REGISTRY}/${APPLICATION_NAME}:<前バージョンのSHA> \
  --region=${GCP_REGION}
```

## 関連 PR

- #1196 (develop に既にマージ済み)

https://claude.ai/code/session_01CBL8TggEpcDZDsq9m6pKgf

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBL8TggEpcDZDsq9m6pKgf)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
