### PR TITLE
feat(votes): 管理画面トップに投票管理カードを追加

### DIFF
--- a/src/app/community/[communityId]/admin/page.tsx
+++ b/src/app/community/[communityId]/admin/page.tsx
@@ -15,6 +15,7 @@ import {
   MegaphoneIcon,
   Ticket,
   Users,
+  Vote,
   Wallet,
 } from "lucide-react";
 import { useCommunityConfig } from "@/contexts/CommunityConfigContext";
@@ -85,6 +86,12 @@ const operatorSettings = [
     href: "/admin/tickets",
     icon: Ticket,
     requiredFeature: "tickets" as FeaturesType,
+  },
+  {
+    title: "投票管理",
+    href: "/admin/votes",
+    icon: Vote,
+    requiredFeature: "votes" as FeaturesType,
   },
 ];
 


### PR DESCRIPTION
## 概要

管理画面トップ（`/admin`）の運用担当者セクションに投票管理カードが無く、`/admin/votes` へメニューから辿り着けなかった。本PRで、`enableFeatures` に `"votes"` を含むコミュニティに対してのみ、投票管理カードを表示する。

（先行PR #1248 でユーザー向け `BottomBar` と `AdminBottomBar` への導線は追加済み。本PRはその補完。）

## 変更内容

- `src/app/community/[communityId]/admin/page.tsx`
  - `operatorSettings` に投票管理（`/admin/votes`、`requiredFeature: "votes"`）のカードを追加
  - lucide-react の `Vote` アイコンを import

## 影響範囲

- 他の管理カードと同じく `requiredFeature` による条件表示のため、`enableFeatures` に `"votes"` を有効化していないコミュニティには一切影響しない
- 運用担当者セクションのため、表示対象は Owner / Manager ロール
- `enableFeatures` は非LOCAL環境ではDBから取得されるため、実際にカードを表示するには対象コミュニティの `enableFeatures` に `"votes"` を追加する必要がある（バックエンド/DB側の設定）

## 動作確認

- [ ] `votes` を有効化したコミュニティの `/admin` に投票管理カードが表示されること
- [ ] カードから `/admin/votes` に遷移できること
- [ ] `votes` を有効化していないコミュニティでカードが表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVNztAuGPSL2hDZHHdzGbU)_