### PR TITLE
fix(sysAdmin/create): prefer current community session for X-Community-Id

### DIFF
--- a/src/app/sysAdmin/create/features/editor/actions/communityCreate.ts
+++ b/src/app/sysAdmin/create/features/editor/actions/communityCreate.ts
@@ -57,12 +57,22 @@ export async function createCommunityAction(
   // X-Community-Id として明示的に渡す。
   // auto-resolve に任せると middleware が cookie の stale な communityId（削除済み等）を
   // ヘッダーにセットしてしまい、バックエンドの Firebase テナント検索が失敗するため。
+  //
+  // 現在の navigation context (x-community-id cookie) に対応するセッションがあれば
+  // それを優先することで、ヘッダーと cookie の不一致による TENANT_MISMATCH 警告を回避し、
+  // 選ばれるテナントを cookie 反復順ではなくユーザーが今いるコミュニティに揃える。
   const cookieStore = await cookies();
-  const authCommunityId = cookieStore
-    .getAll()
-    .filter((c) => c.name.startsWith("__session_"))
-    .map((c) => c.name.replace("__session_", ""))
-    .find((id) => (ACTIVE_COMMUNITY_IDS as readonly string[]).includes(id)) ?? "";
+  const currentCommunityId = cookieStore.get("x-community-id")?.value;
+  const hasCurrentSession =
+    !!currentCommunityId && !!cookieStore.get(`__session_${currentCommunityId}`);
+
+  const authCommunityId = hasCurrentSession
+    ? currentCommunityId!
+    : cookieStore
+        .getAll()
+        .filter((c) => c.name.startsWith("__session_"))
+        .map((c) => c.name.replace("__session_", ""))
+        .find((id) => (ACTIVE_COMMUNITY_IDS as readonly string[]).includes(id)) ?? "";
 
   if (!authCommunityId) {
     return { error: "有効なセッションが見つかりません。いずれかのコミュニティにログインしてから再試行してください" };


### PR DESCRIPTION
## Summary

`/sysAdmin/create` を叩くと以下の警告が出続けていた問題の修正。

```
TENANT_MISMATCH: Header and cookie community IDs differ
headerCommunityId: "dais"
cookieCommunityId: "neo88"
```

## 原因

`communityCreate.ts` の `authCommunityId` 選定が `__session_*` cookie の **挿入順** で先頭の有効ID を拾っていたため、ユーザーが今いるコミュニティとは無関係なテナントが選ばれていた。複数コミュニティのセッション cookie を持つユーザー（dais と neo88 両方ログイン履歴あり）で発生。

- middleware が設定する `x-community-id` cookie: `neo88`（今いるコミュニティ）
- `communityCreate.ts` が選ぶ `X-Community-Id` ヘッダー: `dais`（cookie反復順で先頭）
- → `executeServerGraphQLQuery` (`src/lib/graphql/server.ts:144`) のミスマッチ検出で WARNING

## 修正内容

`x-community-id` cookie の値に対応する `__session_{currentCommunityId}` が存在すれば、それを優先採用するように変更。なければ従来通り `__session_*` 先頭フォールバック。

これにより:
- 「neo88 に居る状態で create を叩く」と必ず neo88 テナントが使われる
- ヘッダーと cookie が揃って TENANT_MISMATCH 警告が消える
- SYS_ADMIN 機能自体は元々全テナントで有効なので、フォールバックパスを残しても問題なし

## Test plan

- [ ] 単一コミュニティのみログイン状態で `/sysAdmin/create` 実行 → 従来通り動作
- [ ] 複数コミュニティのセッション cookie がある状態（dais + neo88 両方）で neo88 に居て `/sysAdmin/create` 実行 → neo88 が `X-Community-Id` として送られる
- [ ] Cloud Logging に `TENANT_MISMATCH: Header and cookie community IDs differ` が出ないことを確認
- [ ] 現在のコミュニティの session cookie が無い場合（cookie失効後など）のフォールバック動作確認

https://claude.ai/code/session_01Xry7cyHDeohdqSSZsGAsNq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xry7cyHDeohdqSSZsGAsNq)_