### PR TITLE
chore(wallets): 取引履歴 key の安定化 & コメント整合（レビュー反映）

### DIFF
--- a/src/app/community/[communityId]/admin/wallet/grant/components/HistoryTab.tsx
+++ b/src/app/community/[communityId]/admin/wallet/grant/components/HistoryTab.tsx
@@ -80,7 +80,7 @@ export function HistoryTab({
             if (tx.isCommunity) {
               return (
                 <UserPointRow
-                  key={`community-${index}`}
+                  key={tx.id ?? `community-${index}`}
                   avatar={tx.otherImage || ""}
                   name={tx.otherName}
                   subText={
@@ -102,7 +102,7 @@ export function HistoryTab({
 
             return (
               <UserPointRow
-                key={`${tx.otherUser.id}-${index}`}
+                key={tx.id ?? `${tx.otherUser.id}-${index}`}
                 avatar={tx.otherUser.image || ""}
                 name={tx.otherUser.name || tx.otherName || ""}
                 subText={subText}

--- a/src/app/community/[communityId]/admin/wallet/grant/data/presenter/transaction.ts
+++ b/src/app/community/[communityId]/admin/wallet/grant/data/presenter/transaction.ts
@@ -156,6 +156,7 @@ function buildPresentedTransaction({
   );
 
   return {
+    id: transaction.id,
     isReceive,
     otherUser,
     otherName,

--- a/src/app/community/[communityId]/wallets/donate/DonatePointPageClient.tsx
+++ b/src/app/community/[communityId]/wallets/donate/DonatePointPageClient.tsx
@@ -140,7 +140,8 @@ export default function DonatePointPageClient({ initialCurrentPoint }: DonatePoi
           activeTab={activeTab}
           setActiveTab={setActiveTab}
           initialConnection={initialConnection}
-          // コミュニティ財布への送付 (CONTRIBUTION) をメンバー/履歴一覧の最上部に同一 Table で固定表示。
+          // コミュニティ財布への送付 (CONTRIBUTION) をメンバー一覧の最上部に同一 Table で固定表示
+          // (履歴タブには出さず、送付履歴の各行で表示)。
           // communityId 未ロード時は空 ID 送金を防ぐため表示しない
           prependRow={
             communityId ? (

--- a/src/components/shared/UserPointRow.tsx
+++ b/src/components/shared/UserPointRow.tsx
@@ -9,7 +9,7 @@ interface UserPointRowProps {
   avatar: string;
   name: string;
   subText: string;
-  pointValue?: number; // 表示用の値。省略時はポイントを表示しない (例: コミュニティ財布宛)
+  pointValue?: number; // 表示用の値。省略時はポイントを表示しない (残高/金額が無い行向け)
   onClick?: () => void;
   selected?: boolean; // 選択状態
 }


### PR DESCRIPTION
#1257（リリース PR）上の Copilot レビュー指摘の反映。

## 変更
- **履歴行の key を安定化**: `index` ベースの key を取引 id ベースに変更。検索条件変更/refetch で行順が変わっても React が行を誤再利用せず、表示崩れ・状態不整合を防ぐ。`presentTransaction` の返り値に `id` を追加。
- **コメント整合**: コミュニティ固定行のコメントを実装に合わせて修正（メンバータブのみ表示・履歴タブには出さない）。`UserPointRow.pointValue` のコメント例示も更新。

## 対応しなかった指摘
- 残高の `Number(raw)` 変換について BigInt 安全変換の提案があったが、既存の `MemberTab` も同じ `Number(...)` パターンでポイントを表示しており、**コードベース整合**を優先して据え置き（ポイント値が `MAX_SAFE_INTEGER` を超える運用は想定されない）。

## 確認
- 新規 TypeScript エラー 0 件（合計 108 は develop 由来の既存エラー）
- 変更ファイルに新規 lint エラーなし / 既存ユニットテスト green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DrCG22MmVSXoLQLDeP2bk

---
_Generated by [Claude Code](https://claude.ai/code/session_018DrCG22MmVSXoLQLDeP2bk)_