### PR TITLE
chore: back-merge master into develop (#1239 hotfix)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,6 +17,7 @@ const EXCLUDED_REDIRECT_PATTERNS = [
   "/communities", // コミュニティアセット
   "/icons",     // アイコン
   "/sysAdmin",  // SYS_ADMIN 専用ルート（コミュニティ作成など）
+  "/.well-known", // /.well-known/* (security.txt 等)
 ];
 
 const COMMUNITY_ID_COOKIE_OPTIONS = {
@@ -372,5 +373,5 @@ function getCommunityIdFromHost(host: string | null): string | null {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|robots.txt|images/|icons/|communities/|api/).*)"],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|robots.txt|images/|icons/|communities/|api/|\\.well-known/).*)"],
 };


### PR DESCRIPTION
## Summary
- master が develop より進んでいた状態を解消するための back-merge です。
- PR #1239 (`fix(middleware): exclude /.well-known/* from community routing`) を誤って develop ではなく master にマージしたため、master → develop の back-merge で同期します。
- コンフリクトなし、`src/middleware.ts` の hotfix 1 ファイルのみが develop に取り込まれます。

## Test plan
- [ ] diff が `src/middleware.ts` の `/.well-known` 除外追加のみであることを確認
- [ ] マージ後 `origin/develop` と `origin/master` の差分がゼロになることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_0125b4hLbCdDp4uq9we4155S)_