### PR TITLE
refactor(transactions): drop unused communityId from UpdatePermission

### DIFF
--- a/src/app/community/[communityId]/transactions/[id]/components/TransactionMetadataEditSheet.tsx
+++ b/src/app/community/[communityId]/transactions/[id]/components/TransactionMetadataEditSheet.tsx
@@ -18,8 +18,12 @@ interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess: () => void;
-  /** Owner がコミュニティウォレット発のトランザクションを編集する場合に渡す */
-  communityId?: string;
+  /**
+   * Owner がコミュニティウォレット発のトランザクションを編集する場合に true。
+   * backend は Apollo client が送る X-Community-Id ヘッダの community で
+   * OWNER 判定するため、URL の community がそのまま対象になる前提。
+   */
+  asCommunityAdmin?: boolean;
 }
 
 async function urlToFile(url: string, onError: (msg: string) => void): Promise<File> {
@@ -45,7 +49,7 @@ export function TransactionMetadataEditSheet({
   open,
   onOpenChange,
   onSuccess,
-  communityId,
+  asCommunityAdmin,
 }: Props) {
   const t = useTranslations();
   const { updateTransactionMetadata } = useUpdateTransactionMetadata();
@@ -129,8 +133,8 @@ export function TransactionMetadataEditSheet({
         return;
       }
 
-      const permission = communityId
-        ? { type: "community" as const, communityId }
+      const permission = asCommunityAdmin
+        ? { type: "community" as const }
         : { type: "self" as const };
 
       const res = await updateTransactionMetadata(

--- a/src/app/community/[communityId]/transactions/[id]/page.tsx
+++ b/src/app/community/[communityId]/transactions/[id]/page.tsx
@@ -179,7 +179,7 @@ export default function TransactionDetailPage({ params }: { params: Promise<{ id
           open={editOpen}
           onOpenChange={setEditOpen}
           onSuccess={() => refetch()}
-          communityId={isOwner && isFromCommunityWallet ? communityId : undefined}
+          asCommunityAdmin={isOwner && isFromCommunityWallet}
         />
       )}
     </div>

--- a/src/hooks/transactions/useUpdateTransactionMetadata.ts
+++ b/src/hooks/transactions/useUpdateTransactionMetadata.ts
@@ -12,15 +12,21 @@ import { useAuthStore } from "@/lib/auth/core/auth-store";
 
 type Result<T> = { success: true; data: T } | { success: false; code: GqlErrorCode };
 
-export type UpdatePermission =
-  | { type: "self" }
-  | { type: "community"; communityId: string };
+export type UpdatePermission = { type: "self" } | { type: "community" };
 
 /**
  * トランザクションのメタデータ（コメント・画像）を更新する汎用 hook。
  * admin 配下の useTransactionMutations に依存せず、
  * ユーザー向けフロー（donate 等）からも安全にインポートできる。
  *
+ * `permissionOverride`:
+ * - `{ type: "self" }` (デフォルト): 自分の transaction を編集。
+ *   `permission: { userId }` を mutation 引数に付与し、backend の IsSelf rule を通す。
+ * - `{ type: "community" }`: community OWNER として community wallet 発の
+ *   transaction を編集。permission 引数は付与せず、Apollo client が送る
+ *   `X-Community-Id` ヘッダの community で backend が OWNER 判定する。
+ *   呼び出し元は `/community/[communityId]/...` 配下にいる前提
+ *   (= Apollo context の community = 対象 community)。
  */
 export function useUpdateTransactionMetadata() {
   const currentUserId = useAuthStore((s) => s.state.currentUser?.id ?? null);


### PR DESCRIPTION
## Summary

`useUpdateTransactionMetadata` の API 表面から、実際には使われていない `communityId` を削除する整理 PR です。**機能変更なし**。

### 背景

Copilot レビュー #4 (#1219 で挙がった) で `UpdatePermission` の `community` variant が dead path と指摘されていました。backend に挙動を確認した結果：

| FE が送るもの | IsSelf | IsCommunityOwner | 通る |
|---|---|---|---|
| `permission: { userId }` のみ | ✅ | – | ✅ |
| permission 無し + ヘッダ=OWNER community | – | ✅ | ✅ |

- **self モード**: `permission: { userId }` を mutation 引数に付ける必要あり (`@authz IsSelf` rule が `args.permission.userId` を必須参照)
- **community モード**: permission 引数は不要。ヘッダ (`X-Community-Id`) の community で backend が OWNER 自動判定

つまり community モードで mutation 引数の `communityId` は **どこにも反映されない**。`/community/[communityId]/...` 配下から呼ぶ前提なので、Apollo client が送るヘッダが自然に対象 community になっており、現状の hook 実装は **機能的には完全に正しい** (Copilot の "dead path" 評は実態と異なる)。

ただし API 表面に「communityId を渡せる」と書いてあるのに無視される嘘が残るため、型から削除します。

### 変更点

- **`src/hooks/transactions/useUpdateTransactionMetadata.ts`**
  - `UpdatePermission` 型から `communityId: string` を削除
  - doc コメントを追加: self / community 各モードで backend が何を見るかを明文化
- **`src/app/community/[communityId]/transactions/[id]/components/TransactionMetadataEditSheet.tsx`**
  - prop を `communityId?: string` → `asCommunityAdmin?: boolean` にリネーム
- **`src/app/community/[communityId]/transactions/[id]/page.tsx`**
  - 呼び出し側を `asCommunityAdmin` に追従

### 機能的な影響

- self モード (自分の donate transaction 編集等): 変更なし
- community モード (community OWNER が community wallet 発 transaction を編集): 変更なし (元々ヘッダで動いていた経路をそのまま使う)

## Test plan

- [ ] community admin として `/community/[communityId]/transactions/[id]` を開き、community wallet 発 transaction の comment / images を編集 → 成功
- [ ] 通常ユーザーとして自分の donate transaction の comment / images を編集 → 成功
- [ ] 編集権限のない transaction で編集シートが出ない (canEdit ロジック確認)
- [ ] `pnpm build` / 型チェックが通る

https://claude.ai/code/session_01BmeD1PyDSr9kMwNavuA3BG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmeD1PyDSr9kMwNavuA3BG)_