### PR TITLE
fix(wallets): コミュニティ送付の誤バリデーション修正 & 選択リストへ統合表示

### DIFF
--- a/src/app/community/[communityId]/admin/wallet/grant/components/HistoryTab.tsx
+++ b/src/app/community/[communityId]/admin/wallet/grant/components/HistoryTab.tsx
@@ -13,9 +13,11 @@ interface HistoryTabProps {
   listType: "donate" | "grant";
   searchQuery: string;
   onSelect: (user: GqlUser) => void;
+  /** リスト最上部に固定表示する行 (例: コミュニティ財布宛)。同一 Table 内に描画して列幅を揃える */
+  prependRow?: React.ReactNode;
 }
 
-export function HistoryTab({ listType, searchQuery, onSelect }: HistoryTabProps) {
+export function HistoryTab({ listType, searchQuery, onSelect, prependRow }: HistoryTabProps) {
   const t = useTranslations();
   const { user } = useAuth();
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
@@ -42,6 +44,11 @@ export function HistoryTab({ listType, searchQuery, onSelect }: HistoryTabProps)
   if (!loading && presentedTransactions.length === 0) {
     return (
       <div className="space-y-3 px-4">
+        {prependRow && (
+          <Table className={"max-w-xl"}>
+            <TableBody>{prependRow}</TableBody>
+          </Table>
+        )}
         <p className="text-sm text-center text-muted-foreground pt-4">
           {listType === "grant"
             ? t("wallets.shared.history.noGrant")
@@ -51,7 +58,18 @@ export function HistoryTab({ listType, searchQuery, onSelect }: HistoryTabProps)
     );
   }
 
-  if (loading) return <Loading />;
+  if (loading) {
+    return (
+      <div className="px-4">
+        {prependRow && (
+          <Table className={"max-w-xl"}>
+            <TableBody>{prependRow}</TableBody>
+          </Table>
+        )}
+        <Loading />
+      </div>
+    );
+  }
 
   const handleSelect = (user: GqlUser) => {
     // すでに選択されているユーザーをクリックした場合は選択解除
@@ -68,6 +86,7 @@ export function HistoryTab({ listType, searchQuery, onSelect }: HistoryTabProps)
     <div className="px-4">
       <Table className={"max-w-xl"}>
         <TableBody>
+          {prependRow}
           {presentedTransactions.map((tx, index) => {
             if (!tx.otherUser) return null;
 

--- a/src/app/community/[communityId]/admin/wallet/grant/components/MemberTab.tsx
+++ b/src/app/community/[communityId]/admin/wallet/grant/components/MemberTab.tsx
@@ -14,9 +14,17 @@ interface MemberTabProps {
   searchQuery: string;
   onSelect: (user: GqlUser) => void;
   initialConnection?: GqlMembershipsConnection | null;
+  /** リスト最上部に固定表示する行 (例: コミュニティ財布宛)。同一 Table 内に描画して列幅を揃える */
+  prependRow?: React.ReactNode;
 }
 
-export function MemberTab({ members, searchQuery, onSelect, initialConnection }: MemberTabProps) {
+export function MemberTab({
+  members,
+  searchQuery,
+  onSelect,
+  initialConnection,
+  prependRow,
+}: MemberTabProps) {
   const t = useTranslations();
   const communityConfig = useCommunityConfig();
   const communityId = communityConfig?.communityId ?? "";
@@ -47,6 +55,11 @@ export function MemberTab({ members, searchQuery, onSelect, initialConnection }:
   if (searchMembershipData.length === 0) {
     return (
       <div className="space-y-3 px-4">
+        {prependRow && (
+          <Table className={"max-w-xl"}>
+            <TableBody>{prependRow}</TableBody>
+          </Table>
+        )}
         <p className="text-sm text-center text-muted-foreground pt-4">
           {t("wallets.shared.member.noMatch")}
         </p>
@@ -69,6 +82,7 @@ export function MemberTab({ members, searchQuery, onSelect, initialConnection }:
     <div className="px-4">
       <Table className={"max-w-xl"}>
         <TableBody>
+          {prependRow}
           {searchMembershipData?.map((m) => (
             <UserPointRow
               key={m.id}

--- a/src/app/community/[communityId]/admin/wallet/grant/components/UserSelectStep.tsx
+++ b/src/app/community/[communityId]/admin/wallet/grant/components/UserSelectStep.tsx
@@ -18,6 +18,8 @@ interface Props {
   setActiveTab: React.Dispatch<React.SetStateAction<TabsEnum>>;
   listType: "donate" | "grant";
   initialConnection?: GqlMembershipsConnection | null;
+  /** リスト最上部に固定表示する行 (例: コミュニティ財布宛)。各タブの Table 内に描画して列幅を揃える */
+  prependRow?: React.ReactNode;
 }
 
 function UserSelectStep({
@@ -28,6 +30,7 @@ function UserSelectStep({
   setActiveTab,
   listType,
   initialConnection,
+  prependRow,
 }: Props) {
   const t = useTranslations();
   const [searchQuery, setSearchQuery] = useState("");
@@ -49,7 +52,12 @@ function UserSelectStep({
       <TabManager activeTab={activeTab} setActiveTab={setActiveTab} />
 
       {activeTab === TabsEnum.History && (
-        <HistoryTab listType={listType} searchQuery={searchQuery} onSelect={onSelect} />
+        <HistoryTab
+          listType={listType}
+          searchQuery={searchQuery}
+          onSelect={onSelect}
+          prependRow={prependRow}
+        />
       )}
 
       {activeTab === TabsEnum.Member && (
@@ -58,6 +66,7 @@ function UserSelectStep({
           searchQuery={searchQuery}
           onSelect={onSelect}
           initialConnection={initialConnection}
+          prependRow={prependRow}
         />
       )}
     </>

--- a/src/app/community/[communityId]/admin/wallet/hooks/useTransactionMutations.ts
+++ b/src/app/community/[communityId]/admin/wallet/hooks/useTransactionMutations.ts
@@ -121,7 +121,8 @@ export const useTransactionMutations = () => {
     const authError = checkAuth();
     if (authError) return authError;
 
-    if (!variables.input?.toUserId || !variables.input?.transferPoints) {
+    // toUserId は任意 (省略時はコミュニティ財布への送付=CONTRIBUTION)。transferPoints のみ必須。
+    if (!variables.input?.transferPoints) {
       return { success: false, code: GqlErrorCode.ValidationError };
     }
 

--- a/src/app/community/[communityId]/wallets/donate/DonatePointPageClient.tsx
+++ b/src/app/community/[communityId]/wallets/donate/DonatePointPageClient.tsx
@@ -11,7 +11,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import LoadingIndicator from "@/components/shared/LoadingIndicator";
 import { ErrorState } from "@/components/shared";
 import { UserPointRow } from "@/components/shared/UserPointRow";
-import { Table, TableBody } from "@/components/ui/table";
 import { useTranslations } from "next-intl";
 import {
   GqlMembershipsConnection,
@@ -122,29 +121,25 @@ export default function DonatePointPageClient({ initialCurrentPoint }: DonatePoi
   return (
     <div className="max-w-xl mx-auto mt-6 space-y-4">
       {!selectedUser ? (
-        <>
-          {/* コミュニティ財布への送付 (CONTRIBUTION) をメンバー一覧の最上部に固定表示。
-              communityId 未ロード時は空 ID 送金を防ぐため表示しない */}
-          {communityId && (
-            <Table className="max-w-xl">
-              <TableBody>
-                <UserPointRow
-                  avatar={communityAsUser.image ?? ""}
-                  name={communityAsUser.name}
-                  subText={t("wallets.donate.communityWallet")}
-                  onClick={() => selectCommunity(communityAsUser)}
-                />
-              </TableBody>
-            </Table>
-          )}
-          <DonateUserSelect
-            members={members}
-            onSelect={setSelectedUser}
-            activeTab={activeTab}
-            setActiveTab={setActiveTab}
-            initialConnection={initialConnection}
-          />
-        </>
+        <DonateUserSelect
+          members={members}
+          onSelect={setSelectedUser}
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+          initialConnection={initialConnection}
+          // コミュニティ財布への送付 (CONTRIBUTION) をメンバー/履歴一覧の最上部に同一 Table で固定表示。
+          // communityId 未ロード時は空 ID 送金を防ぐため表示しない
+          prependRow={
+            communityId ? (
+              <UserPointRow
+                avatar={communityAsUser.image ?? ""}
+                name={communityAsUser.name}
+                subText={t("wallets.donate.communityWallet")}
+                onClick={() => selectCommunity(communityAsUser)}
+              />
+            ) : undefined
+          }
+        />
       ) : (
         <TransferInputStep
           user={selectedUser}

--- a/src/app/community/[communityId]/wallets/features/donate/components/DonateUserSelect.tsx
+++ b/src/app/community/[communityId]/wallets/features/donate/components/DonateUserSelect.tsx
@@ -13,6 +13,8 @@ interface Props {
   activeTab: Tabs;
   setActiveTab: React.Dispatch<React.SetStateAction<Tabs>>;
   initialConnection?: GqlMembershipsConnection | null;
+  /** リスト最上部に固定表示する行 (例: コミュニティ財布宛) */
+  prependRow?: React.ReactNode;
 }
 
 export function DonateUserSelect({
@@ -21,6 +23,7 @@ export function DonateUserSelect({
   activeTab,
   setActiveTab,
   initialConnection,
+  prependRow,
 }: Props) {
   const t = useTranslations();
   return (
@@ -32,6 +35,7 @@ export function DonateUserSelect({
       setActiveTab={setActiveTab}
       listType="donate"
       initialConnection={initialConnection}
+      prependRow={prependRow}
     />
   );
 }


### PR DESCRIPTION
#1256（コミュニティ財布への CONTRIBUTION 送付）のフォローアップ。実機（dev）で見つかった不具合修正と UI 改善。

## 🐛 修正: コミュニティ送付が「入力内容に誤りがあります」で失敗する

`useTransactionMutations.donatePoint` の必須バリデーションに `toUserId` が残っており、コミュニティ財布への送付（`toUserId` を省略）が `ValidationError` で弾かれていた。

```diff
- if (!variables.input?.toUserId || !variables.input?.transferPoints) {
+ // toUserId は任意 (省略時はコミュニティ財布への送付=CONTRIBUTION)。transferPoints のみ必須。
+ if (!variables.input?.transferPoints) {
    return { success: false, code: GqlErrorCode.ValidationError };
  }
```

（`grantPoint` は従来どおり `toUserId` 必須のまま。）

## 💅 改善: コミュニティ財布行を選択リストへ統合（列幅を揃える）

これまではコミュニティ財布行を独立した `<Table>` で表示していたため、メンバー/履歴一覧と**列幅（アバター・名前・右側）がズレて**いた（Gemini レビュー指摘 & 実機で確認）。

- `prependRow` prop を `DonateUserSelect → UserSelectStep → MemberTab / HistoryTab` に通し、**各タブの一覧と同一 `<Table>` の先頭行**として描画。列幅が完全一致する。
- **履歴タブにもコミュニティ財布行を最上部に表示**（空・ローディング時も表示）。
- `prependRow` は grant フローには渡さないため、**grant 側の挙動は不変**（後方互換）。

## 確認
- 新規 TypeScript エラー 0 件（合計 108 は develop 由来で無関係）
- 変更ファイルに新規 lint エラーなし / 既存ユニットテスト green
- ⚠️ 送金フローの実機確認は dev デプロイ後にお願いします（backend/認証が必要なためローカル自動検証は不可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DrCG22MmVSXoLQLDeP2bk

---
_Generated by [Claude Code](https://claude.ai/code/session_018DrCG22MmVSXoLQLDeP2bk)_