### PR TITLE
fix(wallets): コミュニティ財布行の名前/アイコンを portalConfig に統一

### DIFF
--- a/src/app/community/[communityId]/admin/wallet/grant/data/presenter/transaction.ts
+++ b/src/app/community/[communityId]/admin/wallet/grant/data/presenter/transaction.ts
@@ -11,16 +11,23 @@ export function presentTransaction({
   transaction,
   currentUserId,
   listType,
+  community,
 }: {
   transaction: GqlTransaction;
   currentUserId?: string;
   listType: "donate" | "grant";
+  /**
+   * コミュニティ財布行 (CONTRIBUTION) の表示名/アイコン。
+   * portalConfig (title / squareLogoPath) を正として統一するため呼び出し側から渡す。
+   * 取引の community.name / community.image は nullable なため config を優先する。
+   */
+  community?: { name: string; image: string };
 }) {
   const didIssuanceRequests = resolveDidIssuanceRequests({ currentUserId, transaction, listType });
 
   return listType === "grant"
     ? presentGrantTransaction({ transaction, didIssuanceRequests })
-    : presentDonateTransaction({ transaction, currentUserId, didIssuanceRequests });
+    : presentDonateTransaction({ transaction, currentUserId, didIssuanceRequests, community });
 }
 
 const resolveDidIssuanceRequests = ({
@@ -63,10 +70,12 @@ function presentDonateTransaction({
   transaction,
   currentUserId,
   didIssuanceRequests,
+  community,
 }: {
   transaction: GqlTransaction;
   currentUserId?: string;
   didIssuanceRequests: GqlDidIssuanceRequest[];
+  community?: { name: string; image: string };
 }) {
   const fromUser = transaction.fromWallet?.user;
   const toUser = transaction.toWallet?.user;
@@ -74,19 +83,25 @@ function presentDonateTransaction({
   const isReceive = toUser?.id === currentUserId;
   const otherUser = isReceive ? fromUser : toUser;
 
-  // 送付先がコミュニティ財布 (CONTRIBUTION) の場合、相手はユーザーではなくコミュニティ
+  // 送付先がコミュニティ財布 (CONTRIBUTION) の場合、相手はユーザーではなくコミュニティ。
+  // 表示名/アイコンは portalConfig を正として統一し、無い場合のみ取引の community 値へフォールバック。
   const toCommunity = transaction.toWallet?.type === GqlWalletType.Community
     ? transaction.toWallet?.community
     : undefined;
 
-  const otherName = toCommunity?.name ?? otherUser?.name ?? "";
+  const otherName = toCommunity
+    ? community?.name || toCommunity.name || ""
+    : otherUser?.name ?? "";
+  const otherImage = toCommunity
+    ? community?.image || toCommunity.image || ""
+    : otherUser?.image ?? "";
 
   return buildPresentedTransaction({
     transaction,
     isReceive,
     otherUser,
     otherName,
-    otherImage: toCommunity?.image ?? otherUser?.image ?? "",
+    otherImage,
     isCommunity: !!toCommunity,
     actionType: "donation",
     didIssuanceRequests,

--- a/src/app/community/[communityId]/admin/wallet/grant/hooks/useWalletsAndDidIssuanceRequests.ts
+++ b/src/app/community/[communityId]/admin/wallet/grant/hooks/useWalletsAndDidIssuanceRequests.ts
@@ -29,7 +29,16 @@ export function useWalletsAndDidIssuanceRequests({
   presentedTransactions: PresentedTransaction[];
   refetch: () => void;
 } {
-  const { communityId } = useCommunityConfig();
+  const communityConfig = useCommunityConfig();
+  const communityId = communityConfig?.communityId ?? "";
+  // コミュニティ財布行の表示は portalConfig を正として統一する
+  const community = useMemo(
+    () => ({
+      name: communityConfig?.title ?? "",
+      image: communityConfig?.squareLogoPath ?? "",
+    }),
+    [communityConfig?.title, communityConfig?.squareLogoPath],
+  );
   const walletTypeFilter: GqlTransactionFilterInput =
     listType === "grant"
       ? {
@@ -120,9 +129,10 @@ export function useWalletsAndDidIssuanceRequests({
         transaction,
         currentUserId,
         listType,
+        community,
       }),
     );
-  }, [allTransactions, currentUserId, listType]);
+  }, [allTransactions, currentUserId, listType, community]);
 
   return {
     // 待機中は空状態のちらつきを避けるため loading を維持する


### PR DESCRIPTION
## 背景
コミュニティ財布の名前/アイコンが**2系統のデータ**を使っていた:

| 表示箇所 | ソース | 備考 |
|---|---|---|
| donate の固定行/選択（`communityAsUser`）・送金確認 | `portalConfig.title` / `.squareLogoPath` | 常に設定される |
| **履歴のコミュニティ行（CONTRIBUTION）** | 取引の `community.name` / `community.image` | **nullable**（未設定なら空/不一致） |

`GqlCommunity.name` / `.image` は schema 上 nullable のため、履歴行だけ**名前が空・アイコンが別画像/空**になりうる非対称があった。

## 対応
**portalConfig を正**として統一。presenter にコミュニティ表示情報（`title` / `squareLogoPath`）を渡し、コミュニティ行の名前/アイコンは config を優先（無い場合のみ取引の `community` 値へフォールバック）。

- `useWalletsAndDidIssuanceRequests`: `useCommunityConfig()` から `title` / `squareLogoPath` を取得し `presentTransaction` に `community` として渡す。
- `presentTransaction` / `presentDonateTransaction`: `community?: { name; image }` を受け取り、コミュニティ行（CONTRIBUTION）の `otherName` / `otherImage` に優先適用。
- あわせて `useCommunityConfig()` の null 安全アクセス化（既存の型エラー 1 件も解消）。

これで donate の固定行・履歴行・送金確認がすべて同じ portalConfig 由来の名前/アイコンで揃う。

## スコープ補足
grant 履歴では CONTRIBUTION も「メンバーから受領」表示になりコミュニティ名の行は出ないため、変更は donate 経路（`presentDonateTransaction`）に限定。

## 確認
- TypeScript エラー合計 **107**（develop の 108 から純減：null 安全化で 1 件解消。新規エラー 0）
- 変更ファイルに新規 lint エラーなし / 既存ユニットテスト green
- ⚠️ 実機での名前/アイコン一致は dev デプロイ後にご確認ください

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DrCG22MmVSXoLQLDeP2bk

---
_Generated by [Claude Code](https://claude.ai/code/session_018DrCG22MmVSXoLQLDeP2bk)_