### PR TITLE
fix(auth, sysAdmin): SSR session cookie 認証下の Mutation を通す＋ハイライトUI微調整

### DIFF
--- a/src/app/community/[communityId]/layout.tsx
+++ b/src/app/community/[communityId]/layout.tsx
@@ -74,7 +74,7 @@ export async function generateMetadata({
 
 const CommunityLayout = async ({ children, params }: CommunityLayoutProps) => {
   const { communityId } = await params;
-  const { user, lineAuthenticated, phoneAuthenticated } = await getUserServer();
+  const { user, lineAuthenticated, phoneAuthenticated, hasSession } = await getUserServer();
 
   // Fetch community config from database
   let communityConfig: CommunityPortalConfig | null = null;
@@ -111,6 +111,7 @@ const CommunityLayout = async ({ children, params }: CommunityLayoutProps) => {
           ssrCurrentUser={user}
           ssrLineAuthenticated={lineAuthenticated}
           ssrPhoneAuthenticated={phoneAuthenticated}
+          ssrHasSession={hasSession}
         >
           <LiffDeepLinkHandler />
           <HeaderProvider>

--- a/src/app/sysAdmin/features/reportDetail/components/ReportFeedbackTriggers.tsx
+++ b/src/app/sysAdmin/features/reportDetail/components/ReportFeedbackTriggers.tsx
@@ -72,9 +72,10 @@ export function ReportFeedbackTriggers({
     wasSavingRef.current = saving;
   }, [saving, saveError]);
 
-  const floatPosition = useMemo(() => computeFloatPosition(selection?.rect), [
-    selection?.rect,
-  ]);
+  const floatPosition = useMemo(
+    () => computeFloatPosition(selection?.rect, selection?.lineHeight),
+    [selection?.rect, selection?.lineHeight],
+  );
 
   return (
     <>
@@ -86,14 +87,14 @@ export function ReportFeedbackTriggers({
           <Button
             type="button"
             size="sm"
+            variant="tertiary"
             onMouseDown={(e) => {
               // mousedown 時点で選択が消えないよう preventDefault。
               e.preventDefault();
             }}
             onClick={() => openWithQuote(selection.text)}
-            className="pointer-events-auto h-8 gap-1.5 px-2.5 text-body-xs shadow-lg"
+            className="pointer-events-auto h-8 px-2.5 text-body-xs shadow-lg"
           >
-            <MessageSquarePlus className="h-3.5 w-3.5" aria-hidden />
             この箇所にレビュー
           </Button>
         </div>
@@ -155,14 +156,18 @@ function buildQuotePrefix(text: string): string {
 /**
  * 選択範囲の真上にフロートボタンを置く。viewport 上端に近すぎる場合は下に回す。
  * `position: fixed` で配置するため `getBoundingClientRect` の値をそのまま使う。
+ *
+ * gap は選択中テキストの line-height に比例させる。固定値だと見出し等の
+ * 大きいフォントを選択したときにボタンが本文に近づきすぎて窮屈になる。
  */
-function computeFloatPosition(rect: DOMRect | undefined): {
-  top: number;
-  left: number;
-} | null {
+function computeFloatPosition(
+  rect: DOMRect | undefined,
+  lineHeight: number | undefined,
+): { top: number; left: number } | null {
   if (!rect) return null;
   const buttonHeight = 36;
-  const gap = 8;
+  const baseLineHeight = lineHeight && lineHeight > 0 ? lineHeight : 19.2;
+  const gap = Math.round(Math.min(24, Math.max(8, baseLineHeight * 0.5)));
   const minTopMargin = 56; // header の被り回避
   const placeAbove = rect.top - buttonHeight - gap >= minTopMargin;
   const top = placeAbove

--- a/src/app/sysAdmin/features/reportDetail/components/useReportTextSelection.ts
+++ b/src/app/sysAdmin/features/reportDetail/components/useReportTextSelection.ts
@@ -5,6 +5,8 @@ import { useEffect, useState, type RefObject } from "react";
 export type ReportSelection = {
   text: string;
   rect: DOMRect;
+  /** 選択開始位置の行の高さ (px)。フロート UI の縦位置をフォントサイズに追従させるために使う。 */
+  lineHeight: number;
 };
 
 /**
@@ -50,7 +52,8 @@ export function useReportTextSelection(
       if (text.trim() === "") return null;
       const rect = range.getBoundingClientRect();
       if (rect.width === 0 && rect.height === 0) return null;
-      return { text: text.trim(), rect };
+      const lineHeight = readLineHeight(anchor);
+      return { text: text.trim(), rect, lineHeight };
     };
 
     const schedule = () => {
@@ -79,4 +82,23 @@ export function useReportTextSelection(
   }, [containerRef, enabled]);
 
   return selection;
+}
+
+/**
+ * 選択開始ノードに最も近い Element の computed line-height を取得。
+ * `normal` の場合は font-size の 1.2 倍、それも不明なら 16px の 1.2 倍にフォールバック。
+ */
+function readLineHeight(node: Node): number {
+  const el =
+    node.nodeType === Node.ELEMENT_NODE
+      ? (node as Element)
+      : node.parentElement;
+  const fallback = 19.2;
+  if (!el || typeof window === "undefined") return fallback;
+  const style = window.getComputedStyle(el);
+  const lh = parseFloat(style.lineHeight);
+  if (!Number.isNaN(lh) && lh > 0) return lh;
+  const fs = parseFloat(style.fontSize);
+  if (!Number.isNaN(fs) && fs > 0) return fs * 1.2;
+  return fallback;
 }

--- a/src/app/sysAdmin/layout.tsx
+++ b/src/app/sysAdmin/layout.tsx
@@ -15,10 +15,11 @@ export default async function SysAdminLayout({ children }: { children: ReactNode
   const headersList = await headers();
   const communityId = headersList.get("x-community-id") ?? null;
 
-  const [communityConfig, { user, lineAuthenticated, phoneAuthenticated }] = await Promise.all([
-    communityId ? getCommunityConfig(communityId) : Promise.resolve(null),
-    getUserServer(),
-  ]);
+  const [communityConfig, { user, lineAuthenticated, phoneAuthenticated, hasSession }] =
+    await Promise.all([
+      communityId ? getCommunityConfig(communityId) : Promise.resolve(null),
+      getUserServer(),
+    ]);
 
   return (
     <CommunityConfigProvider config={communityConfig} isFromDatabase={!!communityConfig}>
@@ -27,6 +28,7 @@ export default async function SysAdminLayout({ children }: { children: ReactNode
           ssrCurrentUser={user}
           ssrLineAuthenticated={lineAuthenticated}
           ssrPhoneAuthenticated={phoneAuthenticated}
+          ssrHasSession={hasSession}
         >
           <HeaderProvider>
             <div className="min-h-screen flex flex-col max-w-mobile-l mx-auto w-full bg-background">

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -21,6 +21,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   ssrCurrentUser,
   ssrLineAuthenticated,
   ssrPhoneAuthenticated,
+  ssrHasSession,
 }) => {
   const communityConfig = useCommunityConfig();
   const { liffService, phoneAuthService, authStateManager } = useAuthDependencies(communityConfig);
@@ -44,7 +45,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
     });
 
     // ✅ SSR初期状態適用
-    applySsrAuthState(ssrCurrentUser, ssrLineAuthenticated, ssrPhoneAuthenticated);
+    applySsrAuthState(ssrCurrentUser, ssrLineAuthenticated, ssrPhoneAuthenticated, ssrHasSession);
 
     // 🚀 通常の初期化
     void initAuth({
@@ -55,7 +56,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
       ssrLineAuthenticated,
       ssrPhoneAuthenticated,
     });
-  }, [authStateManager, liffService, ssrCurrentUser, ssrLineAuthenticated, ssrPhoneAuthenticated]);
+  }, [
+    authStateManager,
+    liffService,
+    ssrCurrentUser,
+    ssrLineAuthenticated,
+    ssrPhoneAuthenticated,
+    ssrHasSession,
+  ]);
 
   // 認証が完了するまでクエリの自動発火を抑制する。
   // loading/authenticating 中に発火すると Bearer トークンなしの匿名リクエストになり、

--- a/src/hooks/auth/actions/useLogout.ts
+++ b/src/hooks/auth/actions/useLogout.ts
@@ -34,6 +34,7 @@ export const useLogout = (liffService: LiffService, phoneAuthService: PhoneAuthS
         firebaseUser: null,
         currentUser: null,
         authenticationState: "unauthenticated",
+        hasSessionCookie: false,
         lineTokens: {
           idToken: null,
           refreshToken: null,

--- a/src/lib/apollo.ts
+++ b/src/lib/apollo.ts
@@ -39,7 +39,9 @@ const requestLink = setContext(async (operation, prevContext) => {
     );
 
     if (isMutation) {
-      if (authenticationState === "loading") {
+      // session cookie が確定している場合は cookie で認証されるため、
+      // クライアント側の auth-store の loading 状態は無視して通す。
+      if (authenticationState === "loading" && !hasSessionCookie) {
         throw new Error("認証情報を読み込み中です。少し待ってから再度お試しください");
       }
 

--- a/src/lib/apollo.ts
+++ b/src/lib/apollo.ts
@@ -30,22 +30,22 @@ const requestLink = setContext(async (operation, prevContext) => {
   let firebaseUserTenantId: string | null = null;
 
   if (isBrowser) {
-    const { firebaseUser, authenticationState } = useAuthStore.getState().state;
+    const { firebaseUser, authenticationState, lineTokens, hasSessionCookie } =
+      useAuthStore.getState().state;
 
     // Mutation の場合は認証を厳格にチェック
     const isMutation = operation.query.definitions.some(
       (def) => def.kind === "OperationDefinition" && def.operation === "mutation",
     );
 
-    const { lineTokens } = useAuthStore.getState().state;
-
     if (isMutation) {
       if (authenticationState === "loading") {
         throw new Error("認証情報を読み込み中です。少し待ってから再度お試しください");
       }
 
-      // firebaseUser または lineTokens.idToken（exchange 経由）のいずれかが必要
-      if (!firebaseUser && !lineTokens.idToken) {
+      // firebaseUser / lineTokens.idToken / SSR で発行された session cookie のいずれかが必要。
+      // session cookie は HttpOnly のため SSR から store に流したフラグで判定する。
+      if (!firebaseUser && !lineTokens.idToken && !hasSessionCookie) {
         throw new Error("認証情報が取得できませんでした。ページをリロードしてください");
       }
     }
@@ -58,7 +58,7 @@ const requestLink = setContext(async (operation, prevContext) => {
         firebaseUserTenantId = firebaseUser.tenantId ?? null;
       } catch (error) {
         logger.warn("Failed to get ID token", { error });
-        if (isMutation) {
+        if (isMutation && !hasSessionCookie) {
           throw new Error("認証トークンの取得に失敗しました");
         }
       }
@@ -66,6 +66,12 @@ const requestLink = setContext(async (operation, prevContext) => {
       // Server-side exchange 経由: firebaseUser なし → exchange で取得した idToken を直接使用
       token = lineTokens.idToken;
       authSource = "lineTokens";
+    }
+
+    // Bearer トークンが取れず session cookie だけが頼りの場合は cookie 認証として送る。
+    // (createUploadLink の credentials: "include" で cookie が自動送信される)
+    if (!token && hasSessionCookie) {
+      authMode = "session";
     }
   }
 

--- a/src/lib/auth/core/auth-store.ts
+++ b/src/lib/auth/core/auth-store.ts
@@ -17,6 +17,7 @@ const initialAuthState: AuthState = {
   environment: getInitialEnvironment(),
   isAuthenticating: false,
   isAuthInProgress: false,
+  hasSessionCookie: false,
   lineTokens: {
     idToken: null,
     refreshToken: null,

--- a/src/lib/auth/init/applySsrAuthState.ts
+++ b/src/lib/auth/init/applySsrAuthState.ts
@@ -7,7 +7,14 @@ export function applySsrAuthState(
   ssrCurrentUser?: GqlUser | null,
   ssrLineAuthenticated?: boolean,
   ssrPhoneAuthenticated?: boolean,
+  ssrHasSession?: boolean,
 ) {
+  // セッション cookie の有無は他の SSR フラグと独立に store へ反映する。
+  // (HttpOnly のためクライアントから直接読めない)
+  if (typeof ssrHasSession === "boolean") {
+    useAuthStore.getState().setState({ hasSessionCookie: ssrHasSession });
+  }
+
   if (!ssrLineAuthenticated && !ssrPhoneAuthenticated && !ssrCurrentUser) return;
 
   let initialState: AuthenticationState = "loading";
@@ -23,6 +30,7 @@ export function applySsrAuthState(
     ssrCurrentUserId: ssrCurrentUser?.id,
     ssrLineAuthenticated,
     ssrPhoneAuthenticated,
+    ssrHasSession,
   });
 
   useAuthStore.getState().setState({

--- a/src/lib/auth/init/getUserServer.ts
+++ b/src/lib/auth/init/getUserServer.ts
@@ -13,6 +13,7 @@ export async function getUserServer(): Promise<{
   user: GqlUser | null;
   lineAuthenticated: boolean;
   phoneAuthenticated: boolean;
+  hasSession: boolean;
 }> {
   const cookieStore = await cookies();
   const hasSession = await hasServerSession();
@@ -24,6 +25,7 @@ export async function getUserServer(): Promise<{
       user: null,
       lineAuthenticated: false,
       phoneAuthenticated: false,
+      hasSession: false,
     };
   }
 
@@ -40,6 +42,7 @@ export async function getUserServer(): Promise<{
       user,
       lineAuthenticated: true, // SSR時点でsessionがあればtrue扱い
       phoneAuthenticated: hasPhoneIdentity,
+      hasSession: true,
     };
   } catch (error) {
     logger.warn("⚠️ Failed to fetch currentUser:", {
@@ -50,6 +53,7 @@ export async function getUserServer(): Promise<{
       user: null,
       lineAuthenticated: true,
       phoneAuthenticated,
+      hasSession: true,
     };
   }
 }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -20,6 +20,7 @@ export type AuthState = {
   environment: AuthEnvironment;
   isAuthenticating: boolean;
   isAuthInProgress: boolean;
+  hasSessionCookie: boolean;
   lineTokens: {
     idToken: string | null;
     refreshToken: string | null;
@@ -85,4 +86,5 @@ export interface AuthProviderProps {
   ssrCurrentUser?: GqlUser | undefined | null;
   ssrLineAuthenticated?: boolean;
   ssrPhoneAuthenticated?: boolean;
+  ssrHasSession?: boolean;
 }


### PR DESCRIPTION
## Summary

### 1. Apollo Mutation ガードが SSR session cookie 認証を無視していた問題の修正

`src/lib/apollo.ts` のクライアント側 Mutation チェックは `firebaseUser` か `lineTokens.idToken` のいずれかが必須で、HttpOnly な session cookie だけで認証されているクライアント (sysAdmin など) は **必ず** 「認証情報が取得できませんでした。ページをリロードしてください」を踏んでいた。これは sysAdmin に限らず、community 側でも Firebase 認証復元前のタイミングや exchange 経由のフローでも顕在化しうる問題。

修正方針:
- SSR の `hasServerSession()` 結果を `getUserServer()` の戻り値に追加
- `community/[communityId]/layout.tsx` と `sysAdmin/layout.tsx` から `<AuthProvider ssrHasSession={hasSession} />` で渡す
- `applySsrAuthState` で auth-store に `hasSessionCookie` を反映
- `apollo.ts` の Mutation ガードを「firebaseUser / lineTokens / hasSessionCookie のいずれかがあれば OK」に緩和し、cookie 認証時は `X-Auth-Mode: session` を送る (cookie は `credentials: "include"` で自動送信される)

### 2. ハイライトのフロート UI 微調整 (sysAdmin reportDetail)

- 「この箇所にレビュー」ボタンの上下 gap を選択中テキストの `line-height` に比例させ、見出し等の大きいフォントを選択したときに窮屈にならないように
- ボタンを白背景＋グレー枠線 (tertiary variant) に変更し、`MessageSquarePlus` アイコンを削除

## Test plan

- [ ] sysAdmin の report 詳細でフィードバック投稿 (Mutation) が「認証情報が取得できませんでした」エラーを出さずに通ること
- [ ] community 側の通常フロー (Firebase 認証ユーザー) で Mutation が引き続き正常に動くこと
- [ ] community 側で初回ロード直後の Mutation でもエラーにならないこと
- [ ] 本文選択時のフロートボタンが本文 (通常サイズ) と見出し (大きめサイズ) の両方で違和感ない位置に出ること
- [ ] フロートボタンが白背景 + グレー枠線、アイコン無しで表示されること
- [ ] 右下 FAB (`MessageSquarePlus` アイコン円形) は従来どおり

https://claude.ai/code/session_01TSGuVRNMHguYS54R3p6sKS

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSGuVRNMHguYS54R3p6sKS)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
