### PR TITLE
fix(sysAdmin): feedback 投稿を home community で叩く server action に切替

### DIFF
--- a/src/app/sysAdmin/features/reportDetail/actions/submitFeedback.ts
+++ b/src/app/sysAdmin/features/reportDetail/actions/submitFeedback.ts
@@ -1,0 +1,86 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { executeServerGraphQLQuery } from "@/lib/graphql/server";
+import { ACTIVE_COMMUNITY_IDS } from "@/lib/communities/constants";
+import { SUBMIT_REPORT_FEEDBACK_SERVER_MUTATION } from "@/graphql/account/report/server";
+import type {
+  GqlSubmitReportFeedbackMutation,
+  GqlSubmitReportFeedbackMutationVariables,
+} from "@/types/graphql";
+
+export type SubmitFeedbackActionInput = {
+  reportId: string;
+  rating: number;
+  feedbackType?: GqlSubmitReportFeedbackMutationVariables["input"]["feedbackType"];
+  comment?: string;
+  /** 投稿対象の community (= URL の `/sysAdmin/{communityId}/...` および `report.community.id`) */
+  targetCommunityId: string;
+};
+
+export type SubmitFeedbackActionResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+/**
+ * sysAdmin の feedback 投稿用 server action。
+ *
+ * backend の auth middleware (`firebase-auth.ts`) は `X-Community-Id` を
+ * (a) Firebase tenant 解決 (b) `identities.some.{uid, communityId}` の検索キー
+ * の両方に使う。sysAdmin の identity は home community ぶんしか発行されないため、
+ * `X-Community-Id` を URL の対象 community に切り替えると identity が見つからず
+ * `currentUser=null` になり、`IsAdmin` (sysAdmin bypass) と `IsCommunityMember`
+ * の OR ルール両方が落ちて `FORBIDDEN` になる。
+ *
+ * よって `X-Community-Id` には HttpOnly cookie `__session_{community}` から
+ * 推定した home community を入れ、対象 community は GraphQL 引数
+ * `permission.communityId` で別途指定する。これは `communityCreate.ts` と同じ
+ * パターン。
+ */
+export async function submitReportFeedbackAction(
+  input: SubmitFeedbackActionInput,
+): Promise<SubmitFeedbackActionResult> {
+  const cookieStore = await cookies();
+  const homeCommunityId = cookieStore
+    .getAll()
+    .filter((c) => c.name.startsWith("__session_"))
+    .map((c) => c.name.replace("__session_", ""))
+    .find((id) => (ACTIVE_COMMUNITY_IDS as readonly string[]).includes(id));
+
+  if (!homeCommunityId) {
+    return {
+      ok: false,
+      error:
+        "有効なセッションが見つかりません。一度ログアウトしてから再度ログインしてください",
+    };
+  }
+
+  try {
+    await executeServerGraphQLQuery<
+      GqlSubmitReportFeedbackMutation,
+      GqlSubmitReportFeedbackMutationVariables
+    >(
+      SUBMIT_REPORT_FEEDBACK_SERVER_MUTATION,
+      {
+        input: {
+          reportId: input.reportId,
+          rating: input.rating,
+          feedbackType: input.feedbackType ?? undefined,
+          comment: input.comment ?? undefined,
+        },
+        permission: { communityId: input.targetCommunityId },
+      },
+      { "X-Community-Id": homeCommunityId },
+      15000,
+    );
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "フィードバックの投稿に失敗しました",
+    };
+  }
+}

--- a/src/app/sysAdmin/features/reportDetail/actions/submitFeedback.ts
+++ b/src/app/sysAdmin/features/reportDetail/actions/submitFeedback.ts
@@ -41,11 +41,22 @@ export async function submitReportFeedbackAction(
   input: SubmitFeedbackActionInput,
 ): Promise<SubmitFeedbackActionResult> {
   const cookieStore = await cookies();
-  const homeCommunityId = cookieStore
+  // 複数 community にログイン履歴があると `__session_{id}` が複数存在し、
+  // `find()` は cookie 走査順序依存で非決定的になる。`x-community-id` cookie
+  // (middleware が host / 直前の `/community/{id}/...` 経由で解決した値) を
+  // hint として優先し、それに対応する `__session_{id}` があれば確定で採用、
+  // 無ければ ACTIVE_COMMUNITY_IDS にマッチする最初の session に fallback する。
+  const sessionIds = cookieStore
     .getAll()
     .filter((c) => c.name.startsWith("__session_"))
-    .map((c) => c.name.replace("__session_", ""))
-    .find((id) => (ACTIVE_COMMUNITY_IDS as readonly string[]).includes(id));
+    .map((c) => c.name.replace("__session_", ""));
+  const hintedCommunityId = cookieStore.get("x-community-id")?.value;
+  const homeCommunityId =
+    hintedCommunityId && sessionIds.includes(hintedCommunityId)
+      ? hintedCommunityId
+      : sessionIds.find((id) =>
+          (ACTIVE_COMMUNITY_IDS as readonly string[]).includes(id),
+        );
 
   if (!homeCommunityId) {
     return {

--- a/src/app/sysAdmin/features/reportDetail/components/ReportDetailContainer.tsx
+++ b/src/app/sysAdmin/features/reportDetail/components/ReportDetailContainer.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import {
-  useSubmitReportFeedbackMutation,
-  type GqlGetAdminReportQuery,
-  type GqlReportFeedbackFieldsFragment,
+import type {
+  GqlGetAdminReportQuery,
+  GqlReportFeedbackFieldsFragment,
 } from "@/types/graphql";
 import { ReportDetailView } from "./ReportDetailView";
 import type { FeedbackFormInput } from "./ReportFeedbackForm";
+import { submitReportFeedbackAction } from "../actions/submitFeedback";
 
 type Report = NonNullable<GqlGetAdminReportQuery["report"]>;
 
@@ -20,14 +20,16 @@ type Props = {
 };
 
 /**
- * `ReportDetailView` (presentational) と submitReportFeedback mutation を
+ * `ReportDetailView` (presentational) と feedback 投稿 server action を
  * 結ぶ container。
  *
+ * client Apollo mutation ではなく server action (`submitReportFeedbackAction`)
+ * 経由で叩く。理由は同 action ファイルの doc コメント参照 (sysAdmin の
+ * `X-Community-Id` を home community に固定する必要があるため、HttpOnly な
+ * `__session_*` cookie をサーバ側で読む必要がある)。
+ *
  * 投稿成功後は `router.refresh()` で SSR を再走させ、`myFeedback` と
- * `feedbacks` connection を最新化する。Apollo cache を直接書き換える形に
- * すると、SSR で hydrate された initial state との整合を取るのが面倒
- * (Connection の cursor / totalCount との辻褄合わせ) なので、SSR 再走で
- * 揃えるのが運用上シンプル。
+ * `feedbacks` connection を最新化する。
  */
 export function ReportDetailContainer({
   report,
@@ -36,37 +38,28 @@ export function ReportDetailContainer({
   feedbacksTotalCount,
 }: Props) {
   const router = useRouter();
-  const [submit, { loading: saving, error: saveError }] =
-    useSubmitReportFeedbackMutation();
+  const [isPending, startTransition] = useTransition();
+  const [saveError, setSaveError] = useState<{ message: string } | null>(null);
 
   const handleSubmit = useCallback(
-    async (input: FeedbackFormInput) => {
-      try {
-        await submit({
-          variables: {
-            input: {
-              reportId: report.id,
-              rating: input.rating,
-              feedbackType: input.feedbackType ?? undefined,
-              comment: input.comment ?? undefined,
-            },
-            permission: { communityId: report.community.id },
-          },
-        });
-        router.refresh();
-      } catch {
-        // saveError state でハンドル済み
-      }
-    },
-    [submit, report.id, report.community.id, router],
-  );
-
-  const handleSubmitSync = useCallback(
     (input: FeedbackFormInput) => {
-      // form の onSubmit が同期 () => void なので、async 結果は捨てる
-      void handleSubmit(input);
+      setSaveError(null);
+      startTransition(async () => {
+        const result = await submitReportFeedbackAction({
+          reportId: report.id,
+          rating: input.rating,
+          feedbackType: input.feedbackType ?? undefined,
+          comment: input.comment ?? undefined,
+          targetCommunityId: report.community.id,
+        });
+        if (result.ok) {
+          router.refresh();
+        } else {
+          setSaveError({ message: result.error });
+        }
+      });
     },
-    [handleSubmit],
+    [report.id, report.community.id, router],
   );
 
   return (
@@ -75,9 +68,9 @@ export function ReportDetailContainer({
       body={body}
       feedbacks={feedbacks}
       feedbacksTotalCount={feedbacksTotalCount}
-      saving={saving}
-      saveError={saveError ?? null}
-      onSubmitFeedback={handleSubmitSync}
+      saving={isPending}
+      saveError={saveError}
+      onSubmitFeedback={handleSubmit}
     />
   );
 }

--- a/src/graphql/account/report/mutation.ts
+++ b/src/graphql/account/report/mutation.ts
@@ -3,12 +3,18 @@ import { REPORT_FEEDBACK_FIELDS } from "../reportFeedback/fragment";
 
 /**
  * Report detail page から admin が代行で投稿する feedback。
- * permission は `CheckCommunityPermissionInput` (community owner 必須)、
- * sysAdmin は全 community のオーナーなので任意の community のレポートに
- * 投稿可能。ただし backend の auth テナントは `X-Community-Id` ヘッダー /
- * `__session_{communityId}` cookie で決まるので、URL 側で
- * `/sysAdmin/{communityId}/...` の community と一致させる必要がある
- * (middleware で URL から community を抽出して同期している)。
+ * permission は `CheckCommunityPermissionInput` で OR チェック (`IsCommunityMember`
+ * または `IsAdmin`)、`IsAdmin` は `User.sysRole = SYS_ADMIN` を見て bypass する。
+ *
+ * ただし backend の auth middleware (`firebase-auth.ts`) は `X-Community-Id` を
+ * Firebase tenant 解決と `identities.some.{uid, communityId}` の検索キーの両方に
+ * 使うので、sysAdmin の identity が住む home community と `X-Community-Id` が
+ * 一致していないと `currentUser=null` になり OR の両側が落ちる。
+ *
+ * sysAdmin が他 community の report に投稿する場合は client mutation ではなく
+ * server action `submitReportFeedbackAction` を使うこと (HttpOnly cookie から
+ * home community を解決して `X-Community-Id` を組み立てる)。この `gql`
+ * テンプレートは generated types / SSR 用 `print` のソースとして残してある。
  */
 export const SUBMIT_REPORT_FEEDBACK = gql`
   mutation SubmitReportFeedback(

--- a/src/graphql/account/report/server.ts
+++ b/src/graphql/account/report/server.ts
@@ -3,6 +3,7 @@ import { print } from "graphql/language/printer";
 import {
   GetAdminReportDocument,
   GetAdminReportFeedbacksDocument,
+  SubmitReportFeedbackDocument,
 } from "@/types/graphql";
 
 /**
@@ -20,4 +21,16 @@ export const GET_ADMIN_REPORT_SERVER_QUERY = print(
 
 export const GET_ADMIN_REPORT_FEEDBACKS_SERVER_QUERY = print(
   addTypenameToDocument(GetAdminReportFeedbacksDocument),
+);
+
+/**
+ * sysAdmin の feedback 投稿は client Apollo ではなく server action 経由で叩く。
+ * backend (`firebase-auth.ts`) は X-Community-Id を tenant 解決と identity 検索の
+ * 両方に使うので、sysAdmin の auth identity が住んでいる home community を
+ * X-Community-Id に当てる必要がある。home community は HttpOnly な
+ * `__session_{community}` cookie からしか確実に判定できないため、サーバ側で
+ * 組み立てる。`permission.communityId` には URL の対象 community を入れる。
+ */
+export const SUBMIT_REPORT_FEEDBACK_SERVER_MUTATION = print(
+  addTypenameToDocument(SubmitReportFeedbackDocument),
 );

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -117,16 +117,15 @@ export async function middleware(request: NextRequest) {
 
   // 3. DBから動的設定を取得（存在しないコミュニティは404）
   // /sysAdmin はコミュニティスコープ外のため DB 設定チェックをスキップ。
-  // ただし /sysAdmin/{communityId}/... のように URL から community を解決できた場合
-  // (communityIdSource === "path") は、その community の認証テナントで操作する
-  // 必要があるので x-community-id cookie を URL の community に同期する。
-  // 同期しないと、後続のクライアント側 GraphQL リクエストの X-Community-Id ヘッダーや
-  // __session_{communityId} cookie の解決が前の community のままになり、permission
-  // チェック (CheckCommunityPermissionInput) で membership lookup が空になる。
+  // sysAdmin の認証 identity は home community の `__session_{home}` cookie に
+  // 紐づいており、backend の auth middleware は `X-Community-Id` を tenant 解決と
+  // identity 検索キーの両方に使う (`identities.some.{uid, communityId}`)。
+  // URL の community に X-Community-Id を同期すると home tenant 以外で identity が
+  // 見つからず currentUser=null になり、IsAdmin / IsCommunityMember 両ルールが落ちる。
+  // よって sysAdmin パスでは x-community-id cookie を URL に揃えず、cookie 元の
+  // home community のまま通す。permission scope は GraphQL 引数 `permission.communityId`
+  // で別途指定する (server action 側で組み立て)。
   if (pathname === "/sysAdmin" || pathname.startsWith("/sysAdmin/")) {
-    if (communityIdSource === "path") {
-      res.cookies.set("x-community-id", communityId, COMMUNITY_ID_COOKIE_OPTIONS);
-    }
     if (shouldClearSessionCookies) {
       clearLegacySessionCookies(res);
     }
@@ -177,25 +176,18 @@ export async function middleware(request: NextRequest) {
 /**
  * パスから communityId を抽出
  * /community/{communityId}/... 形式の場合に communityId を返す
- * /sysAdmin/{communityId}/... 形式の場合も、{communityId} が ACTIVE_COMMUNITY_IDS
- * に含まれる場合に限り返す。これは sysAdmin が特定 community のスコープで操作する
- * 際の認証テナント (X-Community-Id ヘッダー / __session_{communityId} cookie) を
- * URL の community に揃えるため。`create` `system` 等の予約セグメントは
- * ACTIVE_COMMUNITY_IDS に無いので誤検出されない。
+ * ホワイトリストチェックは行わず、DB検証に委ねる。
+ *
+ * /sysAdmin/{communityId}/... は意図的に抽出対象外。sysAdmin の auth identity は
+ * home community の `__session_{home}` cookie に紐づいており、URL community に
+ * X-Community-Id を切り替えると backend (`firebase-auth.ts` の identity lookup が
+ * `{uid, communityId: X-Community-Id}` で User を引く) で identity が見つからず
+ * currentUser=null になって permission チェックが全部落ちるため。sysAdmin の
+ * permission scope は GraphQL 引数 `permission.communityId` で表現する。
  */
 function getCommunityIdFromPath(pathname: string): string | null {
-  const communityMatch = pathname.match(/^\/community\/([a-zA-Z0-9-]+)/);
-  if (communityMatch) return communityMatch[1];
-
-  const sysAdminMatch = pathname.match(/^\/sysAdmin\/([a-zA-Z0-9-]+)/);
-  if (sysAdminMatch) {
-    const id = sysAdminMatch[1];
-    if ((ACTIVE_COMMUNITY_IDS as readonly string[]).includes(id)) {
-      return id;
-    }
-  }
-
-  return null;
+  const match = pathname.match(/^\/community\/([a-zA-Z0-9-]+)/);
+  return match ? match[1] : null;
 }
 
 /**


### PR DESCRIPTION
## Summary

`submitReportFeedback` mutation で `User must be a community member / User must be admin` で permission に落ちる件、backend チームから挙動が確定した (こちらの hypothesis 一致) ので根本対応します。

## backend 確定仕様

- `firebase-auth.ts` は `X-Community-Id` を **(a) Firebase tenant 解決** と **(b) `identities.some.{uid, communityId}` の identity 検索キー** の両方に使う。
- sysAdmin の identity は **home community ぶんしか発行されない**。
- `IsAdmin` ルール (`rules/index.ts`) は `User.sysRole === SYS_ADMIN` で community membership を bypass する。**`currentUser` さえ取れれば community 越えで通る**。

つまり `X-Community-Id = sysAdmin の home community` で叩けば `IsAdmin` で通り、対象 community は GraphQL 引数 `permission.communityId` で表現できる。

#1208 はこれを誤解していて URL の community を `X-Community-Id` に同期していたため、home tenant 以外で identity が見つからず `currentUser=null` → OR の両側が落ちて FORBIDDEN、という症状を **逆に発生させていた**。

## 変更

- **`src/middleware.ts`**: PR #1208 で入れた `/sysAdmin/{id}/...` の URL → `X-Community-Id` 同期を revert。sysAdmin パスでは cookie 元の home community を維持する。
- **`src/app/sysAdmin/features/reportDetail/actions/submitFeedback.ts`** (新規): feedback 投稿用 server action。HttpOnly な `__session_{community}` cookie から home community を解決して `X-Community-Id` に当て、`permission.communityId` には URL の対象 community (`report.community.id`) を入れる。`communityCreate.ts` と同じパターン。
- **`src/app/sysAdmin/features/reportDetail/components/ReportDetailContainer.tsx`**: `useSubmitReportFeedbackMutation` を上記 server action に差し替え、`useTransition` + state で loading / error をハンドル。
- **`src/graphql/account/report/server.ts`**: server action 用に `SUBMIT_REPORT_FEEDBACK_SERVER_MUTATION` を追加。
- **`src/graphql/account/report/mutation.ts`**: ドキュメントを backend 確定仕様に合わせて更新。

## Test plan

- [ ] sysAdmin でログイン (任意 1 community) → `/sysAdmin/{home community}/reports/{reportId}` で feedback 投稿 → 200 で投稿される
- [ ] sysAdmin で `/sysAdmin/{home 以外の community}/reports/{reportId}` で feedback 投稿 → 200 で投稿される (これが今回直したい本体)
- [ ] feedback 投稿後 `router.refresh()` で `myFeedback` / `feedbacks` connection が更新される
- [ ] `/sysAdmin/{communityId}/reports/...` 以外の sysAdmin 画面 (一覧・テンプレ詳細など) は引き続き動く (middleware の sysAdmin path 早抜けは維持)
- [ ] 一般 community 配下 (`/community/{id}/...`) の挙動は変わらない

https://claude.ai/code/session_01YMe7GygiPXyGPipZYZ6EsY

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRcoQFDUy95Z3XtXQZLcio)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
