### PR TITLE
fix(admin/analytics): correct report href and plumb L2 KPIs to Owner route

### DIFF
--- a/src/app/community/[communityId]/admin/analytics/page.tsx
+++ b/src/app/community/[communityId]/admin/analytics/page.tsx
@@ -15,8 +15,8 @@ export default async function AdminAnalyticsPage({ params }: Props) {
   const { communityId } = await params;
 
   // L1 dashboard (`analyticsDashboard`) は sysAdmin 限定の cross-community
-  // 集計のため Owner ロールでは叩かない。L1 経由でしか取れない
-  // tenureDistribution / hubMemberCount は未提供のまま (子側で「未計測」表示)。
+  // 集計のため Owner ロールでは叩かない。
+  // tenureDistribution / hubMemberCount は L2 payload から取得して提供する。
   const [initialData, initialReports] = await Promise.all([
     fetchSysAdminCommunityDetailServer({
       communityId,
@@ -38,8 +38,10 @@ export default async function AdminAnalyticsPage({ params }: Props) {
       <CommunityDetailPageClient
         communityId={communityId}
         initialData={initialData}
+        tenureDistribution={initialData?.tenureDistribution}
+        hubMemberCount={initialData?.hubMemberCount}
         initialReports={initialReports}
-        reportHrefBase={`/admin/analytics/reports`}
+        reportHrefBase={`/community/${communityId}/admin/analytics/reports`}
       />
     </div>
   );

--- a/src/app/sysAdmin/[communityId]/CommunityDetailPageClient.tsx
+++ b/src/app/sysAdmin/[communityId]/CommunityDetailPageClient.tsx
@@ -19,11 +19,13 @@ import { CommunityReportsTabContainer } from "@/app/sysAdmin/features/communityD
 type Props = {
   communityId: string;
   initialData: GqlGetAnalyticsCommunityQuery["analyticsCommunity"] | null;
-  /** この community の tenure 分布。sysAdmin route では L1 dashboard 経由、
-   * community admin route では L2 payload から取得して受け渡す。 */
+  /** L2 payload が `tenureDistribution` を返さなかった場合の fallback。
+   * 通常は `useCommunityDetail` が返す最新の `data.tenureDistribution` が
+   * 優先される。sysAdmin route が L1 dashboard 経由で渡すケース向け。 */
   tenureDistribution?: GqlAnalyticsTenureDistribution | null;
-  /** この community の hub メンバー数。sysAdmin route では L1 dashboard 経由、
-   * community admin route では L2 payload から取得して受け渡す。 */
+  /** L2 payload が `hubMemberCount` を返さなかった場合の fallback。
+   * 通常は `useCommunityDetail` が返す最新の `data.hubMemberCount` が
+   * 優先される。sysAdmin route が L1 dashboard 経由で渡すケース向け。 */
   hubMemberCount?: number | null;
   /** SSR で取得した「レポート発行履歴」初期 1 ページ。 */
   initialReports?: GqlGetReportsAllQuery["reportsAll"] | null;
@@ -65,12 +67,18 @@ export function CommunityDetailPageClient({
   if (!data) return null;
 
   // L2 detail schema doesn't expose L1's windowActivity, so we approximate
-  // newMemberCount from the latest monthly trend point. hubMemberCount stays
-  // unprovided (renders as 未計測) until backend exposes it on
-  // AnalyticsCommunityPayload.
+  // newMemberCount from the latest monthly trend point.
   const latestMonth =
     data.monthlyActivityTrend[data.monthlyActivityTrend.length - 1];
   const newMemberCount = latestMonth?.newMembers;
+
+  // L2 payload では tenureDistribution / hubMemberCount を直接持つため、
+  // refetch (フィルター変更等) でも追従するよう `data` を優先する。
+  // sysAdmin route で L1 から渡される prop は L2 が null を返す場合の fallback。
+  const effectiveTenureDistribution =
+    data.tenureDistribution ?? tenureDistribution ?? undefined;
+  const effectiveHubMemberCount =
+    data.hubMemberCount ?? hubMemberCount ?? undefined;
 
   return (
     <div className="flex flex-col gap-6">
@@ -80,8 +88,8 @@ export function CommunityDetailPageClient({
         data={data}
         communityName={data.communityName}
         newMemberCount={newMemberCount}
-        tenureDistribution={tenureDistribution ?? undefined}
-        hubMemberCount={hubMemberCount ?? undefined}
+        tenureDistribution={effectiveTenureDistribution}
+        hubMemberCount={effectiveHubMemberCount}
         slot="summary"
       />
       <Tabs defaultValue="dashboard" className="w-full">
@@ -94,8 +102,8 @@ export function CommunityDetailPageClient({
             data={data}
             communityName={data.communityName}
             newMemberCount={newMemberCount}
-            tenureDistribution={tenureDistribution ?? undefined}
-            hubMemberCount={hubMemberCount ?? undefined}
+            tenureDistribution={effectiveTenureDistribution}
+            hubMemberCount={effectiveHubMemberCount}
             slot="details"
           />
         </TabsContent>

--- a/src/app/sysAdmin/[communityId]/CommunityDetailPageClient.tsx
+++ b/src/app/sysAdmin/[communityId]/CommunityDetailPageClient.tsx
@@ -19,12 +19,11 @@ import { CommunityReportsTabContainer } from "@/app/sysAdmin/features/communityD
 type Props = {
   communityId: string;
   initialData: GqlGetAnalyticsCommunityQuery["analyticsCommunity"] | null;
-  /** L1 dashboard 経由で取得した、この community の tenure 分布。L2 schema
-   * が tenureDistribution を露出するまでの SSR 横断の橋渡し。 */
+  /** この community の tenure 分布。sysAdmin route では L1 dashboard 経由、
+   * community admin route では L2 payload から取得して受け渡す。 */
   tenureDistribution?: GqlAnalyticsTenureDistribution | null;
-  /** L1 dashboard 経由で取得した、この community の hub メンバー数。L2
-   * schema には未掲載のため、tenureDistribution と同じく page.tsx で
-   * L1 と並列 fetch して受け渡す。 */
+  /** この community の hub メンバー数。sysAdmin route では L1 dashboard 経由、
+   * community admin route では L2 payload から取得して受け渡す。 */
   hubMemberCount?: number | null;
   /** SSR で取得した「レポート発行履歴」初期 1 ページ。 */
   initialReports?: GqlGetReportsAllQuery["reportsAll"] | null;

--- a/src/graphql/account/sysAdmin/query.ts
+++ b/src/graphql/account/sysAdmin/query.ts
@@ -10,6 +10,7 @@ import {
   ANALYTICS_PLATFORM_SUMMARY_FRAGMENT,
   ANALYTICS_RETENTION_TREND_POINT_FRAGMENT,
   ANALYTICS_STAGE_DISTRIBUTION_FRAGMENT,
+  ANALYTICS_TENURE_DISTRIBUTION_FRAGMENT,
 } from "./fragment";
 
 export const GET_ANALYTICS_DASHBOARD = gql`
@@ -36,6 +37,10 @@ export const GET_ANALYTICS_COMMUNITY = gql`
       communityName
       windowMonths
       dormantCount
+      hubMemberCount
+      tenureDistribution {
+        ...AnalyticsTenureDistributionFields
+      }
       alerts {
         ...AnalyticsAlertFields
       }
@@ -67,6 +72,7 @@ export const GET_ANALYTICS_COMMUNITY = gql`
     }
   }
   ${ANALYTICS_ALERT_FRAGMENT}
+  ${ANALYTICS_TENURE_DISTRIBUTION_FRAGMENT}
   ${ANALYTICS_COMMUNITY_DETAIL_SUMMARY_FRAGMENT}
   ${ANALYTICS_STAGE_DISTRIBUTION_FRAGMENT}
   ${ANALYTICS_MONTHLY_ACTIVITY_POINT_FRAGMENT}

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -6622,6 +6622,19 @@ export type GqlGetAnalyticsCommunityQuery = {
     communityName: string;
     windowMonths: number;
     dormantCount: number;
+    hubMemberCount: number;
+    tenureDistribution: {
+      __typename?: "AnalyticsTenureDistribution";
+      lt1Month: number;
+      m1to3Months: number;
+      m3to12Months: number;
+      gte12Months: number;
+      monthlyHistogram: Array<{
+        __typename?: "AnalyticsTenureHistogramBucket";
+        monthsIn: number;
+        count: number;
+      }>;
+    };
     alerts: {
       __typename?: "AnalyticsCommunityAlerts";
       activeDrop: boolean;
@@ -13890,6 +13903,10 @@ export const GetAnalyticsCommunityDocument = gql`
       communityName
       windowMonths
       dormantCount
+      hubMemberCount
+      tenureDistribution {
+        ...AnalyticsTenureDistributionFields
+      }
       alerts {
         ...AnalyticsAlertFields
       }
@@ -13920,6 +13937,7 @@ export const GetAnalyticsCommunityDocument = gql`
       }
     }
   }
+  ${AnalyticsTenureDistributionFieldsFragmentDoc}
   ${AnalyticsAlertFieldsFragmentDoc}
   ${AnalyticsCommunityDetailSummaryFieldsFragmentDoc}
   ${AnalyticsStageDistributionFieldsFragmentDoc}


### PR DESCRIPTION
## Summary

リリース PR #1228 (develop → master) の gemini-code-assist レビューで指摘された admin/analytics の不具合 / 改善を develop にバックフィルする。

### 修正内容

- **🐛 reportHrefBase のナビゲーションバグ** (high)
  `/admin/analytics/reports` はドメインルート絶対パスとして解決されるため、`/community/[communityId]/admin/analytics/reports/[reportId]` にあるレポート詳細へ正しく遷移できなかった。`/community/${communityId}/admin/analytics/reports` に修正。

- **✨ L2 payload の `hubMemberCount` / `tenureDistribution` を活用** (medium)
  schema 側で `AnalyticsCommunityPayload` (L2) に追加された両フィールドを `GET_ANALYTICS_COMMUNITY` query で select し、`admin/analytics/page.tsx` 経由で `CommunityDetailPageClient` に受け渡し。Owner ロールでも L1 dashboard (sysAdmin 限定) を叩かずに「ハブユーザー比率」「在籍率」KPI を表示可能に。

- 古いコメント (「未提供のまま」「L1 dashboard 経由で取得」) を新しい挙動に合わせて更新。
- `CommunityDetailPageClient` の Props docstring も sysAdmin / community admin の両 route から渡される前提に書き換え。

### 関連
- リリース対象 PR: #1228
- 元機能 PR: #1220

## Test plan

- [ ] community admin (Owner ロール) で `/community/[id]/admin/analytics` から各レポートをクリックして詳細へ遷移できる
- [ ] ハブユーザー比率 / 在籍率の KPI が Owner ロールでも表示される
- [ ] sysAdmin route の挙動は従来どおり (regression なし)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PunWn3nSKtWTaHg8hpT5tN)_