### PR TITLE
fix(graphql): align frontend with permission-arg removal in backend

### DIFF
--- a/codegen.yaml
+++ b/codegen.yaml
@@ -5,6 +5,7 @@ schema:
         "X-Community-Id": ${NEXT_PUBLIC_COMMUNITY_ID}
 documents:
   - src/**/*.ts?(x)
+  - "!src/types/graphql.tsx"
 generates:
   ./src/types/graphql.tsx:
     plugins:

--- a/src/app/community/[communityId]/admin/bonuses/components/EditBonusSheet.tsx
+++ b/src/app/community/[communityId]/admin/bonuses/components/EditBonusSheet.tsx
@@ -11,7 +11,6 @@ import { Label } from "@/components/ui/label";
 import { Item, ItemActions, ItemContent, ItemGroup, ItemTitle } from "@/components/ui/item";
 import { GqlCommunitySignupBonusConfig, useUpdateSignupBonusConfigMutation } from "@/types/graphql";
 import { toast } from "react-toastify";
-import { useCommunityConfig } from "@/contexts/CommunityConfigContext";
 
 interface EditBonusSheetProps {
   currentConfig?: GqlCommunitySignupBonusConfig | null;
@@ -20,8 +19,6 @@ interface EditBonusSheetProps {
 
 export default function EditBonusSheet({ currentConfig, onSave }: EditBonusSheetProps) {
   const t = useTranslations();
-  const communityConfig = useCommunityConfig();
-  const communityId = communityConfig?.communityId;
   const [open, setOpen] = useState(false);
   const [isEnabled, setIsEnabled] = useState(currentConfig?.isEnabled ?? false);
   const [bonusPoint, setBonusPoint] = useState(String(currentConfig?.bonusPoint ?? 0));
@@ -45,11 +42,6 @@ export default function EditBonusSheet({ currentConfig, onSave }: EditBonusSheet
       return;
     }
 
-    if (!communityId) {
-      toast.error(t("adminWallet.settings.signupBonus.form.error"));
-      return;
-    }
-
     try {
       await updateConfig({
         variables: {
@@ -58,7 +50,6 @@ export default function EditBonusSheet({ currentConfig, onSave }: EditBonusSheet
             bonusPoint: pointValue,
             message,
           },
-          communityId,
         },
       });
       toast.success(t("adminWallet.settings.signupBonus.form.success"));

--- a/src/app/community/[communityId]/admin/bonuses/components/FailedBonusItem.tsx
+++ b/src/app/community/[communityId]/admin/bonuses/components/FailedBonusItem.tsx
@@ -12,7 +12,6 @@ import {
   useIncentiveGrantRetryMutation,
 } from "@/types/graphql";
 import { toast } from "react-toastify";
-import { useCommunityConfig } from "@/contexts/CommunityConfigContext";
 
 interface FailedBonusItemProps {
   bonus: {
@@ -29,22 +28,15 @@ interface FailedBonusItemProps {
 
 export default function FailedBonusItem({ bonus, onRetrySuccess }: FailedBonusItemProps) {
   const t = useTranslations();
-  const communityConfig = useCommunityConfig();
-  const communityId = communityConfig?.communityId;
   const [retrying, setRetrying] = useState(false);
 
   const [retryGrant] = useIncentiveGrantRetryMutation();
 
   const handleRetry = async () => {
-    if (!communityId) {
-      toast.error(t("adminWallet.settings.pending.retryError.generic"));
-      return;
-    }
-
     setRetrying(true);
     try {
       const { data } = await retryGrant({
-        variables: { incentiveGrantId: bonus.id, communityId },
+        variables: { incentiveGrantId: bonus.id },
       });
 
       if (data?.incentiveGrantRetry) {

--- a/src/app/community/[communityId]/admin/credentials/components/selectUser/CredentialRecipientSelector.tsx
+++ b/src/app/community/[communityId]/admin/credentials/components/selectUser/CredentialRecipientSelector.tsx
@@ -202,7 +202,6 @@ export default function CredentialRecipientSelector({
               userIds: selectedSlot.userIds,
               slotId: selectedSlot.slotId,
             },
-            permission: { communityId },
           },
         });
       } finally {

--- a/src/app/community/[communityId]/admin/credentials/hooks/useEvaluationBulkCreate.ts
+++ b/src/app/community/[communityId]/admin/credentials/hooks/useEvaluationBulkCreate.ts
@@ -32,7 +32,6 @@ export const useEvaluationBulkCreate = ({ onSuccess, onError }: UseEvaluationBul
       const response = await mutate({
         variables: {
           input: { evaluations },
-          permission: { communityId },
         },
       });
       onSuccess?.(response);

--- a/src/app/community/[communityId]/admin/members/hooks/useMembershipMutations.ts
+++ b/src/app/community/[communityId]/admin/members/hooks/useMembershipMutations.ts
@@ -37,10 +37,7 @@ export const useMembershipCommand = () => {
 
       try {
         const { data } = await mutationFn({
-          variables: {
-            input,
-            permission: { communityId: input.communityId },
-          },
+          variables: { input },
         });
 
         if (data) {

--- a/src/app/community/[communityId]/admin/opportunities/[id]/edit/page.tsx
+++ b/src/app/community/[communityId]/admin/opportunities/[id]/edit/page.tsx
@@ -22,10 +22,7 @@ export default function EditOpportunityPage() {
 
   // 既存データ取得
   const { data, loading, error } = useGetOpportunityQuery({
-    variables: {
-      id: opportunityId,
-      permission: { communityId },
-    },
+    variables: { id: opportunityId },
     fetchPolicy: "network-only",
   });
 

--- a/src/app/community/[communityId]/admin/opportunities/[id]/page.tsx
+++ b/src/app/community/[communityId]/admin/opportunities/[id]/page.tsx
@@ -42,7 +42,6 @@ export default function AdminOpportunityDetailPage() {
   const { data, loading, error, refetch } = useGetOpportunityQuery({
     variables: {
       id: id ?? "",
-      permission: { communityId: communityId ?? "" },
       slotSort: { startsAt: GqlSortDirection.Asc },
       slotFilter: { hostingStatus: [GqlOpportunitySlotHostingStatus.Scheduled] },
     },

--- a/src/app/community/[communityId]/admin/opportunities/features/editor/hooks/useOpportunitySave.ts
+++ b/src/app/community/[communityId]/admin/opportunities/features/editor/hooks/useOpportunitySave.ts
@@ -146,7 +146,6 @@ export const useOpportunitySave = ({
               ...categorySpecificInput,
               slots: slotsInputForCreate,
             },
-            permission: { communityId },
           },
         });
 

--- a/src/app/community/[communityId]/admin/places/features/editor/hooks/usePlaceSave.ts
+++ b/src/app/community/[communityId]/admin/places/features/editor/hooks/usePlaceSave.ts
@@ -55,7 +55,6 @@ export const usePlaceSave = ({ placeId, onSuccess }: UsePlaceSaveOptions = {}) =
             variables: {
               id: placeId,
               input: { ...input, id: placeId },
-              permission: { communityId },
             },
           });
           const updatedId = data?.placeUpdate?.place?.id;
@@ -69,7 +68,6 @@ export const usePlaceSave = ({ placeId, onSuccess }: UsePlaceSaveOptions = {}) =
           const { data } = await createPlace({
             variables: {
               input: { ...input, communityId },
-              permission: { communityId },
             },
           });
           const createdId = data?.placeCreate?.place?.id;

--- a/src/app/community/[communityId]/admin/places/features/list/components/PlaceCardMenu.tsx
+++ b/src/app/community/[communityId]/admin/places/features/list/components/PlaceCardMenu.tsx
@@ -39,10 +39,7 @@ export function PlaceCardMenu({ placeId, placeName, onDelete }: PlaceCardMenuPro
     setIsDeleting(true);
     try {
       await deletePlace({
-        variables: {
-          id: placeId,
-          permission: { communityId },
-        },
+        variables: { id: placeId },
       });
       toast.success("場所を削除しました");
       onDelete?.();

--- a/src/app/community/[communityId]/admin/reservations/features/detail/hooks/attendance/useSaveAttendances.ts
+++ b/src/app/community/[communityId]/admin/reservations/features/detail/hooks/attendance/useSaveAttendances.ts
@@ -27,7 +27,6 @@ export const useSaveAttendances = ({ onSuccess, onError }: UseSaveAttendancesArg
       await mutate({
         variables: {
           input: { evaluations },
-          permission: { communityId },
         },
       });
       toast.success("出欠情報を保存しました");

--- a/src/app/community/[communityId]/admin/tickets/components/CreateTicketSheet.tsx
+++ b/src/app/community/[communityId]/admin/tickets/components/CreateTicketSheet.tsx
@@ -66,7 +66,6 @@ export default function CreateTicketSheet({ onTicketCreated }: CreateTicketSheet
             utilityId: selectedUtilityId,
             qtyToBeIssued: ticketQty,
           },
-          permission: { communityId },
         },
       });
 

--- a/src/app/community/[communityId]/admin/tickets/utilities/components/CreateUtilitySheet.tsx
+++ b/src/app/community/[communityId]/admin/tickets/utilities/components/CreateUtilitySheet.tsx
@@ -76,7 +76,6 @@ export default function CreateUtilitySheet({ buttonLabel, onUtilityCreated }: Cr
             images: [],
             requiredForOpportunityIds: selectedOpportunityIds.length > 0 ? selectedOpportunityIds : undefined,
           },
-          permission: { communityId },
         },
       });
       const id = res.data?.utilityCreate?.utility?.id;

--- a/src/app/community/[communityId]/admin/votes/features/editor/hooks/useVoteTopicSave.ts
+++ b/src/app/community/[communityId]/admin/votes/features/editor/hooks/useVoteTopicSave.ts
@@ -76,7 +76,6 @@ export function useVoteTopicSave({
           const { data } = await createVoteTopic({
             variables: {
               input: { ...input, communityId },
-              permission: { communityId },
             },
           });
           const id = data?.voteTopicCreate?.voteTopic?.id ?? null;
@@ -92,7 +91,6 @@ export function useVoteTopicSave({
             variables: {
               id: topicId,
               input,
-              permission: { communityId },
             },
           });
           const id = data?.voteTopicUpdate?.voteTopic?.id ?? null;

--- a/src/app/community/[communityId]/admin/votes/features/list/hooks/useVoteTopicActions.ts
+++ b/src/app/community/[communityId]/admin/votes/features/list/hooks/useVoteTopicActions.ts
@@ -37,10 +37,7 @@ export function useVoteTopicActions({
       if (!window.confirm(t("adminVotes.list.deleteConfirm"))) return;
       try {
         await deleteVoteTopic({
-          variables: {
-            id: voteTopicId,
-            permission: { communityId },
-          },
+          variables: { id: voteTopicId },
         });
         toast.success(t("adminVotes.toast.deleteSuccess"));
         refetch?.();

--- a/src/app/community/[communityId]/admin/wallet/grant/GrantPageClient.tsx
+++ b/src/app/community/[communityId]/admin/wallet/grant/GrantPageClient.tsx
@@ -76,7 +76,6 @@ export default function GrantPageClient({ initialConnection }: GrantPageClientPr
           comment,
           images: imagesInput && imagesInput.length > 0 ? imagesInput : undefined,
         },
-        permission: { communityId },
       });
 
       if (res.success) {

--- a/src/app/community/[communityId]/admin/wallet/issue/page.tsx
+++ b/src/app/community/[communityId]/admin/wallet/issue/page.tsx
@@ -104,7 +104,6 @@ export default function IssuePointPage() {
           comment: comment.trim() || undefined,
           images: imagesInput.length > 0 ? imagesInput : undefined,
         },
-        permission: { communityId },
       });
 
       if (res.success) {

--- a/src/app/community/[communityId]/articles/hooks/useArticleQuery.ts
+++ b/src/app/community/[communityId]/articles/hooks/useArticleQuery.ts
@@ -1,18 +1,10 @@
 "use client";
 
-import { useCommunityConfig } from "@/contexts/CommunityConfigContext";
 import { useGetArticleQuery } from "@/types/graphql";
 
 export const useArticleQuery = (id: string) => {
-  const { communityId } = useCommunityConfig();
-  
   return useGetArticleQuery({
-    variables: {
-      id,
-      permission: {
-        communityId: communityId ?? "",
-      },
-    },
+    variables: { id },
     skip: !id,
   });
 };

--- a/src/app/community/[communityId]/reservation/confirm/hooks/useReservationOpportunity.ts
+++ b/src/app/community/[communityId]/reservation/confirm/hooks/useReservationOpportunity.ts
@@ -24,10 +24,7 @@ export const useReservationOpportunity = ({
     error,
     refetch,
   } = useGetOpportunityQuery({
-    variables: {
-      id: opportunityId,
-      permission: { communityId: communityId ?? "" },
-    },
+    variables: { id: opportunityId },
     skip: !opportunityId,
     fetchPolicy: "network-only",
     errorPolicy: "all",

--- a/src/app/sysAdmin/features/reportDetail/actions/submitFeedback.ts
+++ b/src/app/sysAdmin/features/reportDetail/actions/submitFeedback.ts
@@ -79,7 +79,6 @@ export async function submitReportFeedbackAction(
           feedbackType: input.feedbackType ?? undefined,
           comment: input.comment ?? undefined,
         },
-        permission: { communityId: input.targetCommunityId },
       },
       { "X-Community-Id": homeCommunityId },
       15000,

--- a/src/graphql/account/community/mutation.ts
+++ b/src/graphql/account/community/mutation.ts
@@ -15,8 +15,8 @@ export const COMMUNITY_CREATE = gql`
 `;
 
 export const UPDATE_SIGNUP_BONUS_CONFIG = gql`
-  mutation UpdateSignupBonusConfig($input: UpdateSignupBonusConfigInput!, $communityId: ID!) {
-    updateSignupBonusConfig(input: $input, permission: { communityId: $communityId }) {
+  mutation UpdateSignupBonusConfig($input: UpdateSignupBonusConfigInput!) {
+    updateSignupBonusConfig(input: $input) {
       bonusPoint
       isEnabled
       message
@@ -25,11 +25,8 @@ export const UPDATE_SIGNUP_BONUS_CONFIG = gql`
 `;
 
 export const INCENTIVE_GRANT_RETRY = gql`
-  mutation IncentiveGrantRetry($incentiveGrantId: ID!, $communityId: ID!) {
-    incentiveGrantRetry(
-      input: { incentiveGrantId: $incentiveGrantId }
-      permission: { communityId: $communityId }
-    ) {
+  mutation IncentiveGrantRetry($incentiveGrantId: ID!) {
+    incentiveGrantRetry(input: { incentiveGrantId: $incentiveGrantId }) {
       ... on IncentiveGrantRetrySuccess {
         incentiveGrant {
           id
@@ -43,8 +40,8 @@ export const INCENTIVE_GRANT_RETRY = gql`
 `;
 
 export const UPDATE_PORTAL_CONFIG = gql`
-  mutation UpdatePortalConfig($input: CommunityPortalConfigInput!, $communityId: ID!) {
-    updatePortalConfig(input: $input, permission: { communityId: $communityId }) {
+  mutation UpdatePortalConfig($input: CommunityPortalConfigInput!) {
+    updatePortalConfig(input: $input) {
       communityId
       title
       description

--- a/src/graphql/account/membership/mutation.ts
+++ b/src/graphql/account/membership/mutation.ts
@@ -1,11 +1,8 @@
 import { gql } from "@apollo/client";
 
 export const ASSIGN_OWNER = gql`
-  mutation assignOwner(
-    $input: MembershipSetRoleInput!
-    $permission: CheckCommunityPermissionInput!
-  ) {
-    membershipAssignOwner(input: $input, permission: $permission) {
+  mutation assignOwner($input: MembershipSetRoleInput!) {
+    membershipAssignOwner(input: $input) {
       ... on MembershipSetRoleSuccess {
         membership {
           ...MembershipFields
@@ -16,11 +13,8 @@ export const ASSIGN_OWNER = gql`
 `;
 
 export const ASSIGN_MANAGER = gql`
-  mutation assignManager(
-    $input: MembershipSetRoleInput!
-    $permission: CheckCommunityPermissionInput!
-  ) {
-    membershipAssignManager(input: $input, permission: $permission) {
+  mutation assignManager($input: MembershipSetRoleInput!) {
+    membershipAssignManager(input: $input) {
       ... on MembershipSetRoleSuccess {
         membership {
           ...MembershipFields
@@ -31,11 +25,8 @@ export const ASSIGN_MANAGER = gql`
 `;
 
 export const ASSIGN_MEMBER = gql`
-  mutation assignMember(
-    $input: MembershipSetRoleInput!
-    $permission: CheckCommunityPermissionInput!
-  ) {
-    membershipAssignMember(input: $input, permission: $permission) {
+  mutation assignMember($input: MembershipSetRoleInput!) {
+    membershipAssignMember(input: $input) {
       ... on MembershipSetRoleSuccess {
         membership {
           ...MembershipFields

--- a/src/graphql/account/report/mutation.ts
+++ b/src/graphql/account/report/mutation.ts
@@ -17,11 +17,8 @@ import { REPORT_FEEDBACK_FIELDS } from "../reportFeedback/fragment";
  * テンプレートは generated types / SSR 用 `print` のソースとして残してある。
  */
 export const SUBMIT_REPORT_FEEDBACK = gql`
-  mutation SubmitReportFeedback(
-    $input: SubmitReportFeedbackInput!
-    $permission: CheckCommunityPermissionInput!
-  ) {
-    submitReportFeedback(input: $input, permission: $permission) {
+  mutation SubmitReportFeedback($input: SubmitReportFeedbackInput!) {
+    submitReportFeedback(input: $input) {
       ... on SubmitReportFeedbackSuccess {
         feedback {
           ...ReportFeedbackFields

--- a/src/graphql/content/article/query.ts
+++ b/src/graphql/content/article/query.ts
@@ -33,8 +33,8 @@ export const GET_ARTICLES = gql`
 `;
 
 export const GET_ARTICLE = gql`
-  query GetArticle($id: ID!, $permission: CheckCommunityPermissionInput!) {
-    article(id: $id, permission: $permission) {
+  query GetArticle($id: ID!) {
+    article(id: $id) {
       ...ArticleFields
       relatedUsers {
         ...UserFields

--- a/src/graphql/experience/evaluation/batchMutation.ts
+++ b/src/graphql/experience/evaluation/batchMutation.ts
@@ -2,11 +2,8 @@ import { gql } from "@apollo/client";
 import { EVALUATION_FRAGMENT } from "./fragment";
 
 export const EVALUATION_BULK_CREATE = gql`
-  mutation EvaluationBulkCreate(
-    $input: EvaluationBulkCreateInput!, 
-    $permission: CheckCommunityPermissionInput!
-  ) {
-    evaluationBulkCreate(input: $input, permission: $permission) {
+  mutation EvaluationBulkCreate($input: EvaluationBulkCreateInput!) {
+    evaluationBulkCreate(input: $input) {
       ... on EvaluationBulkCreateSuccess {
         evaluations {
           ...EvaluationFields

--- a/src/graphql/experience/opportunity/mutation.ts
+++ b/src/graphql/experience/opportunity/mutation.ts
@@ -4,11 +4,8 @@ import { gql } from "@apollo/client";
 // CREATE OPPORTUNITY
 // =====================================
 export const CREATE_OPPORTUNITY = gql`
-  mutation CreateOpportunity(
-    $input: OpportunityCreateInput!
-    $permission: CheckCommunityPermissionInput!
-  ) {
-    opportunityCreate(input: $input, permission: $permission) {
+  mutation CreateOpportunity($input: OpportunityCreateInput!) {
+    opportunityCreate(input: $input) {
       ... on OpportunityCreateSuccess {
         opportunity {
           id

--- a/src/graphql/experience/opportunity/query.ts
+++ b/src/graphql/experience/opportunity/query.ts
@@ -87,11 +87,10 @@ export const GET_OPPORTUNITIES = gql`
 export const GET_OPPORTUNITY = gql`
   query GetOpportunity(
     $id: ID!
-    $permission: CheckCommunityPermissionInput!
     $slotFilter: OpportunitySlotFilterInput
     $slotSort: OpportunitySlotSortInput
   ) {
-    opportunity(id: $id, permission: $permission) {
+    opportunity(id: $id) {
       id
       title
       description

--- a/src/graphql/experience/participation/batchMutation.ts
+++ b/src/graphql/experience/participation/batchMutation.ts
@@ -2,11 +2,8 @@ import { gql } from "@apollo/client";
 import { PARTICIPATION_FRAGMENT } from "./fragment";
 
 export const PARTICIPATION_BULK_CREATE = gql`
-  mutation ParticipationBulkCreate(
-    $input: ParticipationBulkCreateInput!, 
-    $permission: CheckCommunityPermissionInput!
-  ) {
-    participationBulkCreate(input: $input, permission: $permission) {
+  mutation ParticipationBulkCreate($input: ParticipationBulkCreateInput!) {
+    participationBulkCreate(input: $input) {
       ... on ParticipationBulkCreateSuccess {
         participations {
           ...ParticipationFields

--- a/src/graphql/location/place/mutation.ts
+++ b/src/graphql/location/place/mutation.ts
@@ -1,8 +1,8 @@
 import { gql } from "@apollo/client";
 
 export const PLACE_CREATE = gql`
-  mutation PlaceCreate($input: PlaceCreateInput!, $permission: CheckCommunityPermissionInput!) {
-    placeCreate(input: $input, permission: $permission) {
+  mutation PlaceCreate($input: PlaceCreateInput!) {
+    placeCreate(input: $input) {
       ... on PlaceCreateSuccess {
         place {
           id
@@ -35,12 +35,8 @@ export const PLACE_CREATE = gql`
 `;
 
 export const PLACE_UPDATE = gql`
-  mutation PlaceUpdate(
-    $id: ID!
-    $input: PlaceUpdateInput!
-    $permission: CheckCommunityPermissionInput!
-  ) {
-    placeUpdate(id: $id, input: $input, permission: $permission) {
+  mutation PlaceUpdate($id: ID!, $input: PlaceUpdateInput!) {
+    placeUpdate(id: $id, input: $input) {
       ... on PlaceUpdateSuccess {
         place {
           id
@@ -69,8 +65,8 @@ export const PLACE_UPDATE = gql`
 `;
 
 export const PLACE_DELETE = gql`
-  mutation PlaceDelete($id: ID!, $permission: CheckCommunityPermissionInput!) {
-    placeDelete(id: $id, permission: $permission) {
+  mutation PlaceDelete($id: ID!) {
+    placeDelete(id: $id) {
       ... on PlaceDeleteSuccess {
         id
       }

--- a/src/graphql/reward/ticket/mutation.ts
+++ b/src/graphql/reward/ticket/mutation.ts
@@ -1,8 +1,8 @@
 import { gql } from "@apollo/client";
 
 export const TICKET_ISSUE = gql`
-  mutation ticketIssue($input: TicketIssueInput!, $permission: CheckCommunityPermissionInput!) {
-    ticketIssue(input: $input, permission: $permission) {
+  mutation ticketIssue($input: TicketIssueInput!) {
+    ticketIssue(input: $input) {
       ... on TicketIssueSuccess {
         issue {
           id

--- a/src/graphql/reward/utility/mutation.ts
+++ b/src/graphql/reward/utility/mutation.ts
@@ -1,8 +1,8 @@
 import { gql } from "@apollo/client";
 
 export const CREATE_UTILITY = gql`
-  mutation CreateUtility($input: UtilityCreateInput!, $permission: CheckCommunityPermissionInput!) {
-    utilityCreate(input: $input, permission: $permission) {
+  mutation CreateUtility($input: UtilityCreateInput!) {
+    utilityCreate(input: $input) {
       ... on UtilityCreateSuccess {
         utility {
           ...UtilityFields

--- a/src/graphql/transaction/mutation.ts
+++ b/src/graphql/transaction/mutation.ts
@@ -1,11 +1,8 @@
 import { gql } from "@apollo/client";
 
 export const ISSUE_POINT = gql`
-  mutation pointIssue(
-    $input: TransactionIssueCommunityPointInput!
-    $permission: CheckCommunityPermissionInput!
-  ) {
-    transactionIssueCommunityPoint(input: $input, permission: $permission) {
+  mutation pointIssue($input: TransactionIssueCommunityPointInput!) {
+    transactionIssueCommunityPoint(input: $input) {
       ... on TransactionIssueCommunityPointSuccess {
         transaction {
           ...TransactionFields
@@ -16,11 +13,8 @@ export const ISSUE_POINT = gql`
 `;
 
 export const GRANT_POINT = gql`
-  mutation pointGrant(
-    $input: TransactionGrantCommunityPointInput!
-    $permission: CheckCommunityPermissionInput!
-  ) {
-    transactionGrantCommunityPoint(input: $input, permission: $permission) {
+  mutation pointGrant($input: TransactionGrantCommunityPointInput!) {
+    transactionGrantCommunityPoint(input: $input) {
       ... on TransactionGrantCommunityPointSuccess {
         transaction {
           ...TransactionFields
@@ -50,9 +44,8 @@ export const TRANSACTION_UPDATE_METADATA = gql`
     $id: ID!
     $input: TransactionUpdateMetadataInput!
     $permission: CheckIsSelfPermissionInput
-    $communityPermission: CheckCommunityPermissionInput
   ) {
-    transactionUpdateMetadata(id: $id, input: $input, permission: $permission, communityPermission: $communityPermission) {
+    transactionUpdateMetadata(id: $id, input: $input, permission: $permission) {
       ... on TransactionUpdateMetadataSuccess {
         transaction {
           id

--- a/src/graphql/vote/voteTopic/mutation.ts
+++ b/src/graphql/vote/voteTopic/mutation.ts
@@ -2,11 +2,8 @@ import { gql } from "@apollo/client";
 import { VOTE_TOPIC_FRAGMENT } from "./fragment";
 
 export const CREATE_VOTE_TOPIC = gql`
-  mutation CreateVoteTopic(
-    $input: VoteTopicCreateInput!
-    $permission: CheckCommunityPermissionInput!
-  ) {
-    voteTopicCreate(input: $input, permission: $permission) {
+  mutation CreateVoteTopic($input: VoteTopicCreateInput!) {
+    voteTopicCreate(input: $input) {
       ... on VoteTopicCreateSuccess {
         voteTopic {
           ...VoteTopicFields
@@ -18,8 +15,8 @@ export const CREATE_VOTE_TOPIC = gql`
 `;
 
 export const DELETE_VOTE_TOPIC = gql`
-  mutation DeleteVoteTopic($id: ID!, $permission: CheckCommunityPermissionInput!) {
-    voteTopicDelete(id: $id, permission: $permission) {
+  mutation DeleteVoteTopic($id: ID!) {
+    voteTopicDelete(id: $id) {
       ... on VoteTopicDeleteSuccess {
         voteTopicId
       }
@@ -46,12 +43,8 @@ export const VOTE_CAST = gql`
 `;
 
 export const UPDATE_VOTE_TOPIC = gql`
-  mutation UpdateVoteTopic(
-    $id: ID!
-    $input: VoteTopicUpdateInput!
-    $permission: CheckCommunityPermissionInput!
-  ) {
-    voteTopicUpdate(id: $id, input: $input, permission: $permission) {
+  mutation UpdateVoteTopic($id: ID!, $input: VoteTopicUpdateInput!) {
+    voteTopicUpdate(id: $id, input: $input) {
       ... on VoteTopicUpdateSuccess {
         voteTopic {
           ...VoteTopicFields

--- a/src/hooks/opportunities/useOpportunityDetail.ts
+++ b/src/hooks/opportunities/useOpportunityDetail.ts
@@ -21,7 +21,6 @@ export const useOpportunityDetail = (id: string | undefined) => {
   const { data, loading, error, refetch } = useGetOpportunityQuery({
     variables: {
       id: id ?? "",
-      permission: { communityId },
       slotSort: { startsAt: GqlSortDirection.Asc },
       slotFilter: { hostingStatus: [GqlOpportunitySlotHostingStatus.Scheduled] },
     },

--- a/src/hooks/transactions/useUpdateTransactionMetadata.ts
+++ b/src/hooks/transactions/useUpdateTransactionMetadata.ts
@@ -61,9 +61,6 @@ export function useUpdateTransactionMetadata() {
           ...(!permissionOverride || permissionOverride.type === "self"
             ? { permission: { userId: currentUserId! } }
             : {}),
-          ...(permissionOverride?.type === "community"
-            ? { communityPermission: { communityId: permissionOverride.communityId } }
-            : {}),
         },
       });
 


### PR DESCRIPTION
## Summary

`pnpm gql:generate` が backend スキーマ更新（civicship-api#1057）で 47 件の document validation エラーを吐いて落ちていたのを修正する。

問題は 2 段構成だった:

1. **`codegen.yaml` が自分の出力を再 validate していた**
   `documents: src/**/*.ts?(x)` のグロブが `src/types/graphql.tsx`（codegen の出力ファイル）を拾っていたため、前回成果物として埋め込まれていた 155 個の `gql` テンプレートリテラル（古いスキーマ準拠）が新スキーマで再検証され、`sysAdminDashboard` / `SysAdmin*Input` / `admin*Reports` などの旧クエリ・型を参照してエラー化していた。
   → グロブから `!src/types/graphql.tsx` を除外。

2. **手書き query/mutation が削除済みの `permission` 引数を渡し続けていた**
   civicship-api#1057 で `IsCommunityOwner / IsCommunityManager / IsCommunityMember` ルールが `x-community-id` リクエストヘッダ参照に統一され、`CheckCommunityPermissionInput` を取る field-level argument が schema から削除された（`@deprecated` ではなく完全に Unknown 化）。`CheckOpportunityPermissionInput` / `CheckIsSelfPermissionInput` 系は据え置き。
   → `CheckCommunityPermissionInput` を渡している全 gql 定義（vote, membership, report, article, place, utility, ticket, transaction の community 系, opportunity create + query, evaluation/participation bulk, signup bonus / incentive retry / portal config）と、`transactionUpdateMetadata` の `communityPermission` 引数を削除。呼び出し側 22 ファイルで `permission`/`communityPermission` variable と用済みになった `communityId` lookup も合わせて落とす。

これで `pnpm gql:generate` のドキュメント検証は通る（残りの tsc エラー 171 件は本 PR 起因ではなく既存問題）。

## ⚠️ 動作確認してほしい点

`src/app/sysAdmin/features/reportDetail/actions/submitFeedback.ts` の sysAdmin cross-community feedback フロー。

旧フロー:

- `X-Community-Id` ヘッダ = sysAdmin の home community（identity 解決のため）
- `permission.communityId` = 投稿対象 community

新フロー（本 PR 以降）:

- `permission` 引数が消えたので `X-Community-Id` だけで対象を表現することになる
- 上記コードはまだヘッダに home community を入れたままなので、**sysAdmin が home 以外の community に feedback 投稿すると routing が壊れる可能性**がある
- backend 側で sysAdmin の bypass がヘッダ無視 / target 上書きで動くようになっているなら問題ない。実機で要確認。

## Test plan

- [x] `pnpm gql:generate` がエラーなしで通る
- [ ] sysAdmin 同 community feedback 投稿の正常系
- [ ] sysAdmin 他 community feedback 投稿（上記 ⚠️ の影響範囲）
- [ ] community 系 mutation 一通り（vote, place, ticket, utility, membership, point grant/issue, opportunity create, evaluation/participation bulk）が `x-community-id` ヘッダ経由で正しく認可される

## 変更ファイル数

- gql 定義: 13 ファイル
- 呼び出し側: 22 ファイル
- codegen 設定: 1 ファイル

https://claude.ai/code/session_01FpZkU1bb5en2tAmiTkMrGP