### PR TITLE
feat(wallets): コミュニティ財布の残高表示 & 送付履歴を履歴タブに表示

### DIFF
--- a/src/app/community/[communityId]/admin/wallet/grant/components/HistoryTab.tsx
+++ b/src/app/community/[communityId]/admin/wallet/grant/components/HistoryTab.tsx
@@ -15,9 +15,17 @@ interface HistoryTabProps {
   onSelect: (user: GqlUser) => void;
   /** リスト最上部に固定表示する行 (例: コミュニティ財布宛)。同一 Table 内に描画して列幅を揃える */
   prependRow?: React.ReactNode;
+  /** 履歴内のコミュニティ財布宛 (CONTRIBUTION) 行をクリックしたときの選択ハンドラ */
+  onSelectCommunity?: () => void;
 }
 
-export function HistoryTab({ listType, searchQuery, onSelect, prependRow }: HistoryTabProps) {
+export function HistoryTab({
+  listType,
+  searchQuery,
+  onSelect,
+  prependRow,
+  onSelectCommunity,
+}: HistoryTabProps) {
   const t = useTranslations();
   const { user } = useAuth();
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
@@ -88,6 +96,22 @@ export function HistoryTab({ listType, searchQuery, onSelect, prependRow }: Hist
         <TableBody>
           {prependRow}
           {presentedTransactions.map((tx, index) => {
+            // コミュニティ財布宛 (CONTRIBUTION) の履歴行。相手はユーザーではないので専用に描画
+            if (tx.isCommunity) {
+              return (
+                <UserPointRow
+                  key={`community-${index}`}
+                  avatar={tx.otherImage || ""}
+                  name={tx.otherName}
+                  subText={
+                    tx.createdAt ? new Date(tx.createdAt.toString()).toLocaleDateString() : ""
+                  }
+                  pointValue={Number(tx.point || 0)}
+                  onClick={() => onSelectCommunity?.()}
+                />
+              );
+            }
+
             if (!tx.otherUser) return null;
 
             const subText = tx.createdAt

--- a/src/app/community/[communityId]/admin/wallet/grant/components/HistoryTab.tsx
+++ b/src/app/community/[communityId]/admin/wallet/grant/components/HistoryTab.tsx
@@ -107,7 +107,7 @@ export function HistoryTab({
                     tx.createdAt ? new Date(tx.createdAt.toString()).toLocaleDateString() : ""
                   }
                   pointValue={Number(tx.point || 0)}
-                  onClick={() => onSelectCommunity?.()}
+                  onClick={onSelectCommunity}
                 />
               );
             }

--- a/src/app/community/[communityId]/admin/wallet/grant/components/HistoryTab.tsx
+++ b/src/app/community/[communityId]/admin/wallet/grant/components/HistoryTab.tsx
@@ -13,8 +13,6 @@ interface HistoryTabProps {
   listType: "donate" | "grant";
   searchQuery: string;
   onSelect: (user: GqlUser) => void;
-  /** リスト最上部に固定表示する行 (例: コミュニティ財布宛)。同一 Table 内に描画して列幅を揃える */
-  prependRow?: React.ReactNode;
   /** 履歴内のコミュニティ財布宛 (CONTRIBUTION) 行をクリックしたときの選択ハンドラ */
   onSelectCommunity?: () => void;
 }
@@ -23,7 +21,6 @@ export function HistoryTab({
   listType,
   searchQuery,
   onSelect,
-  prependRow,
   onSelectCommunity,
 }: HistoryTabProps) {
   const t = useTranslations();
@@ -52,11 +49,6 @@ export function HistoryTab({
   if (!loading && presentedTransactions.length === 0) {
     return (
       <div className="space-y-3 px-4">
-        {prependRow && (
-          <Table className={"max-w-xl"}>
-            <TableBody>{prependRow}</TableBody>
-          </Table>
-        )}
         <p className="text-sm text-center text-muted-foreground pt-4">
           {listType === "grant"
             ? t("wallets.shared.history.noGrant")
@@ -66,18 +58,7 @@ export function HistoryTab({
     );
   }
 
-  if (loading) {
-    return (
-      <div className="px-4">
-        {prependRow && (
-          <Table className={"max-w-xl"}>
-            <TableBody>{prependRow}</TableBody>
-          </Table>
-        )}
-        <Loading />
-      </div>
-    );
-  }
+  if (loading) return <Loading />;
 
   const handleSelect = (user: GqlUser) => {
     // すでに選択されているユーザーをクリックした場合は選択解除
@@ -94,7 +75,6 @@ export function HistoryTab({
     <div className="px-4">
       <Table className={"max-w-xl"}>
         <TableBody>
-          {prependRow}
           {presentedTransactions.map((tx, index) => {
             // コミュニティ財布宛 (CONTRIBUTION) の履歴行。相手はユーザーではないので専用に描画
             if (tx.isCommunity) {

--- a/src/app/community/[communityId]/admin/wallet/grant/components/UserSelectStep.tsx
+++ b/src/app/community/[communityId]/admin/wallet/grant/components/UserSelectStep.tsx
@@ -20,6 +20,8 @@ interface Props {
   initialConnection?: GqlMembershipsConnection | null;
   /** リスト最上部に固定表示する行 (例: コミュニティ財布宛)。各タブの Table 内に描画して列幅を揃える */
   prependRow?: React.ReactNode;
+  /** 履歴内のコミュニティ財布宛 (CONTRIBUTION) 行をクリックしたときの選択ハンドラ */
+  onSelectCommunity?: () => void;
 }
 
 function UserSelectStep({
@@ -31,6 +33,7 @@ function UserSelectStep({
   listType,
   initialConnection,
   prependRow,
+  onSelectCommunity,
 }: Props) {
   const t = useTranslations();
   const [searchQuery, setSearchQuery] = useState("");
@@ -57,6 +60,7 @@ function UserSelectStep({
           searchQuery={searchQuery}
           onSelect={onSelect}
           prependRow={prependRow}
+          onSelectCommunity={onSelectCommunity}
         />
       )}
 

--- a/src/app/community/[communityId]/admin/wallet/grant/components/UserSelectStep.tsx
+++ b/src/app/community/[communityId]/admin/wallet/grant/components/UserSelectStep.tsx
@@ -55,11 +55,12 @@ function UserSelectStep({
       <TabManager activeTab={activeTab} setActiveTab={setActiveTab} />
 
       {activeTab === TabsEnum.History && (
+        // 履歴タブはコミュニティへの送付履歴 (送ったpt) を並べる。
+        // 残高付きの固定行 (prependRow) はメンバータブのみに表示し、意味の混在を避ける
         <HistoryTab
           listType={listType}
           searchQuery={searchQuery}
           onSelect={onSelect}
-          prependRow={prependRow}
           onSelectCommunity={onSelectCommunity}
         />
       )}

--- a/src/app/community/[communityId]/admin/wallet/grant/data/presenter/transaction.ts
+++ b/src/app/community/[communityId]/admin/wallet/grant/data/presenter/transaction.ts
@@ -73,13 +73,21 @@ function presentDonateTransaction({
 
   const isReceive = toUser?.id === currentUserId;
   const otherUser = isReceive ? fromUser : toUser;
-  const otherName = otherUser?.name ?? "";
+
+  // 送付先がコミュニティ財布 (CONTRIBUTION) の場合、相手はユーザーではなくコミュニティ
+  const toCommunity = transaction.toWallet?.type === GqlWalletType.Community
+    ? transaction.toWallet?.community
+    : undefined;
+
+  const otherName = toCommunity?.name ?? otherUser?.name ?? "";
 
   return buildPresentedTransaction({
     transaction,
     isReceive,
     otherUser,
     otherName,
+    otherImage: toCommunity?.image ?? otherUser?.image ?? "",
+    isCommunity: !!toCommunity,
     actionType: "donation",
     didIssuanceRequests,
   });
@@ -119,6 +127,8 @@ function buildPresentedTransaction({
   isReceive,
   otherUser,
   otherName,
+  otherImage,
+  isCommunity = false,
   actionType,
   didIssuanceRequests,
 }: {
@@ -126,6 +136,9 @@ function buildPresentedTransaction({
   isReceive: boolean;
   otherUser?: Maybe<GqlUser>;
   otherName: string;
+  otherImage?: string;
+  /** 相手がコミュニティ財布 (CONTRIBUTION) かどうか */
+  isCommunity?: boolean;
   actionType: "donation" | "grant";
   didIssuanceRequests: GqlDidIssuanceRequest[];
 }) {
@@ -146,6 +159,8 @@ function buildPresentedTransaction({
     isReceive,
     otherUser,
     otherName,
+    otherImage: otherImage ?? otherUser?.image ?? "",
+    isCommunity,
     actionType,
     point,
     sign,

--- a/src/app/community/[communityId]/admin/wallet/grant/hooks/useWalletsAndDidIssuanceRequests.ts
+++ b/src/app/community/[communityId]/admin/wallet/grant/hooks/useWalletsAndDidIssuanceRequests.ts
@@ -53,9 +53,21 @@ export function useWalletsAndDidIssuanceRequests({
               or: [{ fromUserId: currentUserId }, { toUserId: currentUserId }],
             },
             {
-              and: [
-                { fromWalletType: GqlWalletType.Member },
-                { toWalletType: GqlWalletType.Member },
+              or: [
+                // 従来: メンバー間送付 (DONATION)
+                {
+                  and: [
+                    { fromWalletType: GqlWalletType.Member },
+                    { toWalletType: GqlWalletType.Member },
+                  ],
+                },
+                // 追加: 自分からコミュニティ財布への送付 (CONTRIBUTION)
+                {
+                  and: [
+                    { toWalletType: GqlWalletType.Community },
+                    { reason: GqlTransactionReason.Contribution },
+                  ],
+                },
               ],
             },
           ],

--- a/src/app/community/[communityId]/wallets/donate/DonatePointPageClient.tsx
+++ b/src/app/community/[communityId]/wallets/donate/DonatePointPageClient.tsx
@@ -19,6 +19,7 @@ import {
   GqlMembershipStatusReason,
   GqlUser,
   useGetUserFlexibleQuery,
+  useGetCommunityWalletQuery,
 } from "@/types/graphql";
 import { useCommunityConfig } from "@/contexts/CommunityConfigContext";
 
@@ -85,6 +86,18 @@ export default function DonatePointPageClient({ initialCurrentPoint }: DonatePoi
     [communityId, communityConfig?.title, communityConfig?.squareLogoPath],
   );
 
+  // コミュニティ財布の残高を取得し、選択行にメンバーと同じ形式で表示する
+  const { data: communityWalletData } = useGetCommunityWalletQuery({
+    variables: { communityId },
+    skip: !communityId,
+    fetchPolicy: "cache-and-network",
+  });
+  const communityPoint = useMemo<number | undefined>(() => {
+    const raw =
+      communityWalletData?.wallets?.edges?.[0]?.node?.currentPointView?.currentPoint;
+    return raw != null ? Number(raw) : undefined;
+  }, [communityWalletData]);
+
   const [notFoundInMembers, setNotFoundInMembers] = useState(false);
   const lastProcessedRecipientId = useRef<string | null>(null);
   useEffect(() => {
@@ -135,10 +148,12 @@ export default function DonatePointPageClient({ initialCurrentPoint }: DonatePoi
                 avatar={communityAsUser.image ?? ""}
                 name={communityAsUser.name}
                 subText={t("wallets.donate.communityWallet")}
+                pointValue={communityPoint}
                 onClick={() => selectCommunity(communityAsUser)}
               />
             ) : undefined
           }
+          onSelectCommunity={() => selectCommunity(communityAsUser)}
         />
       ) : (
         <TransferInputStep

--- a/src/app/community/[communityId]/wallets/features/donate/components/DonateUserSelect.tsx
+++ b/src/app/community/[communityId]/wallets/features/donate/components/DonateUserSelect.tsx
@@ -15,6 +15,8 @@ interface Props {
   initialConnection?: GqlMembershipsConnection | null;
   /** リスト最上部に固定表示する行 (例: コミュニティ財布宛) */
   prependRow?: React.ReactNode;
+  /** 履歴内のコミュニティ財布宛 (CONTRIBUTION) 行をクリックしたときの選択ハンドラ */
+  onSelectCommunity?: () => void;
 }
 
 export function DonateUserSelect({
@@ -24,6 +26,7 @@ export function DonateUserSelect({
   setActiveTab,
   initialConnection,
   prependRow,
+  onSelectCommunity,
 }: Props) {
   const t = useTranslations();
   return (
@@ -36,6 +39,7 @@ export function DonateUserSelect({
       listType="donate"
       initialConnection={initialConnection}
       prependRow={prependRow}
+      onSelectCommunity={onSelectCommunity}
     />
   );
 }


### PR DESCRIPTION
コミュニティ財布への送付（CONTRIBUTION）まわりの UX 改善。実機フィードバック対応。

## 1. メンバータブのコミュニティ財布行に残高を表示

これまでコミュニティ財布行は残高を出していなかった。既存の `GetCommunityWallet` クエリで `currentPointView.currentPoint` を取得し、**メンバー行と同じ pt 表示**にした。

## 2. 履歴タブにコミュニティ送付（CONTRIBUTION）を表示

これまで donate 履歴フィルタが **Member→Member 限定**だったため、コミュニティ財布への送付が履歴に出なかった。

- **フィルタ** (`useWalletsAndDidIssuanceRequests`, donate): 「自分 → コミュニティ財布（`reason: CONTRIBUTION`）」を `or` で追加。**従来のメンバー間送付はそのまま温存**。
- **presenter** (`presentDonateTransaction`): 相手がコミュニティ財布のとき、名前/画像を `toWallet.community` から解決し `isCommunity` フラグを付与。
- **HistoryTab**: コミュニティ行を描画し、クリックで**コミュニティ送付を選択**（`onSelectCommunity` を `DonateUserSelect → UserSelectStep → HistoryTab` に配線）。

## 後方互換
- `onSelectCommunity` / `isCommunity` は **grant フローには渡さない/立たない**ため、grant 側の挙動は不変。
- `prependRow` と合わせ、共有コンポーネント (`UserSelectStep` / `HistoryTab` / presenter) への追加は全てオプショナル。

## 確認
- 新規 TypeScript エラー 0 件（合計 108 は develop 由来の既存エラーで無関係、突き合わせ済み）
- 変更ファイルに新規 lint エラーなし / 既存ユニットテスト green
- ⚠️ 送金・履歴の実機確認は dev デプロイ後にお願いします

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DrCG22MmVSXoLQLDeP2bk

---
_Generated by [Claude Code](https://claude.ai/code/session_018DrCG22MmVSXoLQLDeP2bk)_