### PR TITLE
test(votes): schemaテストの現在時刻を固定してフレーク回避

### DIFF
--- a/src/app/community/[communityId]/admin/votes/features/editor/validation/__tests__/schema.test.ts
+++ b/src/app/community/[communityId]/admin/votes/features/editor/validation/__tests__/schema.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import dayjs from "dayjs";
 import { GqlRole, GqlVoteGateType, GqlVotePowerPolicyType } from "@/types/graphql";
 import { createVoteTopicSchema } from "../schema";
@@ -9,6 +9,17 @@ const t = (key: string) => key;
 const schema = createVoteTopicSchema(t);
 
 const fmt = (d: ReturnType<typeof dayjs>) => d.format("YYYY-MM-DDTHH:mm");
+
+// startsInPast の判定はスキーマ内部の dayjs()（現在時刻）に依存するため、
+// 分の境界でフレークしないよう現在時刻を固定する。
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-07-10T14:30:00"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 const baseValues = (overrides: Partial<VoteTopicFormValues> = {}): VoteTopicFormValues => ({
   title: "テスト投票",


### PR DESCRIPTION
## 概要

リリースPR #1251 に対する Copilot レビュー指摘の対応です。`schema.test.ts` の「開始日時が現在の分ちょうどは許可される」テストが、テスト側の `dayjs()` とスキーマ内部の `dayjs()` の間で分をまたぐとフレークしうるため、現在時刻を固定します。

## 変更内容

- `schema.test.ts` に `vi.useFakeTimers()` + `vi.setSystemTime("2026-07-10T14:30:00")` を `beforeEach` で設定、`afterEach` で `vi.useRealTimers()`。
- これにより `startsInPast` 判定が決定的になり、境界タイミングでのフレークを排除。

※ `dateTimeUtils.test.ts` は `now` を明示注入しているため元々決定的で、変更不要。

## 確認
- 対象テスト 6件 pass
- eslint クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVNztAuGPSL2hDZHHdzGbU)_