### PR TITLE
fix(sysAdmin): use target community in X-Community-Id for report feedback

### DIFF
--- a/src/app/sysAdmin/features/reportDetail/actions/submitFeedback.ts
+++ b/src/app/sysAdmin/features/reportDetail/actions/submitFeedback.ts
@@ -1,8 +1,6 @@
 "use server";
 
-import { cookies } from "next/headers";
 import { executeServerGraphQLQuery } from "@/lib/graphql/server";
-import { ACTIVE_COMMUNITY_IDS } from "@/lib/communities/constants";
 import { SUBMIT_REPORT_FEEDBACK_SERVER_MUTATION } from "@/graphql/account/report/server";
 import type {
   GqlSubmitReportFeedbackMutation,
@@ -14,7 +12,7 @@ export type SubmitFeedbackActionInput = {
   rating: number;
   feedbackType?: GqlSubmitReportFeedbackMutationVariables["input"]["feedbackType"];
   comment?: string;
-  /** 投稿対象の community (= URL の `/sysAdmin/{communityId}/...` および `report.community.id`) */
+  /** 投稿対象 report の community.id。X-Community-Id ヘッダに渡す */
   targetCommunityId: string;
 };
 
@@ -25,47 +23,15 @@ export type SubmitFeedbackActionResult =
 /**
  * sysAdmin の feedback 投稿用 server action。
  *
- * backend の auth middleware (`firebase-auth.ts`) は `X-Community-Id` を
- * (a) Firebase tenant 解決 (b) `identities.some.{uid, communityId}` の検索キー
- * の両方に使う。sysAdmin の identity は home community ぶんしか発行されないため、
- * `X-Community-Id` を URL の対象 community に切り替えると identity が見つからず
- * `currentUser=null` になり、`IsAdmin` (sysAdmin bypass) と `IsCommunityMember`
- * の OR ルール両方が落ちて `FORBIDDEN` になる。
- *
- * よって `X-Community-Id` には HttpOnly cookie `__session_{community}` から
- * 推定した home community を入れ、対象 community は GraphQL 引数
- * `permission.communityId` で別途指定する。これは `communityCreate.ts` と同じ
- * パターン。
+ * backend は `submitReportFeedback` usecase 内で
+ * `ctx.communityId (= X-Community-Id) === report.communityId` を要求する
+ * ので、対象 report の community をヘッダに入れる。@authz は
+ * `IsCommunityMember OR IsAdmin` で、sysAdmin は `User.sysRole === SYS_ADMIN`
+ * で bypass される。
  */
 export async function submitReportFeedbackAction(
   input: SubmitFeedbackActionInput,
 ): Promise<SubmitFeedbackActionResult> {
-  const cookieStore = await cookies();
-  // 複数 community にログイン履歴があると `__session_{id}` が複数存在し、
-  // `find()` は cookie 走査順序依存で非決定的になる。`x-community-id` cookie
-  // (middleware が host / 直前の `/community/{id}/...` 経由で解決した値) を
-  // hint として優先し、それに対応する `__session_{id}` があれば確定で採用、
-  // 無ければ ACTIVE_COMMUNITY_IDS にマッチする最初の session に fallback する。
-  const sessionIds = cookieStore
-    .getAll()
-    .filter((c) => c.name.startsWith("__session_"))
-    .map((c) => c.name.replace("__session_", ""));
-  const hintedCommunityId = cookieStore.get("x-community-id")?.value;
-  const homeCommunityId =
-    hintedCommunityId && sessionIds.includes(hintedCommunityId)
-      ? hintedCommunityId
-      : sessionIds.find((id) =>
-          (ACTIVE_COMMUNITY_IDS as readonly string[]).includes(id),
-        );
-
-  if (!homeCommunityId) {
-    return {
-      ok: false,
-      error:
-        "有効なセッションが見つかりません。一度ログアウトしてから再度ログインしてください",
-    };
-  }
-
   try {
     await executeServerGraphQLQuery<
       GqlSubmitReportFeedbackMutation,
@@ -80,7 +46,7 @@ export async function submitReportFeedbackAction(
           comment: input.comment ?? undefined,
         },
       },
-      { "X-Community-Id": homeCommunityId },
+      { "X-Community-Id": input.targetCommunityId },
       15000,
     );
     return { ok: true };

--- a/src/app/sysAdmin/features/reportDetail/components/ReportDetailContainer.tsx
+++ b/src/app/sysAdmin/features/reportDetail/components/ReportDetailContainer.tsx
@@ -24,9 +24,9 @@ type Props = {
  * 結ぶ container。
  *
  * client Apollo mutation ではなく server action (`submitReportFeedbackAction`)
- * 経由で叩く。理由は同 action ファイルの doc コメント参照 (sysAdmin の
- * `X-Community-Id` を home community に固定する必要があるため、HttpOnly な
- * `__session_*` cookie をサーバ側で読む必要がある)。
+ * 経由で叩く。Apollo client が送る `X-Community-Id` は URL の community に
+ * 固定されてしまうが、sysAdmin は別 community の report にも投稿するので、
+ * リクエストごとに対象 report の community をヘッダに当てる必要がある。
  *
  * 投稿成功後は `router.refresh()` で SSR を再走させ、`myFeedback` と
  * `feedbacks` connection を最新化する。

--- a/src/graphql/account/report/mutation.ts
+++ b/src/graphql/account/report/mutation.ts
@@ -3,18 +3,16 @@ import { REPORT_FEEDBACK_FIELDS } from "../reportFeedback/fragment";
 
 /**
  * Report detail page から admin が代行で投稿する feedback。
- * permission は `CheckCommunityPermissionInput` で OR チェック (`IsCommunityMember`
- * または `IsAdmin`)、`IsAdmin` は `User.sysRole = SYS_ADMIN` を見て bypass する。
+ * 認可は `IsCommunityMember OR IsAdmin` で、`IsAdmin` は
+ * `User.sysRole === SYS_ADMIN` で bypass される。対象 community は
+ * `X-Community-Id` ヘッダから解決され、`report.communityId` と一致しないと
+ * usecase が NotFoundError を返す。
  *
- * ただし backend の auth middleware (`firebase-auth.ts`) は `X-Community-Id` を
- * Firebase tenant 解決と `identities.some.{uid, communityId}` の検索キーの両方に
- * 使うので、sysAdmin の identity が住む home community と `X-Community-Id` が
- * 一致していないと `currentUser=null` になり OR の両側が落ちる。
- *
- * sysAdmin が他 community の report に投稿する場合は client mutation ではなく
- * server action `submitReportFeedbackAction` を使うこと (HttpOnly cookie から
- * home community を解決して `X-Community-Id` を組み立てる)。この `gql`
- * テンプレートは generated types / SSR 用 `print` のソースとして残してある。
+ * sysAdmin が他 community の report に投稿する場合、Apollo client が送る
+ * ヘッダ (URL の community) では対象と一致しないので、server action
+ * `submitReportFeedbackAction` 経由でヘッダに対象 report の community を
+ * 当てて送る。この gql テンプレートは generated types / server action の
+ * `print` のソースとして残してある。
  */
 export const SUBMIT_REPORT_FEEDBACK = gql`
   mutation SubmitReportFeedback($input: SubmitReportFeedbackInput!) {

--- a/src/graphql/account/report/server.ts
+++ b/src/graphql/account/report/server.ts
@@ -25,11 +25,11 @@ export const GET_ADMIN_REPORT_FEEDBACKS_SERVER_QUERY = print(
 
 /**
  * sysAdmin の feedback 投稿は client Apollo ではなく server action 経由で叩く。
- * backend (`firebase-auth.ts`) は X-Community-Id を tenant 解決と identity 検索の
- * 両方に使うので、sysAdmin の auth identity が住んでいる home community を
- * X-Community-Id に当てる必要がある。home community は HttpOnly な
- * `__session_{community}` cookie からしか確実に判定できないため、サーバ側で
- * 組み立てる。`permission.communityId` には URL の対象 community を入れる。
+ * backend は `submitReportFeedback` usecase で
+ * `ctx.communityId (= X-Community-Id) === report.communityId` を要求するため、
+ * リクエストごとに対象 report の community をヘッダに当てる。Apollo client は
+ * URL の community で固定するので、別 community の report に投稿する経路では
+ * server action 経由でヘッダを差し替える。
  */
 export const SUBMIT_REPORT_FEEDBACK_SERVER_MUTATION = print(
   addTypenameToDocument(SubmitReportFeedbackDocument),


### PR DESCRIPTION
## Summary

sysAdmin から **他 community の report に feedback 投稿** すると、現状 **常に NotFoundError** で失敗するバグの修正です。`CheckCommunityPermissionInput` 削除後の backend 仕様変更にフロント側 server action が追従できていませんでした。

### 何が起きていたか

| | ヘッダ (X-Community-Id) | input.reportId |
|---|---|---|
| **正しい値** | report が属する community | その report の id |
| **修正前** | sysAdmin の home community | 別 community の report の id |

backend は `submitReportFeedback` usecase で `ctx.communityId (= X-Community-Id) === report.communityId` を要求するため、ヘッダ=home / report=他 community のときは usecase レベルで NotFoundError を返していました。

permission 引数があった旧仕様では、`permission.communityId` で対象 community を別途指定できたため、ヘッダは Firebase tenant / identity 解決のため home に固定する必要がありました。permission 引数削除後、対象 community 解決はヘッダ一本化に切り替わったので、server action 側もそれに追従する必要がありました。

### 変更点

- `src/app/sysAdmin/features/reportDetail/actions/submitFeedback.ts`
  - `X-Community-Id` ヘッダの値を `homeCommunityId` → `input.targetCommunityId` に変更
  - home community を `__session_*` cookie から推定するロジックは不要になったため削除
  - doc コメントを新仕様に書き直し
- `src/app/sysAdmin/features/reportDetail/components/ReportDetailContainer.tsx`
  - doc コメントを新仕様に書き直し
- `src/graphql/account/report/mutation.ts`
  - 旧仕様前提 (permission 引数) で書かれていた doc コメントを新仕様に書き直し
- `src/graphql/account/report/server.ts`
  - 同上

呼び出し側 (`ReportDetailContainer.tsx:48-53`) は `targetCommunityId: report.community.id` を既に渡しており、変更不要です。

### Backend からの仕様確認

PR レビューの過程で backend に挙動を確認済み (`submitReportFeedback` usecase は `X-Community-Id` ヘッダから対象 community を解決、`@authz: IsAdmin` で sysAdmin bypass、Firebase tenant 解決は別経路)。

## Test plan

- [ ] sysAdmin として **自分の home community とは別の community** の report 詳細を開く
- [ ] その report に feedback (rating / comment) を投稿し、**成功すること**を確認
- [ ] `myFeedback` / `feedbacks` connection が更新されること (router.refresh)
- [ ] 自 community の report への投稿もこれまで通り成功すること

修正後のヘッダ送信が Firebase tenant 検証に影響しないかも合わせて確認 (上記が成功すれば OK)。

https://claude.ai/code/session_01BmeD1PyDSr9kMwNavuA3BG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmeD1PyDSr9kMwNavuA3BG)_