### PR TITLE
fix(admin/analytics): raise SSR timeout for heavy analyticsCommunity query

### DIFF
--- a/src/app/sysAdmin/_shared/server/fetchSysAdminCommunityDetail.ts
+++ b/src/app/sysAdmin/_shared/server/fetchSysAdminCommunityDetail.ts
@@ -13,6 +13,13 @@ type Result = NonNullable<
   GqlGetAnalyticsCommunityQuery["analyticsCommunity"]
 >;
 
+// analyticsCommunity は 12 ヶ月トレンド + 週次リテンション + コホート 2 種 +
+// 最大 1000 件のメンバー集計を含む重いクエリで、executeServerGraphQLQuery の
+// デフォルト 5 秒では SSR がタイムアウトしやすい。タイムアウトすると initialData が
+// null になり、クライアント側フォールバッククエリ（cross-origin で認証が乗らず失敗する）
+// に落ちるため、この SSR フェッチだけ長めのタイムアウトを取る。
+const ANALYTICS_COMMUNITY_SERVER_TIMEOUT_MS = 20000;
+
 /**
  * `/sysAdmin/[communityId]` の初期描画データを SSR で取得する。
  * SYS_ADMIN ロールがない / コミュニティが存在しない場合は null を返し、
@@ -29,7 +36,12 @@ export async function fetchSysAdminCommunityDetailServer(
     const data = await executeServerGraphQLQuery<
       GqlGetAnalyticsCommunityQuery,
       { input: GqlAnalyticsCommunityInput }
-    >(GET_ANALYTICS_COMMUNITY_SERVER_QUERY, { input });
+    >(
+      GET_ANALYTICS_COMMUNITY_SERVER_QUERY,
+      { input },
+      {},
+      ANALYTICS_COMMUNITY_SERVER_TIMEOUT_MS,
+    );
     return data.analyticsCommunity ?? null;
   } catch (error) {
     logger.warn("[sysAdmin] fetchSysAdminCommunityDetailServer failed", {


### PR DESCRIPTION
## 概要

`/community/[communityId]/admin/analytics` だけが `"User must be community owner / admin"`（FORBIDDEN）や 500 で落ちる問題の修正です。

### 原因

- `analyticsCommunity` は 12ヶ月トレンド + 週次リテンション + コホート2種 + 最大1000件のメンバー集計を含む**重いクエリ**。
- SSR フェッチ `fetchSysAdminCommunityDetailServer` は `executeServerGraphQLQuery` の**デフォルト 5 秒タイムアウト**で叩いていた。
- `currentUser` / membership など他の SSR クエリは軽く 5 秒以内に成功するため、`/admin` 配下の他ページは正常（＝認証自体は正常）。
- `analyticsCommunity` だけが 5 秒を超えて SSR がタイムアウト → `fetchSysAdminCommunityDetailServer` が `null` を返す → `useCommunityDetail` がキャッシュを seed できず、クライアント側フォールバッククエリを発射 → そのリクエストは cross-origin で認証が乗らず未認証扱い → バックエンドが `FORBIDDEN` / 500。
- 結果として **`admin/analytics` だけ**で症状が出ていた。

### 修正

`analyticsCommunity` の SSR フェッチだけタイムアウトを 20 秒に延長。SSR が確実に成功すれば `initialData` が入り、`cache-first` がキャッシュを読むだけになり、壊れているクライアント側フォールバック経路に落ちなくなる。

## テスト計画

- [ ] `/community/{communityId}/admin/analytics`（コミュニティ Owner）でダッシュボードが表示される
- [ ] サーバーログに `GraphQL request timeout after 5000ms`（analyticsCommunity）が出なくなる
- [ ] `/sysAdmin/{communityId}` の analytics 詳細が従来どおり表示される（同じフェッチ関数を共有）
- [ ] ネットワークタブで `GetAnalyticsCommunity` のクライアント側リクエストが発生しない（SSR キャッシュ命中）

https://claude.ai/code/session_01EEvf5cxHxucAR7QvmHuSfA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEvf5cxHxucAR7QvmHuSfA)_