### PR TITLE
refactor(wallets): useDonateFlow のコールバック参照を安定化

### DIFF
--- a/src/app/community/[communityId]/wallets/features/donate/hooks/useDonateFlow.ts
+++ b/src/app/community/[communityId]/wallets/features/donate/hooks/useDonateFlow.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useAppRouter } from "@/lib/navigation";
 import { useAnalytics } from "@/hooks/analytics/useAnalytics";
 import { useDonatePoint } from "@/app/community/[communityId]/wallets/features/donate/hooks/index";
@@ -19,17 +19,18 @@ export function useDonateFlow(currentUser?: GqlUser | null, currentPoint?: bigin
   const [isCommunityRecipient, setIsCommunityRecipient] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // 通常のメンバー選択。コミュニティ送付フラグは解除する
-  const setSelectedUser = (user: GqlUser | null) => {
+  // 通常のメンバー選択。コミュニティ送付フラグは解除する。
+  // 参照を安定させ、呼び出し元の useEffect 依存に入っても不要な再実行を防ぐ
+  const setSelectedUser = useCallback((user: GqlUser | null) => {
     setIsCommunityRecipient(false);
     setSelectedUserState(user);
-  };
+  }, []);
 
   // コミュニティ財布への送付を選択。表示用に疑似ユーザー (コミュニティ名/ロゴ) を保持する
-  const selectCommunity = (community: GqlUser) => {
+  const selectCommunity = useCallback((community: GqlUser) => {
     setIsCommunityRecipient(true);
     setSelectedUserState(community);
-  };
+  }, []);
 
   const handleDonate = async (amount: number, comment?: string, images?: File[]) => {
     if (!selectedUser || !currentUser?.id) return;


### PR DESCRIPTION
#1256 / #1258 のフォローアップ。#1257 上の Copilot レビュー指摘対応。

## 内容

`useDonateFlow` の `setSelectedUser` / `selectCommunity` を毎レンダー新規生成していたため、呼び出し元 `DonatePointPageClient` の `useEffect` 依存配列に `setSelectedUser` が入っており、**毎レンダーで effect が不要に再実行**されていた（ガードで実害は抑えられていたが参照が不安定）。

- 両コールバックを `useCallback`（空依存）でメモ化し参照を安定化
- 依存の `setSelectedUserState` / `setIsCommunityRecipient` は `useState` セッターで安定のため空依存で正しい

## 確認
- 新規 TypeScript エラー 0 件（合計 108 は develop 由来で無関係）
- 挙動は不変（参照安定化のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DrCG22MmVSXoLQLDeP2bk

---
_Generated by [Claude Code](https://claude.ai/code/session_018DrCG22MmVSXoLQLDeP2bk)_