### PR TITLE
Remove redundant communityId parameter from evaluation and portal config mutations

### DIFF
--- a/src/app/community/[communityId]/admin/credentials/components/selectUser/CredentialRecipientSelector.tsx
+++ b/src/app/community/[communityId]/admin/credentials/components/selectUser/CredentialRecipientSelector.tsx
@@ -119,7 +119,7 @@ export default function CredentialRecipientSelector({
 
   const [createParticipation] = useParticipationBulkCreateMutation({
     onCompleted: (response) => {
-      save(response?.participationBulkCreate?.participations ?? [], communityId);
+      save(response?.participationBulkCreate?.participations ?? []);
       toast.success("登録が完了しました");
     },
     onError: (error) => {

--- a/src/app/community/[communityId]/admin/credentials/components/selectUser/CredentialRecipientSelector.tsx
+++ b/src/app/community/[communityId]/admin/credentials/components/selectUser/CredentialRecipientSelector.tsx
@@ -118,8 +118,8 @@ export default function CredentialRecipientSelector({
   });
 
   const [createParticipation] = useParticipationBulkCreateMutation({
-    onCompleted: (response) => {
-      save(response?.participationBulkCreate?.participations ?? []);
+    onCompleted: async (response) => {
+      await save(response?.participationBulkCreate?.participations ?? []);
       toast.success("登録が完了しました");
     },
     onError: (error) => {

--- a/src/app/community/[communityId]/admin/credentials/hooks/useEvaluationBulkCreate.ts
+++ b/src/app/community/[communityId]/admin/credentials/hooks/useEvaluationBulkCreate.ts
@@ -16,11 +16,7 @@ export const useEvaluationBulkCreate = ({ onSuccess, onError }: UseEvaluationBul
     awaitRefetchQueries: true,
   });
 
-  const save = async (
-    participations: GqlParticipation[],
-    communityId: string,
-  ) => {
-
+  const save = async (participations: GqlParticipation[]) => {
     const evaluations = participations.map((p) => {
       return {
         participationId: p.id,

--- a/src/app/community/[communityId]/admin/setting/hooks/useCommunityProfileEditor.ts
+++ b/src/app/community/[communityId]/admin/setting/hooks/useCommunityProfileEditor.ts
@@ -157,7 +157,7 @@ export function useCommunityProfileEditor(communityId: string | undefined) {
       }
 
       const result = await updatePortalConfig({
-        variables: { communityId, input },
+        variables: { input },
         refetchQueries: ["GetCommunityPortalConfig"],
       });
       const updated = result.data?.updatePortalConfig;


### PR DESCRIPTION
## Summary
This PR removes redundant `communityId` parameters that are already available in the component/hook scope, simplifying the function signatures and reducing unnecessary parameter passing.

## Key Changes
- **useEvaluationBulkCreate hook**: Removed `communityId` parameter from the `save` function signature since it's not used within the function body
- **CredentialRecipientSelector component**: Updated the `save` function call to remove the `communityId` argument, matching the new hook signature
- **useCommunityProfileEditor hook**: Removed `communityId` from the `updatePortalConfig` mutation variables object, as it appears the mutation only requires the `input` parameter

## Implementation Details
These changes improve code clarity by eliminating unused parameters and reducing the surface area of function interfaces. The `communityId` is still available in the component/hook scope through props or parameters if needed for other operations, but these specific mutations don't require it to be passed explicitly.

https://claude.ai/code/session_01VvkTi2Sk39441xhLVkXQUh