### PR TITLE
refactor(sysAdmin): extract dashboard inline metrics to derive.ts

### DIFF
--- a/src/app/sysAdmin/_shared/__tests__/derive.test.ts
+++ b/src/app/sysAdmin/_shared/__tests__/derive.test.ts
@@ -11,6 +11,7 @@ import {
   deriveCommunityAgeMonths,
   deriveD30ActivationRate,
   deriveDonationMoM,
+  deriveHubUserPct,
   deriveNewMemberRate,
   deriveRecipientToSenderRate,
   deriveRecoveryRate,
@@ -24,6 +25,28 @@ import {
   isRegularOverHabitual,
   TENURE_THRESHOLD_DAYS,
 } from "../derive";
+
+describe("deriveHubUserPct", () => {
+  it("returns null when totalMembers is 0", () => {
+    expect(deriveHubUserPct({ hubMemberCount: 5, totalMembers: 0 })).toBeNull();
+  });
+
+  it("returns null when totalMembers is negative (defensive)", () => {
+    expect(
+      deriveHubUserPct({ hubMemberCount: 5, totalMembers: -1 }),
+    ).toBeNull();
+  });
+
+  it("computes hubMemberCount / totalMembers", () => {
+    expect(deriveHubUserPct({ hubMemberCount: 30, totalMembers: 100 })).toBe(
+      0.3,
+    );
+  });
+
+  it("returns 0 when hubMemberCount is 0 and totalMembers > 0 (genuine zero, not undefined)", () => {
+    expect(deriveHubUserPct({ hubMemberCount: 0, totalMembers: 100 })).toBe(0);
+  });
+});
 
 describe("deriveRecipientToSenderRate", () => {
   it("returns null when memberList is undersampled (hasNextPage)", () => {

--- a/src/app/sysAdmin/_shared/__tests__/derive.test.ts
+++ b/src/app/sysAdmin/_shared/__tests__/derive.test.ts
@@ -1,0 +1,448 @@
+import { describe, expect, it } from "vitest";
+import {
+  COHORT_M1_ALERT_THRESHOLD,
+  computeParetoTopShare,
+  countContinuingSenders,
+  D30_COHORT_WINDOW,
+  deriveAvgMonthlyPerMember,
+  deriveAvgMonthlyThroughput,
+  deriveAvgRecipients,
+  deriveCohortM1Delta,
+  deriveCommunityAgeMonths,
+  deriveD30ActivationRate,
+  deriveDonationMoM,
+  deriveNewMemberRate,
+  deriveRecipientToSenderRate,
+  deriveRecoveryRate,
+  deriveRecoverySeries,
+  deriveSentCount,
+  deriveTenuredRatioFromMemberList,
+  deriveWeeklyContinuationRate,
+  deriveWeeklyContinuationSeries,
+  FUNNEL_CONTINUING_MIN_MONTHS,
+  isCohortM1Alert,
+  isRegularOverHabitual,
+  TENURE_THRESHOLD_DAYS,
+} from "../derive";
+
+describe("deriveRecipientToSenderRate", () => {
+  it("returns null when memberList is undersampled (hasNextPage)", () => {
+    const users = [
+      { totalPointsIn: 10, totalPointsOut: 5 },
+      { totalPointsIn: 0, totalPointsOut: 3 },
+    ];
+    expect(deriveRecipientToSenderRate(users, true)).toBeNull();
+  });
+
+  it("returns null when no recipients", () => {
+    const users = [{ totalPointsIn: 0, totalPointsOut: 5 }];
+    expect(deriveRecipientToSenderRate(users, false)).toBeNull();
+  });
+
+  it("returns null on empty users", () => {
+    expect(deriveRecipientToSenderRate([], false)).toBeNull();
+  });
+
+  it("computes recipients-with-send / recipients ratio", () => {
+    const users = [
+      { totalPointsIn: 10, totalPointsOut: 5 }, // recipient + sender
+      { totalPointsIn: 8, totalPointsOut: 0 }, // recipient only
+      { totalPointsIn: 0, totalPointsOut: 4 }, // sender only (excluded)
+      { totalPointsIn: 6, totalPointsOut: 2 }, // recipient + sender
+    ];
+    expect(deriveRecipientToSenderRate(users, false)).toBeCloseTo(2 / 3, 6);
+  });
+});
+
+describe("deriveAvgRecipients", () => {
+  it("returns 0 on empty input", () => {
+    expect(deriveAvgRecipients([])).toBe(0);
+  });
+
+  it("computes mean uniqueDonationRecipients", () => {
+    const members = [
+      { uniqueDonationRecipients: 2 },
+      { uniqueDonationRecipients: 4 },
+      { uniqueDonationRecipients: 6 },
+    ];
+    expect(deriveAvgRecipients(members)).toBe(4);
+  });
+});
+
+describe("deriveDonationMoM", () => {
+  it("returns null when fewer than 2 months", () => {
+    expect(deriveDonationMoM([])).toBeNull();
+    expect(deriveDonationMoM([{ donationPointsSum: 100 }])).toBeNull();
+  });
+
+  it("returns null when prev is zero", () => {
+    expect(
+      deriveDonationMoM([
+        { donationPointsSum: 0 },
+        { donationPointsSum: 200 },
+      ]),
+    ).toBeNull();
+  });
+
+  it("computes MoM growth rate", () => {
+    expect(
+      deriveDonationMoM([
+        { donationPointsSum: 100 },
+        { donationPointsSum: 150 },
+      ]),
+    ).toBeCloseTo(0.5, 6);
+  });
+
+  it("uses last two of trend, ignoring earlier history", () => {
+    expect(
+      deriveDonationMoM([
+        { donationPointsSum: 999 },
+        { donationPointsSum: 200 },
+        { donationPointsSum: 100 },
+      ]),
+    ).toBeCloseTo(-0.5, 6);
+  });
+});
+
+describe("deriveCommunityAgeMonths", () => {
+  it("returns null on missing endpoints", () => {
+    expect(deriveCommunityAgeMonths(null, "2026-01-01")).toBeNull();
+    expect(deriveCommunityAgeMonths("2026-01-01", undefined)).toBeNull();
+    expect(deriveCommunityAgeMonths(null, null)).toBeNull();
+  });
+
+  it("returns 0 for same date", () => {
+    expect(deriveCommunityAgeMonths("2026-01-01", "2026-01-01")).toBe(0);
+  });
+
+  it("approximates months with 30-day denominator", () => {
+    // 90 day diff = 3 months (90/30)
+    expect(
+      deriveCommunityAgeMonths("2026-01-01T00:00:00Z", "2026-04-01T00:00:00Z"),
+    ).toBe(3);
+  });
+
+  it("accepts Date objects", () => {
+    const from = new Date("2026-01-01T00:00:00Z");
+    const to = new Date("2026-02-01T00:00:00Z");
+    // Jan→Feb = 31 days, 31/30 ≈ 1.033 → round to 1
+    expect(deriveCommunityAgeMonths(from, to)).toBe(1);
+  });
+});
+
+describe("deriveAvgMonthlyThroughput", () => {
+  it("returns null when no points", () => {
+    expect(deriveAvgMonthlyThroughput(0, 6)).toBeNull();
+  });
+
+  it("returns null when ageMonths is null or non-positive", () => {
+    expect(deriveAvgMonthlyThroughput(1000, null)).toBeNull();
+    expect(deriveAvgMonthlyThroughput(1000, 0)).toBeNull();
+    expect(deriveAvgMonthlyThroughput(1000, -1)).toBeNull();
+  });
+
+  it("computes total / ageMonths", () => {
+    expect(deriveAvgMonthlyThroughput(1200, 6)).toBe(200);
+  });
+});
+
+describe("deriveAvgMonthlyPerMember", () => {
+  it("returns null when throughput is null", () => {
+    expect(deriveAvgMonthlyPerMember(null, 100)).toBeNull();
+  });
+
+  it("returns null when totalMembers is 0", () => {
+    expect(deriveAvgMonthlyPerMember(500, 0)).toBeNull();
+  });
+
+  it("computes throughput / totalMembers", () => {
+    expect(deriveAvgMonthlyPerMember(500, 100)).toBe(5);
+  });
+});
+
+describe("computeParetoTopShare", () => {
+  it("returns null on empty users", () => {
+    expect(computeParetoTopShare([], 0.8)).toBeNull();
+  });
+
+  it("returns null when all totals are 0", () => {
+    expect(
+      computeParetoTopShare(
+        [{ totalPointsOut: 0 }, { totalPointsOut: 0 }],
+        0.8,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns the index ratio at which cumulative coverage is reached", () => {
+    // 4 users with 80, 10, 5, 5. 80%+ on first user → 1/4 = 0.25
+    const users = [
+      { totalPointsOut: 80 },
+      { totalPointsOut: 10 },
+      { totalPointsOut: 5 },
+      { totalPointsOut: 5 },
+    ];
+    expect(computeParetoTopShare(users, 0.8)).toBe(0.25);
+  });
+
+  it("sorts descending before scanning", () => {
+    const users = [
+      { totalPointsOut: 5 },
+      { totalPointsOut: 5 },
+      { totalPointsOut: 10 },
+      { totalPointsOut: 80 },
+    ];
+    expect(computeParetoTopShare(users, 0.8)).toBe(0.25);
+  });
+
+  it("returns 1 if no prefix reaches coverage (shouldn't happen but defensive)", () => {
+    // coverage > 1 always fails → falls through to return 1
+    const users = [{ totalPointsOut: 1 }];
+    expect(computeParetoTopShare(users, 1.5)).toBe(1);
+  });
+});
+
+describe("deriveWeeklyContinuationRate", () => {
+  it("returns null on undefined week", () => {
+    expect(deriveWeeklyContinuationRate(undefined)).toBeNull();
+  });
+
+  it("returns null when both 0", () => {
+    expect(
+      deriveWeeklyContinuationRate({ retainedSenders: 0, churnedSenders: 0 }),
+    ).toBeNull();
+  });
+
+  it("computes retained / (retained + churned)", () => {
+    expect(
+      deriveWeeklyContinuationRate({ retainedSenders: 7, churnedSenders: 3 }),
+    ).toBeCloseTo(0.7, 6);
+  });
+});
+
+describe("deriveWeeklyContinuationSeries", () => {
+  it("slices the trailing window", () => {
+    const trend = Array.from({ length: 20 }, (_, i) => ({
+      retainedSenders: i + 1,
+      churnedSenders: 1,
+    }));
+    const result = deriveWeeklyContinuationSeries(trend, 5);
+    expect(result).toHaveLength(5);
+    expect(result[0]).toBeCloseTo(16 / 17, 6);
+    expect(result[4]).toBeCloseTo(20 / 21, 6);
+  });
+
+  it("preserves null for zero-denominator weeks", () => {
+    const result = deriveWeeklyContinuationSeries(
+      [
+        { retainedSenders: 0, churnedSenders: 0 },
+        { retainedSenders: 5, churnedSenders: 5 },
+      ],
+      2,
+    );
+    expect(result[0]).toBeNull();
+    expect(result[1]).toBeCloseTo(0.5, 6);
+  });
+});
+
+describe("cohort M1 alert", () => {
+  it("delta is null when either cohort lacks retentionM1", () => {
+    expect(
+      deriveCohortM1Delta(
+        { retentionM1: null },
+        { retentionM1: 0.5 },
+      ),
+    ).toBeNull();
+    expect(
+      deriveCohortM1Delta(
+        { retentionM1: 0.5 },
+        { retentionM1: null },
+      ),
+    ).toBeNull();
+    expect(deriveCohortM1Delta(undefined, { retentionM1: 0.5 })).toBeNull();
+  });
+
+  it("delta is latest - prev", () => {
+    expect(
+      deriveCohortM1Delta(
+        { retentionM1: 0.6 },
+        { retentionM1: 0.7 },
+      ),
+    ).toBeCloseTo(-0.1, 6);
+  });
+
+  it("isCohortM1Alert triggers at threshold", () => {
+    expect(isCohortM1Alert(null)).toBe(false);
+    expect(isCohortM1Alert(-0.04)).toBe(false);
+    expect(isCohortM1Alert(COHORT_M1_ALERT_THRESHOLD)).toBe(true);
+    expect(isCohortM1Alert(-0.1)).toBe(true);
+  });
+});
+
+describe("deriveD30ActivationRate", () => {
+  it("returns null rate when no completed cohorts", () => {
+    const result = deriveD30ActivationRate(
+      [{ retentionM1: null }, { retentionM1: null }],
+    );
+    expect(result.rate).toBeNull();
+    expect(result.cohortCount).toBe(0);
+  });
+
+  it("ignores incomplete cohorts and averages last N", () => {
+    const result = deriveD30ActivationRate(
+      [
+        { retentionM1: 0.2 },
+        { retentionM1: 0.3 },
+        { retentionM1: 0.4 },
+        { retentionM1: 0.5 },
+        { retentionM1: null }, // incomplete latest
+      ],
+      3,
+    );
+    // last 3 completed: 0.3, 0.4, 0.5 → avg = 0.4
+    expect(result.rate).toBeCloseTo(0.4, 6);
+    expect(result.cohortCount).toBe(3);
+  });
+
+  it("uses default window when omitted", () => {
+    expect(D30_COHORT_WINDOW).toBe(3);
+    const trend = [
+      { retentionM1: 0.1 },
+      { retentionM1: 0.2 },
+      { retentionM1: 0.3 },
+      { retentionM1: 0.4 },
+    ];
+    const result = deriveD30ActivationRate(trend);
+    expect(result.cohortCount).toBe(3);
+    expect(result.rate).toBeCloseTo((0.2 + 0.3 + 0.4) / 3, 6);
+  });
+});
+
+describe("deriveNewMemberRate", () => {
+  it("returns null when newMemberCount is null/undefined", () => {
+    expect(deriveNewMemberRate(null, 100)).toBeNull();
+    expect(deriveNewMemberRate(undefined, 100)).toBeNull();
+  });
+
+  it("returns null when totalMembers is 0", () => {
+    expect(deriveNewMemberRate(5, 0)).toBeNull();
+  });
+
+  it("computes count / total", () => {
+    expect(deriveNewMemberRate(20, 200)).toBeCloseTo(0.1, 6);
+  });
+});
+
+describe("deriveRecoveryRate", () => {
+  it("returns null when latest or prev missing", () => {
+    expect(deriveRecoveryRate(undefined, { dormantCount: 5 })).toBeNull();
+    expect(
+      deriveRecoveryRate({ returnedMembers: 1 }, undefined),
+    ).toBeNull();
+  });
+
+  it("returns null when returnedMembers null/undefined", () => {
+    expect(
+      deriveRecoveryRate({ returnedMembers: null }, { dormantCount: 5 }),
+    ).toBeNull();
+    expect(
+      deriveRecoveryRate({ returnedMembers: undefined }, { dormantCount: 5 }),
+    ).toBeNull();
+  });
+
+  it("returns null when prev dormantCount is 0", () => {
+    expect(
+      deriveRecoveryRate({ returnedMembers: 1 }, { dormantCount: 0 }),
+    ).toBeNull();
+  });
+
+  it("computes returnedMembers / prev.dormantCount", () => {
+    expect(
+      deriveRecoveryRate({ returnedMembers: 3 }, { dormantCount: 10 }),
+    ).toBeCloseTo(0.3, 6);
+  });
+});
+
+describe("deriveRecoverySeries", () => {
+  it("first element is always null (no prev)", () => {
+    const result = deriveRecoverySeries([
+      { returnedMembers: 5, dormantCount: 10 },
+      { returnedMembers: 2, dormantCount: 8 },
+    ]);
+    expect(result[0]).toBeNull();
+    expect(result[1]).toBeCloseTo(2 / 10, 6);
+  });
+
+  it("propagates null on missing fields or zero prev", () => {
+    const result = deriveRecoverySeries([
+      { returnedMembers: 1, dormantCount: 10 }, // i=0 always null
+      { returnedMembers: null, dormantCount: 5 }, // returnedMembers null
+      { returnedMembers: 4, dormantCount: 0 }, // ok: prev=5, 4/5
+      { returnedMembers: 3, dormantCount: 10 }, // prev.dormantCount=0 → null
+    ]);
+    expect(result[0]).toBeNull();
+    expect(result[1]).toBeNull();
+    expect(result[2]).toBeCloseTo(4 / 5, 6);
+    expect(result[3]).toBeNull();
+  });
+});
+
+describe("isRegularOverHabitual", () => {
+  it("returns false when habitual is 0", () => {
+    expect(isRegularOverHabitual(0, 5)).toBe(false);
+  });
+
+  it("returns false when regular <= habitual", () => {
+    expect(isRegularOverHabitual(5, 5)).toBe(false);
+    expect(isRegularOverHabitual(5, 3)).toBe(false);
+  });
+
+  it("returns true when 0 < habitual < regular", () => {
+    expect(isRegularOverHabitual(3, 5)).toBe(true);
+  });
+});
+
+describe("deriveSentCount", () => {
+  it("returns totalMembers - latentCount", () => {
+    expect(deriveSentCount(100, 30)).toBe(70);
+  });
+
+  it("clamps to 0 when latent exceeds total", () => {
+    expect(deriveSentCount(50, 100)).toBe(0);
+  });
+});
+
+describe("countContinuingSenders", () => {
+  it("counts users with donationOutMonths >= threshold", () => {
+    expect(FUNNEL_CONTINUING_MIN_MONTHS).toBe(2);
+    const users = [
+      { donationOutMonths: 0 },
+      { donationOutMonths: 1 },
+      { donationOutMonths: 2 },
+      { donationOutMonths: 3 },
+    ];
+    expect(countContinuingSenders(users)).toBe(2);
+  });
+});
+
+describe("deriveTenuredRatioFromMemberList", () => {
+  it("returns null on empty users", () => {
+    expect(deriveTenuredRatioFromMemberList([])).toBeNull();
+  });
+
+  it("uses default TENURE_THRESHOLD_DAYS", () => {
+    expect(TENURE_THRESHOLD_DAYS).toBe(90);
+    const users = [
+      { daysIn: 30 },
+      { daysIn: 60 },
+      { daysIn: 90 },
+      { daysIn: 200 },
+    ];
+    expect(deriveTenuredRatioFromMemberList(users)).toBeCloseTo(0.5, 6);
+  });
+
+  it("accepts custom threshold", () => {
+    const users = [{ daysIn: 30 }, { daysIn: 200 }];
+    expect(deriveTenuredRatioFromMemberList(users, 100)).toBeCloseTo(0.5, 6);
+  });
+});

--- a/src/app/sysAdmin/_shared/derive.ts
+++ b/src/app/sysAdmin/_shared/derive.ts
@@ -60,8 +60,14 @@ export function deriveLatestCohortRetentionM1(
 // "Hub" labels the relational-breadth layer of the donation graph; the
 // node-axis "habitual / regular / occasional / latent" stage hierarchy
 // is orthogonal and surfaces in L2 detail.
-export function deriveHubUserPct(row: GqlAnalyticsCommunityOverview): number {
-  if (row.totalMembers === 0) return 0;
+//
+// totalMembers 0 で null を返す (= 未定義)。他の rate 派生 (`deriveDormantRate`
+// 等) と揃え、backend `computeActiveRate` の null 規約とも整合させる。
+export function deriveHubUserPct(row: {
+  hubMemberCount: number;
+  totalMembers: number;
+}): number | null {
+  if (row.totalMembers <= 0) return null;
   return row.hubMemberCount / row.totalMembers;
 }
 

--- a/src/app/sysAdmin/_shared/derive.ts
+++ b/src/app/sysAdmin/_shared/derive.ts
@@ -108,3 +108,301 @@ export function deriveAlerts(row: GqlAnalyticsCommunityOverview): DerivedAlerts 
 export function hasAnyAlert(alerts: DerivedAlerts): boolean {
   return alerts.churnSpike || alerts.activeDrop || alerts.noNewMembers;
 }
+
+// -----------------------------------------------------------------
+// Dashboard L2 metrics
+//
+// 入力は GraphQL 型ではなく構造的最小 shape にする。これは
+//   1. mock fixtures / test 用の plain object でも呼べる
+//   2. backend (civicship-api) の型と直接バインドしない
+// が狙い。共有ライブラリ化する際の移植コストを最小化する。
+// -----------------------------------------------------------------
+
+/**
+ * 受領→送付 転換率 (互酬到達率): 受領経験者のうち送付経験もある人の比率。
+ *
+ * memberList は totalPointsOut DESC で並ぶため、limit に達していると
+ * 「受領のみで送付なし (totalPointsOut == 0)」のメンバーが末尾で切り捨て
+ * られ、分母 (受領経験者) が過小評価されて転換率が実態より高く出る。
+ * `hasNextPage === true` (= サンプル不足) の時は null を返し、UI 側で
+ * 全件取得 (cursor pagination) か server-side 集計が入るまで値を出さない。
+ */
+export function deriveRecipientToSenderRate(
+  users: ReadonlyArray<{ totalPointsIn: number; totalPointsOut: number }>,
+  hasNextPage: boolean,
+): number | null {
+  if (hasNextPage) return null;
+  const recipients = users.filter((u) => u.totalPointsIn > 0);
+  if (recipients.length === 0) return null;
+  const recipientSenders = recipients.filter((u) => u.totalPointsOut > 0);
+  return recipientSenders.length / recipients.length;
+}
+
+/** 平均送付先数: active members の uniqueDonationRecipients 平均。 */
+export function deriveAvgRecipients(
+  activeMembers: ReadonlyArray<{ uniqueDonationRecipients: number }>,
+): number {
+  if (activeMembers.length === 0) return 0;
+  const sum = activeMembers.reduce(
+    (acc, u) => acc + u.uniqueDonationRecipients,
+    0,
+  );
+  return sum / activeMembers.length;
+}
+
+/**
+ * 流通量 MoM: 最新月と前月の donationPointsSum 比 (curr - prev) / prev。
+ * 前月不在 / 前月分母 0 で null。
+ */
+export function deriveDonationMoM(
+  monthlyTrend: ReadonlyArray<{ donationPointsSum: number }>,
+): number | null {
+  const latest = monthlyTrend[monthlyTrend.length - 1];
+  const prev = monthlyTrend[monthlyTrend.length - 2];
+  if (!latest || !prev || prev.donationPointsSum <= 0) return null;
+  return (latest.donationPointsSum - prev.donationPointsSum) / prev.donationPointsSum;
+}
+
+// 30日 = 1ヶ月 近似。dataFrom/dataTo の差分から月数を出す簡易計算で、
+// 厳密なカレンダー月差ではない (年12.17ヶ月になる程度の誤差が出る)。
+const MS_PER_APPROX_MONTH = 1000 * 60 * 60 * 24 * 30;
+
+/**
+ * コミュニティ年齢 (月数 / Math.round)。
+ * codegen の `Datetime` は型上 Date だが SSR / network からは ISO 文字列で
+ * 来るため、必ず new Date() でラップしてから差を取る。
+ */
+export function deriveCommunityAgeMonths(
+  dataFrom: string | Date | null | undefined,
+  dataTo: string | Date | null | undefined,
+): number | null {
+  if (!dataFrom || !dataTo) return null;
+  const fromMs = new Date(dataFrom).getTime();
+  const toMs = new Date(dataTo).getTime();
+  if (!Number.isFinite(fromMs) || !Number.isFinite(toMs)) return null;
+  return Math.round((toMs - fromMs) / MS_PER_APPROX_MONTH);
+}
+
+/**
+ * 平均月次流通 = 累計 / コミュニティ稼働月数。
+ *
+ * monthlyActivityTrend.length は windowMonths (default 3) で頭打ちなので、
+ * それを分母にすると長く稼働している community ほど見かけ上膨れる
+ * (24 ヶ月稼働なら 8 倍)。dataFrom→dataTo から導いた ageMonths を必ず使う。
+ */
+export function deriveAvgMonthlyThroughput(
+  totalDonationPointsAllTime: number,
+  ageMonths: number | null,
+): number | null {
+  if (totalDonationPointsAllTime <= 0) return null;
+  if (ageMonths == null || ageMonths <= 0) return null;
+  return totalDonationPointsAllTime / ageMonths;
+}
+
+/**
+ * 1 人あたり月次流通 = avgMonthlyThroughput / totalMembers。
+ * civicship 哲学的に「コミュニティ全体の絶対額」より「メンバー 1 人あたりの
+ * 月次活動量」が比較可能で意味がある、という規模補正値。
+ */
+export function deriveAvgMonthlyPerMember(
+  avgMonthlyThroughput: number | null,
+  totalMembers: number,
+): number | null {
+  if (avgMonthlyThroughput == null || totalMembers <= 0) return null;
+  return avgMonthlyThroughput / totalMembers;
+}
+
+/**
+ * 流通量集中度 (Pareto): 累計の coverage (例: 0.8) を達成するのに必要な
+ * 上位ユーザー比率。降順ソート→累積和でカバレッジ到達点のインデックスを
+ * 返す。`users` 空 / 累計 0 で null、誰も到達しない場合は 1。
+ */
+export function computeParetoTopShare(
+  users: ReadonlyArray<{ totalPointsOut: number }>,
+  coverage: number,
+): number | null {
+  if (users.length === 0) return null;
+  const sorted = [...users].sort((a, b) => b.totalPointsOut - a.totalPointsOut);
+  const total = sorted.reduce((acc, u) => acc + u.totalPointsOut, 0);
+  if (total === 0) return null;
+  let cumulative = 0;
+  for (let i = 0; i < sorted.length; i++) {
+    cumulative += sorted[i].totalPointsOut;
+    if (cumulative / total >= coverage) {
+      return (i + 1) / sorted.length;
+    }
+  }
+  return 1;
+}
+
+/**
+ * 週次送付継続率 (単一週): retainedSenders / (retainedSenders + churnedSenders)。
+ * 該当週なし / 母数 0 で null。
+ */
+export function deriveWeeklyContinuationRate(
+  week: { retainedSenders: number; churnedSenders: number } | undefined,
+): number | null {
+  if (!week) return null;
+  const denom = week.retainedSenders + week.churnedSenders;
+  if (denom <= 0) return null;
+  return week.retainedSenders / denom;
+}
+
+/**
+ * 週次送付継続率 シリーズ: 末尾 windowSize 週分を `deriveWeeklyContinuationRate`
+ * で集計。母数 0 のセルは null (HistoryBars 側で gap 表示)。
+ */
+export function deriveWeeklyContinuationSeries(
+  retentionTrend: ReadonlyArray<{
+    retainedSenders: number;
+    churnedSenders: number;
+  }>,
+  windowSize: number,
+): Array<number | null> {
+  return retentionTrend
+    .slice(-windowSize)
+    .map((w) => deriveWeeklyContinuationRate(w));
+}
+
+// 直近 cohort の M+1 が前期から `COHORT_M1_ALERT_THRESHOLD` 以上低下したら
+// alert (onboarding 機能不全シグナル)。
+export const COHORT_M1_ALERT_THRESHOLD = -0.05;
+
+/**
+ * 直近 cohort と前期 cohort の M+1 デルタ (latest - prev)。
+ * どちらかが retentionM1 null で null。
+ */
+export function deriveCohortM1Delta(
+  latest: { retentionM1?: number | null } | undefined,
+  prev: { retentionM1?: number | null } | undefined,
+): number | null {
+  if (latest?.retentionM1 == null || prev?.retentionM1 == null) return null;
+  return latest.retentionM1 - prev.retentionM1;
+}
+
+export function isCohortM1Alert(delta: number | null): boolean {
+  return delta != null && delta <= COHORT_M1_ALERT_THRESHOLD;
+}
+
+// 新規定着率 (D30 相当): 直近完了 N コホートの retentionM1 平均で算出。
+// 最新 cohort は m+1 が未完了で null になりがちなので、retentionM1 != null
+// の cohort だけを slice の対象にする。
+export const D30_COHORT_WINDOW = 3;
+
+/**
+ * D30 初回送付率: retentionM1 が埋まっている cohort のうち末尾 windowSize 個の
+ * retentionM1 平均。完了 cohort 0 件で null。`cohortCount` は集計対象になった
+ * cohort 数 (= UI で「直近 N コホート平均」表示に使う)。
+ */
+export function deriveD30ActivationRate(
+  cohortRetention: ReadonlyArray<{ retentionM1?: number | null }>,
+  windowSize: number = D30_COHORT_WINDOW,
+): { rate: number | null; cohortCount: number } {
+  const completed = cohortRetention.filter((c) => c.retentionM1 != null);
+  const recent = completed.slice(-windowSize);
+  if (recent.length === 0) return { rate: null, cohortCount: 0 };
+  const sum = recent.reduce((acc, c) => acc + (c.retentionM1 ?? 0), 0);
+  return { rate: sum / recent.length, cohortCount: recent.length };
+}
+
+/**
+ * 新規率 (最新月): newMemberCount / totalMembers。
+ * newMemberCount は呼び出し側で渡す calendar-month の値で、28 日 rolling 窓
+ * ではない点に注意。null/undefined や totalMembers 0 で null。
+ */
+export function deriveNewMemberRate(
+  newMemberCount: number | null | undefined,
+  totalMembers: number,
+): number | null {
+  if (newMemberCount == null || totalMembers <= 0) return null;
+  return newMemberCount / totalMembers;
+}
+
+/**
+ * 復帰率 (単一月): 「先月末時点で休眠だった人のうち、今月送付した人の比率」。
+ * 分子は今月点の returnedMembers、分母は前月点の dormantCount。
+ * いずれか欠落、または前月 dormantCount が 0 で null。
+ */
+export function deriveRecoveryRate(
+  latest: { returnedMembers?: number | null } | undefined,
+  prev: { dormantCount: number } | undefined,
+): number | null {
+  if (!latest || !prev) return null;
+  if (latest.returnedMembers == null) return null;
+  if (prev.dormantCount <= 0) return null;
+  return latest.returnedMembers / prev.dormantCount;
+}
+
+/**
+ * 復帰率 月次推移: 各月 i について `deriveRecoveryRate(arr[i], arr[i-1])`。
+ * 先頭は前月不在で null。
+ */
+export function deriveRecoverySeries(
+  monthlyTrend: ReadonlyArray<{
+    returnedMembers?: number | null;
+    dormantCount: number;
+  }>,
+): Array<number | null> {
+  return monthlyTrend.map((m, i, arr) => {
+    if (i === 0) return null;
+    return deriveRecoveryRate(m, arr[i - 1]);
+  });
+}
+
+/**
+ * 3 ヶ月以上 在籍率の memberList fallback。
+ *
+ * 本来は community 全体の `tenureDistribution` から `deriveTenuredRatio`
+ * (TenureBar.tsx) で出すのが正で、これは distribution が無い場合の暫定。
+ * memberList は totalPointsOut DESC top N なので donor 偏重 → 長期在籍に
+ * 偏る。UI では「上位寄与者ベース (暫定)」と注記する。
+ */
+export function deriveTenuredRatioFromMemberList(
+  users: ReadonlyArray<{ daysIn: number }>,
+  thresholdDays: number = TENURE_THRESHOLD_DAYS,
+): number | null {
+  if (users.length === 0) return null;
+  const tenured = users.filter((u) => u.daysIn >= thresholdDays).length;
+  return tenured / users.length;
+}
+
+/**
+ * 「定期」segment が「定着」segment を上回っているか。
+ * 中堅層 (regular) が安定層 (habitual) より厚い = 定着への伸びしろがある
+ * という運用シグナルとして UI で issue 表示する。
+ */
+export function isRegularOverHabitual(
+  habitualCount: number,
+  regularCount: number,
+): boolean {
+  return habitualCount > 0 && regularCount > habitualCount;
+}
+
+// アクティベーションファネル「継続」段の閾値 (donationOutMonths >= N で継続扱い)。
+export const FUNNEL_CONTINUING_MIN_MONTHS = 2;
+
+/**
+ * 送付段の人数 = totalMembers - latentCount (= 1 回でも送付した人)。
+ * 引き算が負になることはないはずだが防御的に Math.max(0, ...)。
+ */
+export function deriveSentCount(
+  totalMembers: number,
+  latentCount: number,
+): number {
+  return Math.max(0, totalMembers - latentCount);
+}
+
+/**
+ * 継続段の人数 = donationOutMonths >= FUNNEL_CONTINUING_MIN_MONTHS のメンバー数。
+ *
+ * 注意: memberList は totalPointsOut DESC で limit (default 1000) され
+ * るので、totalMembers > limit の community では undersampled。呼び出し側で
+ * `memberSampleComplete` フラグを併せて持ち、UI で sample 不足表示する。
+ */
+export function countContinuingSenders(
+  users: ReadonlyArray<{ donationOutMonths: number }>,
+): number {
+  return users.filter(
+    (u) => u.donationOutMonths >= FUNNEL_CONTINUING_MIN_MONTHS,
+  ).length;
+}

--- a/src/app/sysAdmin/features/communityDetail/components/CommunityDashboardOverview.tsx
+++ b/src/app/sysAdmin/features/communityDetail/components/CommunityDashboardOverview.tsx
@@ -50,6 +50,7 @@ import {
   deriveD30ActivationRate,
   deriveDonationMoM,
   deriveDormantRate,
+  deriveHubUserPct,
   deriveNewMemberRate,
   deriveRecipientToSenderRate,
   deriveRecoveryRate,
@@ -164,7 +165,11 @@ export function CommunityDashboardOverview({
   const latentCount = stages.latent.count;
 
   const hubProvided = hubMemberCount !== undefined;
-  const hubPct = hubProvided && totalMembers > 0 ? hubMemberCount / totalMembers : 0;
+  // totalMembers 0 のとき null。他の rate 派生 (`deriveDormantRate` 等) と
+  // 揃え、backend `computeActiveRate` の null 規約とも整合。
+  const hubPct = hubProvided
+    ? deriveHubUserPct({ hubMemberCount, totalMembers })
+    : null;
 
   const activeMembers = data.memberList.users.filter((u) => u.userSendRate > 0);
   const avgRecipients = deriveAvgRecipients(activeMembers);
@@ -335,9 +340,13 @@ export function CommunityDashboardOverview({
             meta="今月"
             infoMetricKey="hubUserPct"
             status={hubProvided ? "ok" : "todo"}
-            hero={hubProvided ? <Hero value={toPct(hubPct)} /> : undefined}
-            viz={
+            hero={
               hubProvided ? (
+                <Hero value={hubPct != null ? toPct(hubPct) : "-"} />
+              ) : undefined
+            }
+            viz={
+              hubPct != null ? (
                 <Ring value={hubPct} colorClass={SCOPE_COLOR.network} />
               ) : undefined
             }

--- a/src/app/sysAdmin/features/communityDetail/components/CommunityDashboardOverview.tsx
+++ b/src/app/sysAdmin/features/communityDetail/components/CommunityDashboardOverview.tsx
@@ -39,8 +39,27 @@ import {
   deriveTenuredRatio,
 } from "@/app/sysAdmin/_shared/components/TenureBar";
 import {
-  TENURE_THRESHOLD_DAYS,
+  computeParetoTopShare,
+  countContinuingSenders,
+  D30_COHORT_WINDOW,
+  deriveAvgMonthlyPerMember,
+  deriveAvgMonthlyThroughput,
+  deriveAvgRecipients,
+  deriveCohortM1Delta,
+  deriveCommunityAgeMonths,
+  deriveD30ActivationRate,
+  deriveDonationMoM,
   deriveDormantRate,
+  deriveNewMemberRate,
+  deriveRecipientToSenderRate,
+  deriveRecoveryRate,
+  deriveRecoverySeries,
+  deriveSentCount,
+  deriveTenuredRatioFromMemberList,
+  deriveWeeklyContinuationRate,
+  deriveWeeklyContinuationSeries,
+  isCohortM1Alert,
+  isRegularOverHabitual,
 } from "@/app/sysAdmin/_shared/derive";
 import { sysAdminDashboardJa } from "@/app/sysAdmin/_shared/i18n/ja";
 
@@ -148,135 +167,55 @@ export function CommunityDashboardOverview({
   const hubPct = hubProvided && totalMembers > 0 ? hubMemberCount / totalMembers : 0;
 
   const activeMembers = data.memberList.users.filter((u) => u.userSendRate > 0);
-  const avgRecipients =
-    activeMembers.length > 0
-      ? activeMembers.reduce((acc, u) => acc + u.uniqueDonationRecipients, 0) /
-        activeMembers.length
-      : 0;
+  const avgRecipients = deriveAvgRecipients(activeMembers);
 
-  // 受領→送付 転換率 (互酬到達率): 受領経験者のうち送付経験もある人の比率。
-  // ギフトエコノミーが配給型 (一方通行) か相互参加型かの本質指標。
-  //
-  // memberList は totalPointsOut DESC で並ぶため、limit に達していると
-  // 「受領のみで送付なし (totalPointsOut == 0)」のメンバーが末尾で切り捨て
-  // られ、分母 (受領経験者) が過小評価されて転換率が実態より高く出る。
-  // hasNextPage が立っているときは undersampled なので null を返し、UI 側で
-  // 全件取得 (cursor pagination) を実装するか server-side 集計 (Option B) を
-  // backend に追加するまで値を出さない。
   const memberSampleComplete = !data.memberList.hasNextPage;
-  const recipientsAll = memberSampleComplete
-    ? data.memberList.users.filter((u) => u.totalPointsIn > 0)
-    : [];
-  const recipientSenders = recipientsAll.filter((u) => u.totalPointsOut > 0);
-  const recipientToSenderRate =
-    memberSampleComplete && recipientsAll.length > 0
-      ? recipientSenders.length / recipientsAll.length
-      : null;
+  const recipientToSenderRate = deriveRecipientToSenderRate(
+    data.memberList.users,
+    data.memberList.hasNextPage,
+  );
   // 「3 ヶ月以上 在籍率」は community 全体の tenureDistribution から計算する
   // のが正。L1 dashboard 経由で受け取った distribution があればそれを使い、
-  // 無ければ memberList (totalPointsOut DESC top N) で近似する暫定 fallback。
-  // fallback は donor 偏重で長期在籍に偏るので「上位寄与者ベース」と注記。
+  // 無ければ memberList (totalPointsOut DESC top N) ベースの暫定 fallback。
   const tenuredRatio: number | null = tenureDistribution
     ? deriveTenuredRatio(tenureDistribution)
-    : data.memberList.users.length > 0
-      ? data.memberList.users.filter((u) => u.daysIn >= TENURE_THRESHOLD_DAYS)
-          .length / data.memberList.users.length
-      : null;
+    : deriveTenuredRatioFromMemberList(data.memberList.users);
   const tenuredFromCommunity = tenureDistribution != null;
 
   const latestMonth =
     data.monthlyActivityTrend[data.monthlyActivityTrend.length - 1];
-
-  // 流通量 MoM
   const prevMonth =
     data.monthlyActivityTrend[data.monthlyActivityTrend.length - 2];
-  const donationMoM =
-    latestMonth && prevMonth && prevMonth.donationPointsSum > 0
-      ? (latestMonth.donationPointsSum - prevMonth.donationPointsSum) /
-        prevMonth.donationPointsSum
-      : null;
 
-  // codegen の scalar mapping は `Datetime: Date` だが Apollo に scalar
-  // deserializer は無く、SSR / network から JSON で来るのは ISO 文字列。
-  // 直接 `.getTime()` を呼ぶと runtime で TypeError なので必ず Date でラップ。
-  const ageMonths =
-    summary.dataFrom && summary.dataTo
-      ? Math.round(
-          (new Date(summary.dataTo).getTime() -
-            new Date(summary.dataFrom).getTime()) /
-            (1000 * 60 * 60 * 24 * 30),
-        )
-      : null;
-
-  // 平均月次流通 = 累計 / コミュニティ稼働月数。monthlyActivityTrend.length
-  // は windowMonths (default 3) で頭打ちなので、それを分母にすると長く稼働
-  // している community ほど見かけ上膨れる (24 ヶ月稼働なら 8 倍)。
-  // dataFrom→dataTo から導いた ageMonths を必ず使う。
-  const avgMonthlyThroughput =
-    summary.totalDonationPointsAllTime > 0 && ageMonths != null && ageMonths > 0
-      ? summary.totalDonationPointsAllTime / ageMonths
-      : null;
-
-  // 流通量集中度 (Pareto)
+  const donationMoM = deriveDonationMoM(data.monthlyActivityTrend);
+  const ageMonths = deriveCommunityAgeMonths(summary.dataFrom, summary.dataTo);
+  const avgMonthlyThroughput = deriveAvgMonthlyThroughput(
+    summary.totalDonationPointsAllTime,
+    ageMonths,
+  );
   const paretoTopShare = computeParetoTopShare(activeMembers, 0.8);
 
-  // 週次送付継続率: retentionTrend の最新週から
   const latestWeek = data.retentionTrend[data.retentionTrend.length - 1];
-  const weeklyContinuationRate =
-    latestWeek && latestWeek.retainedSenders + latestWeek.churnedSenders > 0
-      ? latestWeek.retainedSenders /
-        (latestWeek.retainedSenders + latestWeek.churnedSenders)
-      : null;
+  const weeklyContinuationRate = deriveWeeklyContinuationRate(latestWeek);
 
   const cohortLatest = data.cohortRetention[data.cohortRetention.length - 1];
   const cohortPrev = data.cohortRetention[data.cohortRetention.length - 2];
-  const cohortDelta =
-    cohortLatest?.retentionM1 != null && cohortPrev?.retentionM1 != null
-      ? cohortLatest.retentionM1 - cohortPrev.retentionM1
-      : null;
-  const cohortAlert = cohortDelta != null && cohortDelta <= -0.05;
+  const cohortDelta = deriveCohortM1Delta(cohortLatest, cohortPrev);
+  const cohortAlert = isCohortM1Alert(cohortDelta);
 
-  // 新規定着率 (D30 相当): cohortRetention.retentionM1 = 「entry month の翌月に
-  // DONATION out した cohort の比率」。最新コホートは m+1 が未完了で null に
-  // なりがちなので、retentionM1 != null の直近 N コホートの平均を取る。
-  // 「新規が ~30-60 日以内に送付した率」のシグナル。
-  const D30_COHORT_WINDOW = 3;
-  const completedCohorts = data.cohortRetention.filter(
-    (c) => c.retentionM1 != null,
-  );
-  const recentCompletedCohorts = completedCohorts.slice(-D30_COHORT_WINDOW);
-  const d30ActivationRate =
-    recentCompletedCohorts.length > 0
-      ? recentCompletedCohorts.reduce((acc, c) => acc + (c.retentionM1 ?? 0), 0) /
-        recentCompletedCohorts.length
-      : null;
+  const { rate: d30ActivationRate, cohortCount: d30CohortCount } =
+    deriveD30ActivationRate(data.cohortRetention, D30_COHORT_WINDOW);
 
-  const habitualOverRegular = habitualCount > 0 && regularCount > habitualCount;
+  const habitualOverRegular = isRegularOverHabitual(habitualCount, regularCount);
 
-  // 新規率 (最新月): newMemberCount は L2 detail の monthlyActivityTrend
-  // 最新点 (calendar-month) から渡ってくるので 28 日 rolling 窓ではない。
-  const newRate =
-    totalMembers > 0 && newMemberCount != null
-      ? newMemberCount / totalMembers
-      : null;
+  const newRate = deriveNewMemberRate(newMemberCount, totalMembers);
 
   const dormantRate = deriveDormantRate({
     totalMembers: summary.totalMembers,
     dormantCount: data.dormantCount,
   });
 
-  // 復帰率 (月次): 「先月末時点で休眠だった人のうち、今月送付した人の比率」。
-  // 分子は今月点の returnedMembers、分母は前月点の dormantCount。
-  // 直前月が無い (series 最初) / returnedMembers が null / 前月 dormantCount が
-  // 0 のいずれかで null。
-  const prevMonthForRecovery =
-    data.monthlyActivityTrend[data.monthlyActivityTrend.length - 2];
-  const recoveryRate =
-    latestMonth?.returnedMembers != null &&
-    prevMonthForRecovery != null &&
-    prevMonthForRecovery.dormantCount > 0
-      ? latestMonth.returnedMembers / prevMonthForRecovery.dormantCount
-      : null;
+  const recoveryRate = deriveRecoveryRate(latestMonth, prevMonth);
 
   // 12 期間 footer chart 用の time-series。各カードの動的シグナルを統一表示
   // するために `HistoryBars` (棒グラフ) に流す。null は backend が「この月は
@@ -290,22 +229,11 @@ export function CommunityDashboardOverview({
   const dormantSeries = data.monthlyActivityTrend.map((m) => m.dormantCount);
   const hubSeries = data.monthlyActivityTrend.map((m) => m.hubMemberCount);
 
-  // 復帰率 月次推移: returnedMembers[N] / dormantCount[N-1]。先月データなし or
-  // 分母 0 のセルは null (gap 表示) に倒す。
-  const recoverySeries = data.monthlyActivityTrend.map((m, i, arr) => {
-    if (i === 0) return null;
-    const prev = arr[i - 1];
-    if (m.returnedMembers == null || prev.dormantCount === 0) return null;
-    return m.returnedMembers / prev.dormantCount;
-  });
-
-  // 週次送付継続率 series: 直近 12 週の retainedSenders / (retained + churned)。
-  const weeklyContinuationSeries = data.retentionTrend
-    .slice(-12)
-    .map((w) => {
-      const total = w.retainedSenders + w.churnedSenders;
-      return total > 0 ? w.retainedSenders / total : null;
-    });
+  const recoverySeries = deriveRecoverySeries(data.monthlyActivityTrend);
+  const weeklyContinuationSeries = deriveWeeklyContinuationSeries(
+    data.retentionTrend,
+    12,
+  );
 
   // D30 series: 直近 6 cohort の retentionM1。最新 cohort は M+1 未完了で null
   // の可能性が高いが、null は HistoryBars 側で gap 表示するので問題なし。
@@ -324,12 +252,12 @@ export function CommunityDashboardOverview({
   const funnelStages = [
     {
       label: "送付",
-      count: Math.max(0, totalMembers - stages.latent.count),
+      count: deriveSentCount(totalMembers, latentCount),
       sampleDependent: false,
     },
     {
       label: "継続",
-      count: data.memberList.users.filter((u) => u.donationOutMonths >= 2).length,
+      count: countContinuingSenders(data.memberList.users),
       sampleDependent: true,
     },
     {
@@ -366,11 +294,10 @@ export function CommunityDashboardOverview({
           <CommunityBand
             ageMonths={ageMonths}
             avgMonthlyThroughput={avgMonthlyThroughput}
-            avgMonthlyPerMember={
-              avgMonthlyThroughput != null && totalMembers > 0
-                ? avgMonthlyThroughput / totalMembers
-                : null
-            }
+            avgMonthlyPerMember={deriveAvgMonthlyPerMember(
+              avgMonthlyThroughput,
+              totalMembers,
+            )}
           />
         </header>
       )}
@@ -642,8 +569,8 @@ export function CommunityDashboardOverview({
           colorClass={SCOPE_COLOR.activity}
           title="初回送付率"
           meta={
-            recentCompletedCohorts.length > 0
-              ? `直近 ${recentCompletedCohorts.length} コホート平均`
+            d30CohortCount > 0
+              ? `直近 ${d30CohortCount} コホート平均`
               : "完了コホートなし"
           }
           infoMetricKey="newD30ActivationRate"
@@ -1019,20 +946,3 @@ function CommunityBand({
   );
 }
 
-function computeParetoTopShare(
-  users: ReadonlyArray<{ totalPointsOut: number }>,
-  coverage: number,
-): number | null {
-  if (users.length === 0) return null;
-  const sorted = [...users].sort((a, b) => b.totalPointsOut - a.totalPointsOut);
-  const total = sorted.reduce((acc, u) => acc + u.totalPointsOut, 0);
-  if (total === 0) return null;
-  let cumulative = 0;
-  for (let i = 0; i < sorted.length; i++) {
-    cumulative += sorted[i].totalPointsOut;
-    if (cumulative / total >= coverage) {
-      return (i + 1) / sorted.length;
-    }
-  }
-  return 1;
-}


### PR DESCRIPTION
## Summary

backend (civicship-api) に同等のレポート集計ロジックが既存 (`computeActiveRate` / `percentChange` / `AlertFlags` / `WeeklyReportPayload`) しており、portal 側との「定義の正規化」を進めるための **Phase 0** リファクタです。共有ライブラリ化の前段として、portal 側の計算ロジックを 1 箇所に集約してテスト可能な形にします。

`CommunityDashboardOverview.tsx` (1038 行) に散らばっていた計算式を pure function 化して `_shared/derive.ts` に集約しました:

- `recipientToSenderRate` / `avgRecipients` / `tenuredRatioFromMemberList`
- `donationMoM` / `communityAgeMonths` / `avgMonthlyThroughput` / `avgMonthlyPerMember`
- `paretoTopShare` (dashboard component から移動)
- `weeklyContinuationRate` + `Series` / `cohortM1Delta` + `Alert` / `d30ActivationRate`
- `newMemberRate` / `recoveryRate` + `Series`
- `isRegularOverHabitual` / `sentCount` / `countContinuingSenders`

入力は GraphQL 型ではなく**構造的最小 shape** にして、共有ライブラリ化する際の移植コストを抑えています。各 function に null/zero エッジケースの単体テストを追加 (54 cases)。

ダッシュボード本体の計算ブロックは ~150 行 → ~50 行に圧縮、各行が domain concept を直接参照する形になり可読性が上がります。

## Backend 側との差分 (定義差分シート叩き台)

別途バックエンドチームと突合せ予定の主な論点:

| 項目 | portal | backend |
|---|---|---|
| `activityRate` 分母 0 時 | `0` を返す | `null` を返す |
| `growthRateActivity` 分母 0 | `null` | `null` (一致) |
| `cohortM1Alert` 閾値 | `-0.05` | (要確認) |
| `D30_COHORT_WINDOW` | `3` | (要確認) |
| `FUNNEL_CONTINUING_MIN_MONTHS` | `2` | (要確認) |
| `aggregateVariantSummary` 加重平均母数 | null avgRating 行を母数から除外 | (要確認) |

これらは本 PR ではなく後続の Phase 1 (定義差分シート → 正の決定 → 共有形態の決定) で吸収します。

## Test plan

- [x] `pnpm exec vitest run --project unit src/app/sysAdmin` — 96 tests pass (新規 derive 54 含む)
- [x] `pnpm exec tsc --noEmit` — 変更ファイルに新規エラーなし (既存の `d30Series` / `recoverySeries` の `undefined` エラー 2 件は本 PR 範囲外で main にも存在)
- [x] `pnpm exec eslint` (変更ファイル) — クリーン
- [ ] `/sysAdmin/{communityId}` ダッシュボードを開いてレンダリング確認 (各 metric カードの値が refactor 前と一致すること)
- [ ] storybook (`pnpm storybook`) で `CommunityDashboardOverview` の stories が壊れていないこと

## 関連

- Phase 1 (定義差分シート埋め合わせ): backend チームに確認依頼中
- Phase 2 以降: 共有形態 (npm package / monorepo) の決定、純関数の civicship-api 側からの抽出 PR

https://claude.ai/code/session_share-report-logic-4dazu

---
_Generated by [Claude Code](https://claude.ai/code/session_0173wfLKrpKtHhMzmf6GXTiS)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-portal/pull/1212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
