### PR TITLE
fix(middleware): exclude /.well-known/* from community routing

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,6 +17,7 @@ const EXCLUDED_REDIRECT_PATTERNS = [
   "/communities", // コミュニティアセット
   "/icons",     // アイコン
   "/sysAdmin",  // SYS_ADMIN 専用ルート（コミュニティ作成など）
+  "/.well-known", // /.well-known/* (security.txt 等)
 ];
 
 const COMMUNITY_ID_COOKIE_OPTIONS = {
@@ -372,5 +373,5 @@ function getCommunityIdFromHost(host: string | null): string | null {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|robots.txt|images/|icons/|communities/|api/).*)"],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|robots.txt|images/|icons/|communities/|api/|\\.well-known/).*)"],
 };


### PR DESCRIPTION
## Summary
- `/.well-known/*` (e.g. `security.txt`) was being routed through the community middleware and returning `Community not found` because it was not in the matcher exclusion list nor in `EXCLUDED_REDIRECT_PATTERNS`.
- Adds `\.well-known/` to the matcher negative-lookahead so the middleware no longer runs for these paths.
- Also adds `/.well-known` to `EXCLUDED_REDIRECT_PATTERNS` as a defense-in-depth measure (in case any future matcher change re-enables traversal).

## Test plan
- [ ] Hit `/.well-known/security.txt` on a deployed environment and confirm it returns the file (or 404 from Next, not "Community not found" from middleware).
- [ ] Verify normal community routing (`/community/{id}/...`, subdomain → path redirect) still works.
- [ ] Verify `/sysAdmin` and other previously excluded paths continue to behave correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_0125b4hLbCdDp4uq9we4155S)_