### PR TITLE
fix(wallets): 履歴の全件ヒット防止 & コミュニティ選択の空ID送金防止（レビュー反映）

### DIFF
--- a/src/app/community/[communityId]/admin/wallet/grant/hooks/useWalletsAndDidIssuanceRequests.ts
+++ b/src/app/community/[communityId]/admin/wallet/grant/hooks/useWalletsAndDidIssuanceRequests.ts
@@ -84,6 +84,11 @@ export function useWalletsAndDidIssuanceRequests({
       }
     : undefined;
 
+  // donate は currentUserId で自分の送受信に絞る。currentUserId 未確定のまま実行すると
+  // { fromUserId: undefined } が変数シリアライズで落ちて or:[{},{}] = 全件ヒットになり、
+  // 他メンバーの取引が一瞬表示されうるためクエリ自体を待機させる。
+  const isWaitingForCurrentUser = listType === "donate" && !currentUserId;
+
   const { data, error, loading, refetch } = useGetTransactionsQuery({
     variables: {
       filter: {
@@ -95,6 +100,7 @@ export function useWalletsAndDidIssuanceRequests({
     },
     fetchPolicy: "network-only",
     nextFetchPolicy: "cache-first",
+    skip: isWaitingForCurrentUser,
   });
 
   const allTransactions = useMemo<GqlTransaction[]>(() => {
@@ -119,7 +125,8 @@ export function useWalletsAndDidIssuanceRequests({
   }, [allTransactions, currentUserId, listType]);
 
   return {
-    loading,
+    // 待機中は空状態のちらつきを避けるため loading を維持する
+    loading: loading || isWaitingForCurrentUser,
     error,
     allTransactions,
     presentedTransactions,

--- a/src/app/community/[communityId]/wallets/donate/DonatePointPageClient.tsx
+++ b/src/app/community/[communityId]/wallets/donate/DonatePointPageClient.tsx
@@ -154,7 +154,8 @@ export default function DonatePointPageClient({ initialCurrentPoint }: DonatePoi
               />
             ) : undefined
           }
-          onSelectCommunity={() => selectCommunity(communityAsUser)}
+          // communityId 未ロード時は空 ID 送金を防ぐため無効化 (prependRow と対称)
+          onSelectCommunity={communityId ? () => selectCommunity(communityAsUser) : undefined}
         />
       ) : (
         <TransferInputStep


### PR DESCRIPTION
#1257（リリース PR）上の Copilot レビュー指摘の反映。実機に影響しうる 2 件を修正。

## 🔒 修正1: donate 履歴が一瞬「全件ヒット」する恐れ（プライバシー）
`useWalletsAndDidIssuanceRequests` の donate フィルタは `or: [{ fromUserId: currentUserId }, { toUserId: currentUserId }]` で自分の送受信に絞っている。しかし `currentUserId` が未確定（`undefined`）のまま実行されると、Apollo の変数シリアライズで `undefined` キーが落ちて `or: [{}, {}]` = **全件ヒット**になり、同コミュニティ内の**他メンバーの取引が一瞬表示され得る**。

- `listType === "donate" && !currentUserId` の間はクエリを `skip`。
- 待機中は空状態のちらつきを避けるため `loading` を維持。
- grant フローは `currentUserId` に依存しないため影響なし。

## 🐛 修正2: コミュニティ選択の空 ID 送金
`prependRow`（固定行）は `communityId` でガード済みだったが、`onSelectCommunity` は `communityId` の有無に関わらず渡していたため、履歴タブのコミュニティ送付行から `communityId: ""` のまま送金が飛びうる非対称があった。

- `onSelectCommunity` も `communityId` 未ロード時は `undefined`（＝非クリック）に。`prependRow` と対称化。

## 対応しなかった指摘
- 残高の `Number(raw)` → BigInt 安全変換の提案は、既存 `MemberTab` も同じ `Number(...)` パターンで整合しているため据え置き（ポイント値が `MAX_SAFE_INTEGER` を超える運用は想定外）。
- 他の指摘（テーブル分割・`useCallback`・key 安定化・コメント整合）は #1258/#1259/#1261 で対応済み（outdated）。

## 確認
- 新規 TypeScript エラー 0 件（合計 108 は develop 由来の既存エラー）
- 既存ユニットテスト green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DrCG22MmVSXoLQLDeP2bk

---
_Generated by [Claude Code](https://claude.ai/code/session_018DrCG22MmVSXoLQLDeP2bk)_