### PR TITLE
develop → master: analytics SSR timeout fix

### DIFF
--- a/src/app/sysAdmin/_shared/server/fetchSysAdminCommunityDetail.ts
+++ b/src/app/sysAdmin/_shared/server/fetchSysAdminCommunityDetail.ts
@@ -13,6 +13,13 @@ type Result = NonNullable<
   GqlGetAnalyticsCommunityQuery["analyticsCommunity"]
 >;
 
+// analyticsCommunity は 12 ヶ月トレンド + 週次リテンション + コホート 2 種 +
+// 最大 1000 件のメンバー集計を含む重いクエリで、executeServerGraphQLQuery の
+// デフォルト 5 秒では SSR がタイムアウトしやすい。タイムアウトすると initialData が
+// null になり、クライアント側フォールバッククエリ（cross-origin で認証が乗らず失敗する）
+// に落ちるため、この SSR フェッチだけ長めのタイムアウトを取る。
+const ANALYTICS_COMMUNITY_SERVER_TIMEOUT_MS = 20000;
+
 /**
  * `/sysAdmin/[communityId]` の初期描画データを SSR で取得する。
  * SYS_ADMIN ロールがない / コミュニティが存在しない場合は null を返し、
@@ -29,7 +36,12 @@ export async function fetchSysAdminCommunityDetailServer(
     const data = await executeServerGraphQLQuery<
       GqlGetAnalyticsCommunityQuery,
       { input: GqlAnalyticsCommunityInput }
-    >(GET_ANALYTICS_COMMUNITY_SERVER_QUERY, { input });
+    >(
+      GET_ANALYTICS_COMMUNITY_SERVER_QUERY,
+      { input },
+      {},
+      ANALYTICS_COMMUNITY_SERVER_TIMEOUT_MS,
+    );
     return data.analyticsCommunity ?? null;
   } catch (error) {
     logger.warn("[sysAdmin] fetchSysAdminCommunityDetailServer failed", {


### PR DESCRIPTION
## 概要

`develop` を `master` に反映するための PR です。

`develop` と `master` の差分は **アナリティクス SSR タイムアウト修正の1ファイルのみ**です。

## 含まれる変更

- **fix(admin/analytics): raise SSR timeout for heavy analyticsCommunity query** (#1241)
  - `fetchSysAdminCommunityDetail.ts` の `analyticsCommunity` SSR フェッチのタイムアウトを 5 秒 → 20 秒に延長。
  - 重い `analyticsCommunity` クエリがデフォルト 5 秒でタイムアウトし、`initialData` が null になって認証の乗らないクライアント側フォールバックに落ちる → `/community/[communityId]/admin/analytics` だけが FORBIDDEN/500 になる問題の修正。

## 変更ファイル

- `src/app/sysAdmin/_shared/server/fetchSysAdminCommunityDetail.ts`（+13 -1）

## テスト計画

- [ ] `/community/{communityId}/admin/analytics`（コミュニティ Owner）でダッシュボードが表示される
- [ ] サーバーログに `GraphQL request timeout after 5000ms`（analyticsCommunity）が出ない

https://claude.ai/code/session_01EEvf5cxHxucAR7QvmHuSfA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEvf5cxHxucAR7QvmHuSfA)_