### PR TITLE
fix(votes): 作成確認ダイアログを閉じたら保留値もクリア

### DIFF
--- a/src/app/community/[communityId]/admin/votes/features/editor/components/VoteTopicFormEditor.tsx
+++ b/src/app/community/[communityId]/admin/votes/features/editor/components/VoteTopicFormEditor.tsx
@@ -79,7 +79,10 @@ export function VoteTopicFormEditor({
       <ConfirmDialog
         open={confirmOpen}
         onOpenChange={(open) => {
-          if (!saving) setConfirmOpen(open);
+          if (saving) return;
+          setConfirmOpen(open);
+          // 閉じるときは保留中の入力値も破棄する（古い値での保存を防ぐ）
+          if (!open) setPendingValues(null);
         }}
         title={t("adminVotes.list.createButton")}
         description={t("adminVotes.form.createConfirm")}


### PR DESCRIPTION
## 概要

リリースPR #1251 に対する Copilot レビュー指摘の対応です。投票作成の確認ダイアログをキャンセル／外側クリックで閉じた際、`pendingValues` が残っていました。現状は再送信時に上書きされるため実害はありませんが、将来ダイアログの再オープン経路が増えた場合に古い値で保存されるリスクを避けるため、閉じるタイミングでクリアします。

## 変更内容

- `VoteTopicFormEditor.tsx` の作成確認 `ConfirmDialog` の `onOpenChange` で、閉じる（`open === false`）ときに `setPendingValues(null)` を実行。

## 確認
- eslint クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVNztAuGPSL2hDZHHdzGbU)_