### PR TITLE
fix(votes): 作成保存が失敗したら確認ダイアログを閉じない

### DIFF
--- a/src/app/community/[communityId]/admin/votes/features/editor/components/VoteTopicFormEditor.tsx
+++ b/src/app/community/[communityId]/admin/votes/features/editor/components/VoteTopicFormEditor.tsx
@@ -63,7 +63,9 @@ export function VoteTopicFormEditor({
   });
 
   const handleConfirm = async () => {
-    if (!pendingValues) return;
+    // saving 中の連打によるダブルサブミットを防ぐ（ボタンの disabled が
+    // 反映される前の隙間対策）。
+    if (!pendingValues || saving) return;
     // 保存が成功したときのみ閉じる。失敗時はダイアログを開いたままにして
     // 再試行/キャンセルできるようにする（削除フローと挙動を揃える）。
     const ok = await runSave(pendingValues);

--- a/src/app/community/[communityId]/admin/votes/features/editor/components/VoteTopicFormEditor.tsx
+++ b/src/app/community/[communityId]/admin/votes/features/editor/components/VoteTopicFormEditor.tsx
@@ -46,9 +46,11 @@ export function VoteTopicFormEditor({
   );
   useHeaderConfig(headerConfig);
 
-  const runSave = async (values: VoteTopicFormValues) => {
+  const runSave = async (values: VoteTopicFormValues): Promise<boolean> => {
     const id = await save(values);
-    if (id) onSuccess?.(id);
+    if (!id) return false;
+    onSuccess?.(id);
+    return true;
   };
 
   const handleSubmit = form.handleSubmit(async (values) => {
@@ -62,9 +64,13 @@ export function VoteTopicFormEditor({
 
   const handleConfirm = async () => {
     if (!pendingValues) return;
-    await runSave(pendingValues);
-    setConfirmOpen(false);
-    setPendingValues(null);
+    // 保存が成功したときのみ閉じる。失敗時はダイアログを開いたままにして
+    // 再試行/キャンセルできるようにする（削除フローと挙動を揃える）。
+    const ok = await runSave(pendingValues);
+    if (ok) {
+      setConfirmOpen(false);
+      setPendingValues(null);
+    }
   };
 
   return (


### PR DESCRIPTION
## 概要

リリースPR #1251 に対する Copilot レビュー指摘の対応です。投票作成の確認ダイアログで「作成」を押して保存が失敗（`save` が null 返却）した場合でも、ダイアログを閉じて `pendingValues` を破棄していました。失敗時はダイアログを開いたままにして再試行/キャンセルできるよう、**成功時のみ閉じる＋クリア**に変更します（削除フローと挙動を統一）。

## 変更内容

- `VoteTopicFormEditor.tsx`
  - `runSave` が成功可否（boolean）を返すように変更
  - `handleConfirm` は `runSave` が成功したときのみ `setConfirmOpen(false)` + `setPendingValues(null)` を実行

## 確認
- eslint クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVNztAuGPSL2hDZHHdzGbU)_